### PR TITLE
fix(ci): pass Vercel protection-bypass header on smoke probe

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,16 +18,27 @@ jobs:
         env:
           DEPLOY_URL: ${{ github.event.deployment_status.environment_url }}
           CLEANUP_TOKEN: ${{ secrets.SMOKE_CLEANUP_TOKEN }}
+          BYPASS_TOKEN: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           PROBE="smoke-$(date +%s)-${GITHUB_SHA:0:7}"
           echo "Probing $DEPLOY_URL/api/comments with projectId=$PROBE"
 
+          # Vercel Deployment Protection gates the per-deployment URL behind
+          # SSO. The smoke job can't authenticate, so we pass the project's
+          # "Protection Bypass for Automation" token on every request via the
+          # x-vercel-protection-bypass header.
+          if [ -z "${BYPASS_TOKEN:-}" ]; then
+            echo "::error::VERCEL_AUTOMATION_BYPASS_SECRET not set — the smoke probe URL is SSO-gated and will 401 without it"
+            exit 1
+          fi
+
           cleanup() {
             if [ -n "${CLEANUP_TOKEN:-}" ]; then
               curl -sS -o /dev/null -w "cleanup: %{http_code}\n" \
                 -X DELETE "$DEPLOY_URL/api/comments?projectId=$PROBE" \
+                -H "x-vercel-protection-bypass: $BYPASS_TOKEN" \
                 -H "x-smoke-cleanup-token: $CLEANUP_TOKEN" || true
             else
               echo "::warning::SMOKE_CLEANUP_TOKEN not set — leaving probe row behind"
@@ -38,6 +49,7 @@ jobs:
           POST_RES=$(curl -sS -o /tmp/post.json -w "%{http_code}" \
             -X POST "$DEPLOY_URL/api/comments" \
             -H 'Content-Type: application/json' \
+            -H "x-vercel-protection-bypass: $BYPASS_TOKEN" \
             --data "{\"projectId\":\"$PROBE\",\"url\":\"https://smoke\",\"x\":1,\"y\":1,\"element\":\"body\",\"comment\":\"ci smoke test\"}")
           if [ "$POST_RES" != "200" ]; then
             echo "::error::POST returned $POST_RES: $(cat /tmp/post.json)"
@@ -45,6 +57,7 @@ jobs:
           fi
 
           GET_RES=$(curl -sS -o /tmp/get.json -w "%{http_code}" \
+            -H "x-vercel-protection-bypass: $BYPASS_TOKEN" \
             "$DEPLOY_URL/api/comments?projectId=$PROBE")
           if [ "$GET_RES" != "200" ]; then
             echo "::error::GET returned $GET_RES: $(cat /tmp/get.json)"


### PR DESCRIPTION
Smoke was returning \`POST 401\` on every deploy because Vercel's SSO gate serves its login page in front of per-deployment URLs — the smoke job can't authenticate interactively.

Switching on Vercel's **Protection Bypass for Automation**:

1. Set \`VERCEL_AUTOMATION_BYPASS_SECRET\` on the Vercel project (via \`vercel env add\`) — done out-of-band.
2. Stored the same value as a GitHub Actions secret \`VERCEL_AUTOMATION_BYPASS_SECRET\` — done.
3. This PR: adds \`-H "x-vercel-protection-bypass: \$BYPASS_TOKEN"\` on every \`curl\` in the smoke workflow (POST, GET, DELETE cleanup).

Also fails fast with a clear error if the token secret isn't set on the runner, rather than letting curl 401 and dump the Vercel HTML login page into the log.

Smoke is an \`on: deployment_status\` workflow, so it'll run against the next successful production deploy after this merges.