### PR TITLE
chore: rename npm scope to @thedesignproject

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
           }
           JSON
           cat > index.tsx <<'TSX'
-          import { FeedbackWidget } from '@tosses/feedback-widget'
+          import { FeedbackWidget } from '@thedesignproject/feedback-widget'
           export default function App() {
             return <FeedbackWidget projectId="smoke" apiBase="https://x" />
           }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @tosses/feedback-widget
+# @thedesignproject/feedback-widget
 
 Visual feedback tool for React projects. Your client visits their deployed URL, clicks any element, and leaves a comment. You see everything instantly.
 
@@ -6,7 +6,7 @@ Visual feedback tool for React projects. Your client visits their deployed URL, 
 
 This repository contains two separate things:
 
-- **`src/`** — the React library published to npm as `@tosses/feedback-widget`. This is the product.
+- **`src/`** — the React library published to npm as `@thedesignproject/feedback-widget`. This is the product.
 - **`demo/` + `api/` + `supabase/`** — a live demo hosted on Vercel and a **reference implementation** of the backend the library expects. Copy these into your own project as a starting point; they are not part of the published library.
 
 The library talks to *your* backend, not ours. Only `projectId` and `apiBase` cross the library's boundary.
@@ -14,13 +14,13 @@ The library talks to *your* backend, not ours. Only `projectId` and `apiBase` cr
 ## Installation
 
 ```bash
-npm install @tosses/feedback-widget
+npm install @thedesignproject/feedback-widget
 ```
 
 ## Usage
 
 ```jsx
-import { FeedbackWidget } from '@tosses/feedback-widget'
+import { FeedbackWidget } from '@thedesignproject/feedback-widget'
 
 export default function App() {
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@tosses/feedback-widget",
+  "name": "@thedesignproject/feedback-widget",
   "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@tosses/feedback-widget",
+      "name": "@thedesignproject/feedback-widget",
       "version": "0.3.4",
       "dependencies": {
         "@supabase/supabase-js": "^2.49.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tosses/feedback-widget",
+  "name": "@thedesignproject/feedback-widget",
   "version": "0.3.4",
   "description": "Visual feedback widget for React apps",
   "type": "module",


### PR DESCRIPTION
## Summary

The package is already published to npm as `@thedesignproject/feedback-widget@0.1.0` — the sources still referenced the old `@tosses/*` name. This PR aligns the codebase with the actual published scope.

## Changes

- `package.json` — `"name"` field
- `README.md` — title, install snippet, usage example, repo-layout reference
- `.github/workflows/publish.yml` — consumer-smoke synthetic import
- `package-lock.json` — regenerated with the new top-level package name (301 packages, no dep changes)

## Verified locally

- `npm run typecheck` ✅
- `npm test` → 31/31 ✅
- `npm run build` ✅

## Follow-up (not in this PR)

`@tosses/feedback-widget` still exists on npm with 8 versions through 0.3.4. Worth deprecating so anyone pinned to it sees a pointer:

```bash
npm deprecate @tosses/feedback-widget "moved to @thedesignproject/feedback-widget"
```