### PR TITLE
fix(ci): use bun pm pack --quiet in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Pack tarball
         id: pack
         run: |
-          TARBALL=$(bun pm pack | tail -1)
+          TARBALL=$(bun pm pack --quiet)
           echo "path=$(pwd)/$TARBALL" >> "$GITHUB_OUTPUT"
       - name: Build consumer app against React ${{ matrix.react }}
         env:


### PR DESCRIPTION
The first publish run (tag v0.3.4, run 24691138337) failed in consumer-smoke because \`bun pm pack | tail -1\` captured the trailing \`Packed size: 112.13KB\` line instead of the \`.tgz\` filename. \`bun add \"/.../Packed size: 112.13KB\"\` then errored with \`unrecognised dependency format\`.

\`bun pm pack --quiet\` prints only the tarball name. One-line fix.

After merging, I'll force-update the \`v0.3.4\` tag to the new \`main\` HEAD so the publish workflow re-runs with the fix in place.