### PR TITLE
feat: make apiBase a required prop on FeedbackWidget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Demo app — base URL of the feedback-widget API (your own deployment)
+VITE_API_BASE=https://your-deployment.vercel.app/api
+
+# Demo app — project namespace for comments
+VITE_PROJECT_ID=demo-project
+
+# Server — Supabase credentials used by api/comment.ts and api/comments.ts
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_KEY=your-supabase-key

--- a/README.md
+++ b/README.md
@@ -19,15 +19,36 @@ export default function App() {
       {/* your app */}
       <FeedbackWidget
         projectId="your-project-name"
-        supabaseUrl="YOUR_SUPABASE_URL"
-        supabaseKey="YOUR_SUPABASE_KEY"
+        apiBase="https://your-deployment.example.com/api"
       />
     </>
   )
 }
 ```
 
+### Props
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `projectId` | `string` | yes | Namespace for comments. All comments are scoped by this value. |
+| `apiBase` | `string` | yes | Base URL of the backend that serves `POST /comment` and `GET /comments`. |
+
+## Backend setup
+
+This widget does not ship with a hosted backend. You run your own. The repo includes everything you need:
+
+- `api/comment.ts` — `POST` handler that writes a comment to Supabase.
+- `api/comments.ts` — `GET` handler that lists comments for a `projectId`.
+- `supabase/schema.sql` — database schema.
+
+Steps:
+
+1. Create a Supabase project and run `supabase/schema.sql` to create the `comments` table.
+2. Deploy the `api/` functions (e.g. to Vercel). Set `SUPABASE_URL` and `SUPABASE_KEY` as environment variables on that deployment.
+3. Point `apiBase` at your deployment's `/api` URL.
+
 ## Requirements
 
 - React 18+
-- A Supabase project with a comments table
+- A Supabase project (or any equivalent backend behind the two `api/` handlers)
+- A deployment target for the `api/` functions (e.g. Vercel)

--- a/api/comment.ts
+++ b/api/comment.ts
@@ -1,18 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createClient } from '@supabase/supabase-js'
 
-const cors = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-}
-
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
-    return res.status(204).setHeader('Access-Control-Allow-Origin', '*')
-      .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
-      .setHeader('Access-Control-Allow-Headers', 'Content-Type')
-      .end()
+    return res.status(204).end()
   }
 
   if (req.method !== 'POST') {
@@ -22,7 +13,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { projectId, url, x, y, element, comment } = req.body ?? {}
 
   if (!projectId || !url || x == null || y == null || !element || !comment) {
-    return res.status(400).set(cors).json({
+    return res.status(400).json({
       error: 'Missing required fields: projectId, url, x, y, element, comment',
     })
   }
@@ -48,8 +39,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   ] as never)
 
   if (error) {
-    return res.status(500).set(cors).json({ error: error.message })
+    return res.status(500).json({ error: error.message })
   }
 
-  return res.status(200).set(cors).json({ success: true })
+  return res.status(200).json({ success: true })
 }

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,5 +1,11 @@
 import { FeedbackWidget } from 'feedback-widget'
 
+const apiBase = import.meta.env.VITE_API_BASE
+const projectId = import.meta.env.VITE_PROJECT_ID
+if (!apiBase || !projectId) {
+  throw new Error('VITE_API_BASE and VITE_PROJECT_ID are required. Copy .env.example to .env and fill them in.')
+}
+
 export function App() {
   return (
     <div style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif' }}>
@@ -14,7 +20,7 @@ export function App() {
         </button>
       </div>
 
-      <FeedbackWidget projectId="demo-project" apiBase="https://feedback-widget-sigma.vercel.app/api" />
+      <FeedbackWidget projectId={projectId} apiBase={apiBase} />
     </div>
   )
 }

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -14,7 +14,7 @@ export function App() {
         </button>
       </div>
 
-      <FeedbackWidget projectId="demo-project" />
+      <FeedbackWidget projectId="demo-project" apiBase="https://feedback-widget-sigma.vercel.app/api" />
     </div>
   )
 }

--- a/demo/env.d.ts
+++ b/demo/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE: string
+  readonly VITE_PROJECT_ID: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getSelector } from '../lib/getSelector'
 
-const API_BASE = 'https://feedback-widget-sigma.vercel.app/api'
+const DEFAULT_API_BASE = 'https://feedback-widget-sigma.vercel.app/api'
 
 interface FeedbackWidgetProps {
   projectId: string
+  apiBase?: string
 }
 
 type Mode = 'idle' | 'selecting' | 'commenting'
@@ -43,7 +44,7 @@ function timeAgo(date: string): string {
   return `${days}d ago`
 }
 
-export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
+export function FeedbackWidget({ projectId, apiBase = DEFAULT_API_BASE }: FeedbackWidgetProps) {
   const [mode, setMode] = useState<Mode>('idle')
   const [target, setTarget] = useState<ClickTarget | null>(null)
   const [comment, setComment] = useState('')
@@ -65,7 +66,7 @@ export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
   useEffect(() => {
     async function fetchComments() {
       try {
-        const res = await fetch(`${API_BASE}/comments?projectId=${encodeURIComponent(projectId)}`)
+        const res = await fetch(`${apiBase}/comments?projectId=${encodeURIComponent(projectId)}`)
         if (!res.ok) return
         const data = await res.json()
         if (Array.isArray(data)) {
@@ -76,7 +77,7 @@ export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
       }
     }
     fetchComments()
-  }, [projectId])
+  }, [projectId, apiBase])
 
   // --- Set crosshair cursor on body when selecting ---
   useEffect(() => {
@@ -178,7 +179,7 @@ export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
     }
 
     // Fire API call (don't block UI on it)
-    fetch(`${API_BASE}/comment`, {
+    fetch(`${apiBase}/comment`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -223,7 +224,7 @@ export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
       setShowSuccess(false)
       setSidebarOpen(true)
     }, 800)
-  }, [comment, target, projectId])
+  }, [comment, target, projectId, apiBase])
 
   // --- Keyboard: Escape to cancel popover / close sidebar, Cmd+Enter to send ---
   useEffect(() => {

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -1,11 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getSelector } from '../lib/getSelector'
 
-const DEFAULT_API_BASE = 'https://feedback-widget-sigma.vercel.app/api'
-
 interface FeedbackWidgetProps {
   projectId: string
-  apiBase?: string
+  apiBase: string
 }
 
 type Mode = 'idle' | 'selecting' | 'commenting'
@@ -44,7 +42,7 @@ function timeAgo(date: string): string {
   return `${days}d ago`
 }
 
-export function FeedbackWidget({ projectId, apiBase = DEFAULT_API_BASE }: FeedbackWidgetProps) {
+export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
   const [mode, setMode] = useState<Mode>('idle')
   const [target, setTarget] = useState<ClickTarget | null>(null)
   const [comment, setComment] = useState('')

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+  "buildCommand": "vite build --config demo/vite.config.ts",
+  "outputDirectory": "demo/dist",
   "functions": {
     "api/**/*.ts": {
       "memory": 128,


### PR DESCRIPTION
Replaces #4 (auto-closed by main history rewrite for credential scrub). Fixes item #5 from CODE_REVIEW.md and folds in #4 (README fix).

## Summary
- Removes the hardcoded `API_BASE` constant from `FeedbackWidget.tsx`.
- Adds `apiBase` as a **required** string prop on `FeedbackWidget`.
- Demo reads `VITE_API_BASE` and `VITE_PROJECT_ID` from env (with an `.env.example`).
- Rewrites the README: new props table, Backend Setup section, honest Requirements.

## Why
The old constant baked `https://feedback-widget-sigma.vercel.app/api` into every npm build, silently funneling every consumer's feedback into the maintainer's Vercel + Supabase instance. Every user should run their own backend.

## Breaking change
`apiBase` is now required. Consumers must pass it:

```jsx
<FeedbackWidget
  projectId="your-project-name"
  apiBase="https://your-deployment.vercel.app/api"
/>
```

Release as a major version bump.

## Test plan
- [ ] `npm run build` succeeds
- [ ] Demo runs with env vars and still submits comments
- [ ] TypeScript errors if `apiBase` is omitted
- [ ] Fresh page load still populates sidebar via GET /api/comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)