### PR TITLE
build: externalize @supabase/supabase-js from library bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       formats: ['es', 'umd'],
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      external: ['react', 'react-dom', 'react/jsx-runtime', '@supabase/supabase-js'],
       output: {
         globals: {
           react: 'React',


### PR DESCRIPTION
Fixes item #13 from CODE_REVIEW.md.

## Summary
Adds \`@supabase/supabase-js\` to \`rollupOptions.external\` in \`vite.config.ts\`.

## Why
Item #13 flagged that Supabase was being bundled into the npm library output. In practice, tree-shaking already keeps it out today (nothing reachable from \`src/index.ts\` imports it), so this is a **defensive guard** rather than a corrective fix — it prevents a future accidental import from silently bloating the dist bundle (~100 KB).

The package stays in \`dependencies\` because the server-side \`api/\` handlers genuinely need it at Vercel runtime.

## Test plan
- [ ] \`npm run build\` succeeds
- [ ] \`grep -rF "@supabase" dist/\` returns nothing (if \`dist/\` is built)
- [ ] Install the built package into a test React app — widget still renders and posts comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)