### PR TITLE
fix(supabase): add status column to comments schema

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,16 +18,27 @@ jobs:
         env:
           DEPLOY_URL: ${{ github.event.deployment_status.environment_url }}
           CLEANUP_TOKEN: ${{ secrets.SMOKE_CLEANUP_TOKEN }}
+          BYPASS_TOKEN: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           PROBE="smoke-$(date +%s)-${GITHUB_SHA:0:7}"
           echo "Probing $DEPLOY_URL/api/comments with projectId=$PROBE"
 
+          # Vercel Deployment Protection gates the per-deployment URL behind
+          # SSO. The smoke job can't authenticate, so we pass the project's
+          # "Protection Bypass for Automation" token on every request via the
+          # x-vercel-protection-bypass header.
+          if [ -z "${BYPASS_TOKEN:-}" ]; then
+            echo "::error::VERCEL_AUTOMATION_BYPASS_SECRET not set — the smoke probe URL is SSO-gated and will 401 without it"
+            exit 1
+          fi
+
           cleanup() {
             if [ -n "${CLEANUP_TOKEN:-}" ]; then
               curl -sS -o /dev/null -w "cleanup: %{http_code}\n" \
                 -X DELETE "$DEPLOY_URL/api/comments?projectId=$PROBE" \
+                -H "x-vercel-protection-bypass: $BYPASS_TOKEN" \
                 -H "x-smoke-cleanup-token: $CLEANUP_TOKEN" || true
             else
               echo "::warning::SMOKE_CLEANUP_TOKEN not set — leaving probe row behind"
@@ -38,6 +49,7 @@ jobs:
           POST_RES=$(curl -sS -o /tmp/post.json -w "%{http_code}" \
             -X POST "$DEPLOY_URL/api/comments" \
             -H 'Content-Type: application/json' \
+            -H "x-vercel-protection-bypass: $BYPASS_TOKEN" \
             --data "{\"projectId\":\"$PROBE\",\"url\":\"https://smoke\",\"x\":1,\"y\":1,\"element\":\"body\",\"comment\":\"ci smoke test\"}")
           if [ "$POST_RES" != "200" ]; then
             echo "::error::POST returned $POST_RES: $(cat /tmp/post.json)"
@@ -45,6 +57,7 @@ jobs:
           fi
 
           GET_RES=$(curl -sS -o /tmp/get.json -w "%{http_code}" \
+            -H "x-vercel-protection-bypass: $BYPASS_TOKEN" \
             "$DEPLOY_URL/api/comments?projectId=$PROBE")
           if [ "$GET_RES" != "200" ]; then
             echo "::error::GET returned $GET_RES: $(cat /tmp/get.json)"

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7,6 +7,7 @@ create table projects (
 
 -- Comentarios
 -- project_id is text (not uuid) so callers can use readable string IDs like "demo-project"
+-- status is the reviewer sidebar state: pending (default) | approved | rejected
 create table comments (
   id uuid primary key default gen_random_uuid(),
   project_id text,
@@ -15,5 +16,11 @@ create table comments (
   y float,
   element text,
   comment text,
+  status text default 'pending',
   created_at timestamp default now()
 );
+
+-- Migration for existing databases that predate the status column.
+-- Safe to run repeatedly.
+alter table comments
+  add column if not exists status text default 'pending';


### PR DESCRIPTION
## The bug

PR #20 started selecting \`status\` in \`GET /api/comments\` and writing it via \`PATCH\`, but \`supabase/schema.sql\` was never updated. Any Supabase project that ran the original schema is missing the column — the handler now 500s with:

\`\`\`
column comments.status does not exist
\`\`\`

This was masked behind the SSO 401 in the smoke test; it surfaced once we tested the API directly.

## Fix

- Adds \`status text default 'pending'\` to the base \`create table\` in \`supabase/schema.sql\`
- Adds an idempotent \`ALTER TABLE ... ADD COLUMN IF NOT EXISTS\` migration in the same file so existing databases can catch up without recreating the table

## Manual step required

The live Supabase DB still needs the migration applied. Run in the Supabase SQL editor:

\`\`\`sql
alter table comments
  add column if not exists status text default 'pending';
\`\`\`