### PR TITLE
refactor: fix misleading comments (#18, #19)

### DIFF
--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -215,7 +215,7 @@ export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
     setComment('')
     setSending(false)
     setHovered(null)
-    setMode('selecting') // Show eye button with blue ring during checkmark
+    setMode('selecting')
     setShowSuccess(true)
 
     // After checkmark: stay in selecting mode, open sidebar

--- a/src/lib/getSelector.ts
+++ b/src/lib/getSelector.ts
@@ -1,12 +1,13 @@
-// Characters that are invalid in CSS class selectors (unescaped)
-const INVALID_CLASS_CHARS = /[^a-zA-Z0-9_-]/
+// Characters that would need escaping in a CSS identifier (used for both
+// id selectors and class selectors — same character rules for unescaped form).
+const INVALID_IDENT_CHARS = /[^a-zA-Z0-9_-]/
 
 function isValidClass(name: string): boolean {
-  return name.length > 0 && !INVALID_CLASS_CHARS.test(name)
+  return name.length > 0 && !INVALID_IDENT_CHARS.test(name)
 }
 
 export function getSelector(el: Element): string {
-  if (el.id && !INVALID_CLASS_CHARS.test(el.id)) return `#${el.id}`
+  if (el.id && !INVALID_IDENT_CHARS.test(el.id)) return `#${el.id}`
 
   const parts: string[] = []
   let current: Element | null = el


### PR DESCRIPTION
Fixes items #18 and #19 from CODE_REVIEW.md. No behavior change.

## #18 — misleading selecting-mode comment
\`FeedbackWidget.tsx:218\` had \`setMode('selecting') // Show eye button with blue ring during checkmark\`. In selecting mode the trigger actually renders a red X (the eye icon only appears in idle mode), so the comment described UI that never happens. Dropped the comment — the code is self-explanatory.

## #19 — \`INVALID_CLASS_CHARS\` name
\`getSelector.ts:1-2\` named its regex \`INVALID_CLASS_CHARS\` with a comment saying "invalid in CSS class selectors", but the same regex is used for id-selector validation on line 9. CSS identifier rules are the same for ids and classes (unescaped form), so the logic is correct — only the name misled. Renamed to \`INVALID_IDENT_CHARS\` and clarified the comment.

## Note on overlap with PR #10
PR #10 (await-fetch refactor) also drops the line 218 comment as a side effect of its larger rewrite. Whichever lands first, the other PR's conflict on that line is trivial.

## Test plan
- [ ] \`grep -rF "INVALID_CLASS_CHARS" src/\` returns nothing
- [ ] Widget still generates correct selectors for elements with and without id/class

🤖 Generated with [Claude Code](https://claude.com/claude-code)