### PR TITLE
chore: extend dependabot ignore to vitest + coverage-v8 majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,12 +29,19 @@ updates:
           - patch
       production-dependencies:
         dependency-type: production
-    # Vite 8 requires a coordinated vitest 3→4 + plugin-react 4→6 migration.
-    # Defer until we have a concrete reason (see closed #26 / #27).
+    # The Vite 8 + vitest 4 + plugin-react 6 stack moves together. Bumping
+    # one without the others fails peer resolution. Defer the whole quartet
+    # until we schedule the migration (see closed #26 / #27 / #32).
     ignore:
       - dependency-name: vite
         update-types:
           - version-update:semver-major
       - dependency-name: "@vitejs/plugin-react"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: vitest
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "@vitest/coverage-v8"
         update-types:
           - version-update:semver-major


### PR DESCRIPTION
## Summary

Same story as #31 — the Vite 8 / vitest 4 / plugin-react 6 / coverage-v8 4 versions peer together and can only move as a quartet. #32 (just closed) was the piecewise proposal for coverage-v8 4. Extends the ignore list to keep dependabot from re-proposing vitest + coverage-v8 majors until the migration is deliberately scheduled.

## Related

- Ignore list introduced in #31 (vite + plugin-react)
- Closed peers: #26 (vite 8), #27 (plugin-react 6), #32 (coverage-v8 4)