### PR TITLE
chore: simplify comments API + test helpers post-PR-20 merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,8 @@ jobs:
       - name: Enforce bundle size ceiling
         run: |
           SIZE=$(wc -c < dist/feedback-widget.es.js | tr -d ' ')
-          # 260 KB = post-PR-20 baseline. The animated reviewer UX (framer-motion
-          # + lucide-react) lands the widget around 246 KB; this ceiling gives
-          # ~14 KB headroom to catch accidental regressions while reflecting the
-          # product's actual footprint. Slimming the bundle is tracked in
-          # thedesignproject/feedback-widget#29 — reduce this number when that work lands.
+          # ~14 KB headroom over the current framer-motion baseline. Drop when
+          # the animation bundle shrinks (thedesignproject/feedback-widget#29).
           MAX=266240
           echo "dist/feedback-widget.es.js: $SIZE bytes (max $MAX)"
           if [ "$SIZE" -gt "$MAX" ]; then

--- a/api/comments.ts
+++ b/api/comments.ts
@@ -1,6 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
+const SMOKE_CLEANUP_HEADER = 'x-smoke-cleanup-token'
+const SMOKE_PROJECT_PREFIX = 'smoke-'
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
     return res.status(204).end()
@@ -112,12 +115,9 @@ async function handlePatch(req: VercelRequest, res: VercelResponse, supabase: Su
   return res.status(200).json({ success: true })
 }
 
-// DELETE dispatches by query param:
-//   ?id=<uuid>         → single-comment delete (reviewer sidebar). Unauthenticated
-//                        in v0; requires knowing the UUID. Reviewer auth tracked
-//                        as a follow-up — deploy reviewer UIs behind embedder auth.
-//   ?projectId=smoke-* → bulk cleanup for the CI smoke workflow. Token-gated and
-//                        scoped to smoke-* projectIds so no one else can wipe a project.
+// Two DELETE surfaces with deliberately different trust: ?id= is the reviewer
+// sidebar (unauthenticated in v0, single row per call); ?projectId= is the
+// smoke-cleanup path (token + smoke-* prefix required). See README Security.
 async function handleDelete(req: VercelRequest, res: VercelResponse, supabase: SupabaseClient) {
   const id = typeof req.query.id === 'string' ? req.query.id : undefined
   const projectId = typeof req.query.projectId === 'string' ? req.query.projectId : undefined
@@ -133,12 +133,12 @@ async function handleDelete(req: VercelRequest, res: VercelResponse, supabase: S
     if (!cleanupToken) {
       return res.status(501).json({ error: 'Bulk DELETE disabled: SMOKE_CLEANUP_TOKEN not configured' })
     }
-    const presented = req.headers['x-smoke-cleanup-token']
+    const presented = req.headers[SMOKE_CLEANUP_HEADER]
     if (typeof presented !== 'string' || presented !== cleanupToken) {
       return res.status(401).json({ error: 'Unauthorized' })
     }
-    if (!projectId.startsWith('smoke-')) {
-      return res.status(400).json({ error: 'Bulk DELETE is scoped to smoke-* projectIds only' })
+    if (!projectId.startsWith(SMOKE_PROJECT_PREFIX)) {
+      return res.status(400).json({ error: `Bulk DELETE is scoped to ${SMOKE_PROJECT_PREFIX}* projectIds only` })
     }
     const { error } = await supabase.from('comments').delete().eq('project_id', projectId)
     if (error) return res.status(500).json({ error: error.message })

--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -27,21 +27,14 @@ function mockFetch(
   return calls
 }
 
-// Drive the widget into 'commenting' mode by:
-//  1. Pressing the 'C' shortcut (idle → selecting). More stable than hunting
-//     the redesigned pill trigger's DOM, and exercises the same state path.
-//  2. Dispatching a click on a target node (selecting → commenting with target).
-// Returns the textarea and the Send button for the caller to interact with.
 async function enterCommentingMode() {
-  // Clean up any target node left over from a previous test (render's auto-
-  // cleanup removes the widget root, but not nodes we appended by hand).
+  // render's auto-cleanup removes the widget root but not nodes we appended.
   document.querySelectorAll('[data-test-target]').forEach((n) => n.remove())
 
   const targetNode = document.createElement('article')
   targetNode.setAttribute('data-test-target', '')
   document.body.appendChild(targetNode)
 
-  // Wait for the widget to mount before dispatching shortcuts.
   await waitFor(() => {
     if (document.querySelectorAll('[data-fw]').length === 0) {
       throw new Error('widget root not mounted yet')
@@ -68,10 +61,8 @@ async function enterCommentingMode() {
     return el
   })
 
-  // The Send button is rendered twice in the widget (disabled collapsed form
-  // and enabled expanded form) depending on whether the comment has text.
-  // Don't snapshot it here — each test queries *after* typing, so it grabs
-  // the currently-mounted enabled button.
+  // The widget renders two Send buttons (disabled collapsed / enabled expanded)
+  // conditionally on comment text — re-query after typing, don't snapshot.
   const getSendButton = () => {
     const btn = document.querySelector<HTMLButtonElement>('button[aria-label="Send"]')
     if (!btn) throw new Error('Send button not found')
@@ -212,19 +203,15 @@ describe('<FeedbackWidget />', () => {
         expect(posts.length).toBe(1)
       })
 
-      // Give React a tick to flush any state updates.
       await new Promise((r) => setTimeout(r, 20))
 
-      // The textarea still holds the typed draft (the widget only clears on
-      // success), so checking body.textContent would false-match. Instead,
-      // assert the sidebar's empty-state marker is still present — proving no
-      // optimistic comment was added to state on the failed POST.
+      // Textarea still holds the draft, so body.textContent would false-match.
+      // The sidebar empty-state is the real signal that state wasn't mutated.
       const sidebarEmpty = Array.from(
         document.querySelectorAll<HTMLDivElement>('[data-fw] div'),
       ).some((el) => el.textContent === 'No comments yet')
       expect(sidebarEmpty).toBe(true)
 
-      // Sanity: widget surfaced the failure via console.warn.
       expect(console.warn).toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
## Summary

Post-merge `/simplify` cleanup of the pieces I authored while resolving the PR #20 merge. No behavior changes — typecheck + 31/31 tests green.

- **`api/comments.ts`**: lift `'x-smoke-cleanup-token'` and `'smoke-'` to module-level constants (used both in the auth check and in the error message). Trim `handleDelete`'s preamble comment from 6 lines to 3 — the README Security section already carries the long-form rationale.
- **`src/__tests__/FeedbackWidget.test.tsx`**: drop the narrative block above `enterCommentingMode` (function name + body self-explanatory). Tighten the failed-POST assertion comment and the Send-button re-query note.
- **`.github/workflows/ci.yml`**: collapse the 5-line ceiling rationale to 2 lines pointing at #29 (the real fix).

Net: **-16 lines**, same behavior.

## What I explicitly did NOT change

- `handleDelete` dispatching on query param — matter of taste; the trust-asymmetry comment covers the concern and the current form is compact.
- `createClient` order vs env validation — efficiency review confirmed the wasted work on rejected requests is negligible.
- Status-enum stringly-typed check in `handlePatch` — predates this session; not mine to refactor.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (31/31)
- [ ] CI: bundle-size gate still passes (no code shipped, just comment trims + constants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)