### PR TITLE
fix: await send fetch and guard against duplicate submissions

### DIFF
--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -58,6 +58,9 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
   const [badgeAnim, setBadgeAnim] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
+  // Synchronous guard — state updates are async, so double-firing handleSend
+  // in the same tick (e.g. Cmd+Enter held down) would otherwise slip past `sending`.
+  const sendingRef = useRef(false)
 
   // --- Fetch comments on mount ---
   useEffect(() => {
@@ -155,72 +158,74 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
 
   // --- Send comment ---
   const handleSend = useCallback(async () => {
-    if (!comment.trim() || !target) return
+    if (!comment.trim() || !target || sendingRef.current) return
 
-    // Capture values before clearing state
+    sendingRef.current = true
+    setSending(true)
+
     const commentText = comment.trim()
     const targetData = { ...target }
 
-    setSending(true)
+    try {
+      const res = await fetch(`${apiBase}/comment`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          projectId,
+          url: targetData.url,
+          x: targetData.xPercent,
+          y: targetData.yPercent,
+          element: targetData.selector,
+          comment: commentText,
+        }),
+      })
 
-    // Create local comment object immediately
-    const newComment: Comment = {
-      id: crypto.randomUUID(),
-      project_id: projectId,
-      url: targetData.url,
-      x: targetData.xPercent,
-      y: targetData.yPercent,
-      element: targetData.selector,
-      comment: commentText,
-      created_at: new Date().toISOString(),
-    }
+      if (!res.ok) {
+        console.warn('[FeedbackWidget] API returned', res.status)
+        return
+      }
 
-    // Fire API call (don't block UI on it)
-    fetch(`${apiBase}/comment`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        projectId,
+      const newComment: Comment = {
+        id: crypto.randomUUID(),
+        project_id: projectId,
         url: targetData.url,
         x: targetData.xPercent,
         y: targetData.yPercent,
         element: targetData.selector,
         comment: commentText,
-      }),
-    })
-      .then((res) => {
-        if (!res.ok) console.warn('[FeedbackWidget] API returned', res.status)
-        else console.log('[FeedbackWidget] Comment saved to API')
-      })
-      .catch((err) => console.warn('[FeedbackWidget] API error:', err))
+        created_at: new Date().toISOString(),
+      }
 
-    // Update UI immediately — don't wait for API
-    setComments((prev) => [newComment, ...prev])
-    setNewCommentIds((prev) => new Set(prev).add(newComment.id))
+      setComments((prev) => [newComment, ...prev])
+      setNewCommentIds((prev) => new Set(prev).add(newComment.id))
 
-    setBadgeAnim(true)
-    setTimeout(() => setBadgeAnim(false), 400)
+      setBadgeAnim(true)
+      setTimeout(() => setBadgeAnim(false), 400)
 
-    setTimeout(() => {
-      setNewCommentIds((prev) => {
-        const next = new Set(prev)
-        next.delete(newComment.id)
-        return next
-      })
-    }, 2000)
+      setTimeout(() => {
+        setNewCommentIds((prev) => {
+          const next = new Set(prev)
+          next.delete(newComment.id)
+          return next
+        })
+      }, 2000)
 
-    setTarget(null)
-    setComment('')
-    setSending(false)
-    setHovered(null)
-    setMode('selecting')
-    setShowSuccess(true)
+      setTarget(null)
+      setComment('')
+      setHovered(null)
+      setMode('selecting')
+      setShowSuccess(true)
 
-    // After checkmark: stay in selecting mode, open sidebar
-    setTimeout(() => {
-      setShowSuccess(false)
-      setSidebarOpen(true)
-    }, 800)
+      setTimeout(() => {
+        setShowSuccess(false)
+        setSidebarOpen(true)
+      }, 800)
+    } catch (err) {
+      console.warn('[FeedbackWidget] API error:', err)
+    } finally {
+      sendingRef.current = false
+      setSending(false)
+    }
   }, [comment, target, projectId, apiBase])
 
   // --- Keyboard: Escape to cancel popover / close sidebar, Cmd+Enter to send ---


### PR DESCRIPTION
Replaces #5 (auto-closed by main history rewrite for credential scrub). Fixes item #6 from CODE_REVIEW.md.

## Problem
`handleSend` fired the POST fire-and-forget, then ran `setSending(false)` synchronously on the next line. Because React state updates are async, `sending` was never actually true while the request was in flight — the Send button was re-enabled instantly, and two rapid Cmd+Enter presses in the same tick would re-enter `handleSend` with the same captured `target` and `comment`, firing a duplicate POST.

On top of that, the optimistic sidebar update ran unconditionally, so failed requests left a ghost comment in the UI.

## Fix
- Add a `sendingRef` synchronous guard. Refs update immediately, so a second call in the same tick bails early regardless of state batching.
- Await the fetch with `try/catch/finally`.
- `setSending(false)` (and `sendingRef.current = false`) live in `finally` — always runs.
- Optimistic sidebar update now only runs on HTTP success.

## Test plan
- [ ] Normal send: popover closes, checkmark shows, sidebar opens with the new comment.
- [ ] Hold Cmd+Enter / mash the Send button: only one POST in the Network tab, only one new row in `comments`.
- [ ] Kill the network mid-send (DevTools offline): no ghost comment, Send button re-enables.
- [ ] 500 from the API: no ghost comment, Send button re-enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)