### PR TITLE
hotfix(api): remove res.set() calls — crashes at runtime

### DIFF
--- a/api/comment.ts
+++ b/api/comment.ts
@@ -1,18 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createClient } from '@supabase/supabase-js'
 
-const cors = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-}
-
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
-    return res.status(204).setHeader('Access-Control-Allow-Origin', '*')
-      .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
-      .setHeader('Access-Control-Allow-Headers', 'Content-Type')
-      .end()
+    return res.status(204).end()
   }
 
   if (req.method !== 'POST') {
@@ -22,7 +13,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { projectId, url, x, y, element, comment } = req.body ?? {}
 
   if (!projectId || !url || x == null || y == null || !element || !comment) {
-    return res.status(400).set(cors).json({
+    return res.status(400).json({
       error: 'Missing required fields: projectId, url, x, y, element, comment',
     })
   }
@@ -48,8 +39,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   ] as never)
 
   if (error) {
-    return res.status(500).set(cors).json({ error: error.message })
+    return res.status(500).json({ error: error.message })
   }
 
-  return res.status(200).set(cors).json({ success: true })
+  return res.status(200).json({ success: true })
 }


### PR DESCRIPTION
Hotfix for the production crash (\`FUNCTION_INVOCATION_FAILED\`) affecting every POST to \`/api/comment\`.

## Root cause
\`res.set()\` is Express-style; \`@vercel/node\`'s \`VercelResponse\` only has \`.setHeader()\`. TypeScript flagged this at build time (\`error TS2339: Property 'set' does not exist on type 'VercelResponse'\`) but Vercel shipped the code anyway. At runtime, \`res.status(...).set(...)\` throws because \`.set\` is \`undefined\`.

This affected **every non-OPTIONS response path** since the initial commit — 400, 500, and 200 all crashed on the way to \`.json()\`.

## Fix
Remove all \`.set(cors)\` calls. CORS is already configured globally in \`vercel.json\` for \`/api/*\`, so the per-response set was redundant even before it was broken. Also simplified the OPTIONS handler to just \`res.status(204).end()\` since \`vercel.json\` attaches the preflight headers.

## Verified
Cherry-picked to a temporary deployment (\`feedback-widget-six-steel.vercel.app\`) — same POST now returns \`200 {"success":true}\` instead of \`FUNCTION_INVOCATION_FAILED\`.

## Merge urgency
High — production has been broken since day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)