### PR TITLE
feat: enable RLS and switch API to service_role key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ VITE_API_BASE=https://your-deployment.vercel.app/api
 # Demo app — project namespace for comments
 VITE_PROJECT_ID=demo-project
 
-# Server — Supabase credentials used by api/comment.ts and api/comments.ts
+# Server — Supabase credentials used by api/comment.ts and api/comments.ts.
+# Use the service_role key (Supabase Dashboard → Settings → API). It
+# bypasses RLS and MUST stay server-side — never put it in a VITE_* var.
 SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_KEY=your-supabase-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Demo app — base URL of the feedback-widget API (your own deployment)
+VITE_API_BASE=https://your-deployment.vercel.app/api
+
+# Demo app — project namespace for comments
+VITE_PROJECT_ID=demo-project
+
+# Server — Supabase credentials used by api/comment.ts and api/comments.ts
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_KEY=your-supabase-key

--- a/README.md
+++ b/README.md
@@ -40,12 +40,18 @@ This widget does not ship with a hosted backend. You run your own. The repo incl
 - `api/comment.ts` — `POST` handler that writes a comment to Supabase.
 - `api/comments.ts` — `GET` handler that lists comments for a `projectId`.
 - `supabase/schema.sql` — database schema.
+- `supabase/migrate-enable-rls.sql` — locks the tables down so only the server can read/write.
 
 Steps:
 
-1. Create a Supabase project and run `supabase/schema.sql` to create the `comments` table.
-2. Deploy the `api/` functions (e.g. to Vercel). Set `SUPABASE_URL` and `SUPABASE_KEY` as environment variables on that deployment.
-3. Point `apiBase` at your deployment's `/api` URL.
+1. Create a Supabase project and run `supabase/schema.sql` to create the tables.
+2. Run `supabase/migrate-enable-rls.sql`. This enables Row Level Security with no policies, so the anon/public key is denied everything — all access must flow through the API.
+3. Deploy the `api/` functions (e.g. to Vercel). Set these environment variables on the deployment:
+   - `SUPABASE_URL` — your Supabase project URL.
+   - `SUPABASE_SERVICE_ROLE_KEY` — the **service_role** key from your Supabase dashboard (Settings → API). This key bypasses RLS and must never be exposed to a browser. Do not put it in any `VITE_*` variable.
+4. Point `apiBase` at your deployment's `/api` URL.
+
+> **Security note.** The anon/publishable key is never used here. All access to Supabase goes through the API functions using the service_role key. If you ever leak the service_role key, rotate it immediately in the Supabase dashboard.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,36 @@ export default function App() {
       {/* your app */}
       <FeedbackWidget
         projectId="your-project-name"
-        supabaseUrl="YOUR_SUPABASE_URL"
-        supabaseKey="YOUR_SUPABASE_KEY"
+        apiBase="https://your-deployment.example.com/api"
       />
     </>
   )
 }
 ```
 
+### Props
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `projectId` | `string` | yes | Namespace for comments. All comments are scoped by this value. |
+| `apiBase` | `string` | yes | Base URL of the backend that serves `POST /comment` and `GET /comments`. |
+
+## Backend setup
+
+This widget does not ship with a hosted backend. You run your own. The repo includes everything you need:
+
+- `api/comment.ts` — `POST` handler that writes a comment to Supabase.
+- `api/comments.ts` — `GET` handler that lists comments for a `projectId`.
+- `supabase/schema.sql` — database schema.
+
+Steps:
+
+1. Create a Supabase project and run `supabase/schema.sql` to create the `comments` table.
+2. Deploy the `api/` functions (e.g. to Vercel). Set `SUPABASE_URL` and `SUPABASE_KEY` as environment variables on that deployment.
+3. Point `apiBase` at your deployment's `/api` URL.
+
 ## Requirements
 
 - React 18+
-- A Supabase project with a comments table
+- A Supabase project (or any equivalent backend behind the two `api/` handlers)
+- A deployment target for the `api/` functions (e.g. Vercel)

--- a/api/comment.ts
+++ b/api/comment.ts
@@ -28,10 +28,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const supabaseUrl = process.env.SUPABASE_URL
-  const supabaseKey = process.env.SUPABASE_KEY
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
   if (!supabaseUrl || !supabaseKey) {
-    return res.status(500).json({ error: 'Server misconfigured: missing Supabase credentials' })
+    return res.status(500).set(cors).json({ error: 'Server misconfigured: missing Supabase credentials' })
   }
 
   const supabase = createClient(supabaseUrl, supabaseKey)

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,5 +1,11 @@
 import { FeedbackWidget } from 'feedback-widget'
 
+const apiBase = import.meta.env.VITE_API_BASE
+const projectId = import.meta.env.VITE_PROJECT_ID
+if (!apiBase || !projectId) {
+  throw new Error('VITE_API_BASE and VITE_PROJECT_ID are required. Copy .env.example to .env and fill them in.')
+}
+
 export function App() {
   return (
     <div style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif' }}>
@@ -14,7 +20,7 @@ export function App() {
         </button>
       </div>
 
-      <FeedbackWidget projectId="demo-project" apiBase="https://feedback-widget-sigma.vercel.app/api" />
+      <FeedbackWidget projectId={projectId} apiBase={apiBase} />
     </div>
   )
 }

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -14,7 +14,7 @@ export function App() {
         </button>
       </div>
 
-      <FeedbackWidget projectId="demo-project" />
+      <FeedbackWidget projectId="demo-project" apiBase="https://feedback-widget-sigma.vercel.app/api" />
     </div>
   )
 }

--- a/demo/env.d.ts
+++ b/demo/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE: string
+  readonly VITE_PROJECT_ID: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getSelector } from '../lib/getSelector'
 
-const API_BASE = 'https://feedback-widget-sigma.vercel.app/api'
+const DEFAULT_API_BASE = 'https://feedback-widget-sigma.vercel.app/api'
 
 interface FeedbackWidgetProps {
   projectId: string
+  apiBase?: string
 }
 
 type Mode = 'idle' | 'selecting' | 'commenting'
@@ -43,7 +44,7 @@ function timeAgo(date: string): string {
   return `${days}d ago`
 }
 
-export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
+export function FeedbackWidget({ projectId, apiBase = DEFAULT_API_BASE }: FeedbackWidgetProps) {
   const [mode, setMode] = useState<Mode>('idle')
   const [target, setTarget] = useState<ClickTarget | null>(null)
   const [comment, setComment] = useState('')
@@ -65,7 +66,7 @@ export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
   useEffect(() => {
     async function fetchComments() {
       try {
-        const res = await fetch(`${API_BASE}/comments?projectId=${encodeURIComponent(projectId)}`)
+        const res = await fetch(`${apiBase}/comments?projectId=${encodeURIComponent(projectId)}`)
         if (!res.ok) return
         const data = await res.json()
         if (Array.isArray(data)) {
@@ -76,7 +77,7 @@ export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
       }
     }
     fetchComments()
-  }, [projectId])
+  }, [projectId, apiBase])
 
   // --- Set crosshair cursor on body when selecting ---
   useEffect(() => {
@@ -178,7 +179,7 @@ export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
     }
 
     // Fire API call (don't block UI on it)
-    fetch(`${API_BASE}/comment`, {
+    fetch(`${apiBase}/comment`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -223,7 +224,7 @@ export function FeedbackWidget({ projectId }: FeedbackWidgetProps) {
       setShowSuccess(false)
       setSidebarOpen(true)
     }, 800)
-  }, [comment, target, projectId])
+  }, [comment, target, projectId, apiBase])
 
   // --- Keyboard: Escape to cancel popover / close sidebar, Cmd+Enter to send ---
   useEffect(() => {

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -1,11 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getSelector } from '../lib/getSelector'
 
-const DEFAULT_API_BASE = 'https://feedback-widget-sigma.vercel.app/api'
-
 interface FeedbackWidgetProps {
   projectId: string
-  apiBase?: string
+  apiBase: string
 }
 
 type Mode = 'idle' | 'selecting' | 'commenting'
@@ -44,7 +42,7 @@ function timeAgo(date: string): string {
   return `${days}d ago`
 }
 
-export function FeedbackWidget({ projectId, apiBase = DEFAULT_API_BASE }: FeedbackWidgetProps) {
+export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
   const [mode, setMode] = useState<Mode>('idle')
   const [target, setTarget] = useState<ClickTarget | null>(null)
   const [comment, setComment] = useState('')

--- a/supabase/migrate-enable-rls.sql
+++ b/supabase/migrate-enable-rls.sql
@@ -1,0 +1,24 @@
+-- Enable Row Level Security on the public tables.
+--
+-- Intent: the widget's browser runtime never talks to Supabase directly —
+-- all access goes through the Vercel API functions, which use a
+-- service_role key that bypasses RLS.
+--
+-- With RLS enabled and NO policies defined, the anon/public roles are
+-- denied everything by default. This means:
+--   - The server-side API (using service_role) keeps working.
+--   - Anyone with the old anon/publishable key can't read, write, or
+--     delete any row via the Supabase client SDK.
+--
+-- Before running this migration:
+--   1. In the Supabase dashboard, copy the service_role key.
+--   2. Set SUPABASE_SERVICE_ROLE_KEY on the Vercel deployment to that value.
+--   3. Remove the old SUPABASE_KEY env var.
+--   4. Deploy the api/ handlers (updated to read SUPABASE_SERVICE_ROLE_KEY).
+--
+-- Only after the API is deploying with the service_role key should you
+-- run this migration. Otherwise the API will start returning 500s the
+-- moment RLS is enabled.
+
+alter table comments enable row level security;
+alter table projects enable row level security;


### PR DESCRIPTION
Fixes item #2 from CODE_REVIEW.md.

## Stacked on PR #9

This PR targets \`feat/configurable-api-base\` (PR #9) as its base because it touches the README rewrite and \`.env.example\` added there. Once #9 merges to \`main\`, I'll retarget this PR to \`main\`.

## What's in here
- **\`supabase/migrate-enable-rls.sql\`** — enables RLS on \`comments\` and \`projects\` with no policies. Anon/public roles are denied by default; service_role bypasses RLS, so the API keeps working. Header comment is the operator runbook.
- **\`api/comment.ts\`** — reads \`SUPABASE_SERVICE_ROLE_KEY\` instead of \`SUPABASE_KEY\`. Also adds \`.set(cors)\` to the 500 misconfig response (drive-by).
- **\`.env.example\`** — renames the server var to \`SUPABASE_SERVICE_ROLE_KEY\` and adds a warning that it must stay server-side (never a \`VITE_*\` var).
- **\`README.md\`** — new \"Backend setup\" step for the RLS migration, new env var name, security note explaining the service_role key's power and the no-client-bundle rule.

## Also needed (follow-up)
\`api/comments.ts\` lives on a separate branch (PR #8). When that PR merges — or when this one merges after it — \`api/comments.ts\` must also be switched from \`SUPABASE_KEY\` → \`SUPABASE_SERVICE_ROLE_KEY\`. I can do that as a tiny follow-up PR or fold it into whichever PR lands second.

## Operator deployment order
To avoid downtime when rolling this out:

1. Copy the **service_role** key from Supabase Dashboard → Settings → API.
2. Set \`SUPABASE_SERVICE_ROLE_KEY\` on the Vercel deployment (leaving the old \`SUPABASE_KEY\` in place for now).
3. Deploy this PR (API now reads the new var).
4. Run \`supabase/migrate-enable-rls.sql\` in the Supabase SQL editor.
5. Delete the old \`SUPABASE_KEY\` env var from Vercel.

Running the migration **before** step 3 will cause API 500s because the anon key the API is still using will be denied.

## Test plan
- [ ] Before migrating: API works with new env var name
- [ ] After migrating: API still works (service_role bypasses RLS)
- [ ] After migrating: calling Supabase from a browser with the anon key fails (RLS blocks)
- [ ] Leaking anon key is now harmless — can't read or write anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)