### PR TITLE
chore: ignore Vite + @vitejs/plugin-react major bumps until migration is scheduled

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,12 @@ updates:
           - patch
       production-dependencies:
         dependency-type: production
+    # Vite 8 requires a coordinated vitest 3→4 + plugin-react 4→6 migration.
+    # Defer until we have a concrete reason (see closed #26 / #27).
+    ignore:
+      - dependency-name: vite
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@vitejs/plugin-react"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## Summary

Closed #26 (Vite 6→8) and #27 (@vitejs/plugin-react 4→6) with rationale — both are coupled to a vitest 3→4 migration that isn't scheduled. This PR adds Dependabot ignore rules so those majors don't come back every Monday until we're ready.

## Why

- Vite 8 peers `@vitejs/plugin-react@6` (coupling #26 ↔ #27).
- `@vitest/mocker@3.x` (current) only accepts Vite ≤7, so Vite 8 forces **vitest 3→4** plus `@vitest/coverage-v8` 3→4.
- vitest 4 is a major with its own config/API changes.
- Nothing on the current stack is broken or missing a feature we need.

When there's a concrete reason to migrate, remove the ignore block and bump all four together.

## Test plan

- [ ] CI is green (no code changes; dependabot.yml only).