### PR TITLE
fix: make apiBase optional with sensible default

### DIFF
--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -5,7 +5,7 @@ import { getSelector } from '../lib/getSelector'
 
 interface FeedbackWidgetProps {
   projectId: string
-  apiBase: string
+  apiBase?: string
 }
 
 type Mode = 'idle' | 'selecting' | 'commenting'
@@ -50,7 +50,9 @@ function timeAgo(date: string): string {
   return `${days}d ago`
 }
 
-export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
+const DEFAULT_API_BASE = 'https://feedback-widget-sigma.vercel.app/api'
+
+export function FeedbackWidget({ projectId, apiBase = DEFAULT_API_BASE }: FeedbackWidgetProps) {
   const [mode, setMode] = useState<Mode>('idle')
   const [target, setTarget] = useState<ClickTarget | null>(null)
   const [comment, setComment] = useState('')


### PR DESCRIPTION
## Problem
Widget requires `apiBase` prop but devs don't know they need to pass it, causing broken installs (hubsync case).

## Solution
Made `apiBase` optional with default: `https://feedback-widget-sigma.vercel.app/api`

## Usage before
```jsx
<FeedbackWidget 
  projectId="my-site" 
  apiBase="https://feedback-widget-sigma.vercel.app/api" 
/>
```

## Usage after
```jsx
<FeedbackWidget projectId="my-site" />
```

Still overrideable for custom deployments.

## Testing
- [ ] Tested locally with demo
- [ ] Will test on hubsync after merge + publish