### PR TITLE
hotfix(api): fix comments GET — res.set() + key name

### DIFF
--- a/api/comments.ts
+++ b/api/comments.ts
@@ -1,37 +1,28 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createClient } from '@supabase/supabase-js'
 
-const cors = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-}
-
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
-    return res.status(204).setHeader('Access-Control-Allow-Origin', '*')
-      .setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
-      .setHeader('Access-Control-Allow-Headers', 'Content-Type')
-      .end()
+    return res.status(204).end()
   }
 
   if (req.method !== 'GET') {
-    return res.status(405).set(cors).json({ error: 'Method not allowed' })
+    return res.status(405).json({ error: 'Method not allowed' })
   }
 
   const projectId = typeof req.query.projectId === 'string' ? req.query.projectId : undefined
 
   if (!projectId) {
-    return res.status(400).set(cors).json({
+    return res.status(400).json({
       error: 'Missing required query param: projectId',
     })
   }
 
   const supabaseUrl = process.env.SUPABASE_URL
-  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const supabaseKey = process.env.SUPABASE_KEY
 
   if (!supabaseUrl || !supabaseKey) {
-    return res.status(500).set(cors).json({ error: 'Server misconfigured: missing Supabase credentials' })
+    return res.status(500).json({ error: 'Server misconfigured: missing Supabase credentials' })
   }
 
   const supabase = createClient(supabaseUrl, supabaseKey)
@@ -43,8 +34,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     .order('created_at', { ascending: false })
 
   if (error) {
-    return res.status(500).set(cors).json({ error: error.message })
+    return res.status(500).json({ error: error.message })
   }
 
-  return res.status(200).set(cors).json(data ?? [])
+  return res.status(200).json(data ?? [])
 }


### PR DESCRIPTION
Fixes FUNCTION_INVOCATION_FAILED on \`GET /api/comments\`.

## Two bugs
1. \`res.set(cors)\` doesn't exist on \`VercelResponse\` — same issue fixed in hotfix #16 for \`api/comment.ts\`. CORS is already applied globally by \`vercel.json\`.
2. Handler reads \`SUPABASE_SERVICE_ROLE_KEY\`, but that env var isn't set on the deployment — the project still uses \`SUPABASE_KEY\`. The rename was part of PR #15 (RLS rollout) which isn't being merged right now.

## Verified
Widget sidebar now loads comments from the same-origin \`/api/comments\` endpoint without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)