### PR TITLE
fix(api): validate x and y as finite numbers

### DIFF
--- a/api/comment.ts
+++ b/api/comment.ts
@@ -12,9 +12,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const { projectId, url, x, y, element, comment } = req.body ?? {}
 
-  if (!projectId || !url || x == null || y == null || !element || !comment) {
+  if (!projectId || !url || !element || !comment) {
     return res.status(400).json({
-      error: 'Missing required fields: projectId, url, x, y, element, comment',
+      error: 'Missing required fields: projectId, url, element, comment',
+    })
+  }
+
+  if (typeof x !== 'number' || !Number.isFinite(x) || typeof y !== 'number' || !Number.isFinite(y)) {
+    return res.status(400).json({
+      error: 'x and y must be finite numbers',
     })
   }
 


### PR DESCRIPTION
Fixes item #8 from CODE_REVIEW.md.

## Problem
\`api/comment.ts\` checked \`x == null || y == null\` — catches missing values but accepts strings, \`NaN\`, and \`Infinity\`. Those values hit the Postgres float column at insert time, triggering a type error whose raw message was then returned via \`error.message\` — exposing schema details.

## Fix
Split the check in two:
1. Required string fields checked for presence as before (\`projectId\`, \`url\`, \`element\`, \`comment\`).
2. Separate check for \`x\` / \`y\`: must be \`typeof 'number'\` **and** \`Number.isFinite\`. Rejects at the boundary with a clean 400 and a targeted error message.

## Scope
Only adds **type** validation. Range validation (e.g. 0–100 for percentages) and length caps belong to item #7 (rate limiting / input size limits).

## Test plan
- [ ] Valid POST with numeric x/y → 200
- [ ] POST with \`x: "nope"\` → 400 \`"x and y must be finite numbers"\`
- [ ] POST with \`x: NaN\` or \`x: Infinity\` → 400
- [ ] POST missing x → 400 (same "must be finite numbers" path — x is \`undefined\` which fails \`typeof 'number'\`)
- [ ] POST missing url → 400 "Missing required fields: projectId, url, element, comment"

🤖 Generated with [Claude Code](https://claude.com/claude-code)