### PR TITLE
docs: fix README usage snippet to match actual props

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ export default function App() {
   return (
     <>
       {/* your app */}
-      <FeedbackWidget
-        projectId="your-project-name"
-        supabaseUrl="YOUR_SUPABASE_URL"
-        supabaseKey="YOUR_SUPABASE_KEY"
-      />
+      <FeedbackWidget projectId="your-project-name" />
     </>
   )
 }


### PR DESCRIPTION
Fixes item #4 from [CODE_REVIEW.md](https://github.com/thedesignproject/feedback-widget/blob/docs/code-review/CODE_REVIEW.md).

## Summary
- Removes the non-existent \`supabaseUrl\` and \`supabaseKey\` props from the README usage snippet.
- The only prop \`FeedbackWidget\` actually accepts is \`projectId\` (see [FeedbackWidgetProps](https://github.com/thedesignproject/feedback-widget/blob/main/src/components/FeedbackWidget.tsx#L6-L8)).

## Why
Users following the README were passing props that were silently ignored, giving a false sense of controlling their data destination. The widget currently sends data to a hardcoded backend (\`API_BASE\` in \`FeedbackWidget.tsx:4\`), not to the user's Supabase project directly.

## Follow-up
Making \`API_BASE\` configurable is tracked as item #5 in the review. Once that lands, the README should be updated again to document the new prop and the self-hosted flow honestly.

## Test plan
- [ ] Copy-paste the README snippet into a React app — type-checks and runs without warnings
- [ ] Confirm no \`supabaseUrl\`/\`supabaseKey\` references remain anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)