### PR TITLE
fix(widget): track URL changes in SPAs for pin scoping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thedesignproject/feedback-widget",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Visual feedback widget for React apps",
   "repository": {
     "type": "git",

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -73,6 +73,23 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
   const [editText, setEditText] = useState('')
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null)
 
+  // Track current URL for SPA navigation (pins scoped to page)
+  const [currentUrl, setCurrentUrl] = useState(() => window.location.href.split('?')[0].split('#')[0])
+  useEffect(() => {
+    const update = () => setCurrentUrl(window.location.href.split('?')[0].split('#')[0])
+    window.addEventListener('popstate', update)
+    // Patch pushState/replaceState to detect SPA navigation
+    const origPush = history.pushState.bind(history)
+    const origReplace = history.replaceState.bind(history)
+    history.pushState = (...args) => { origPush(...args); update() }
+    history.replaceState = (...args) => { origReplace(...args); update() }
+    return () => {
+      window.removeEventListener('popstate', update)
+      history.pushState = origPush
+      history.replaceState = origReplace
+    }
+  }, [])
+
   // Sidebar state
   const [comments, setComments] = useState<Comment[]>([])
   const [sidebarOpen, setSidebarOpen] = useState(false)
@@ -399,7 +416,6 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
   }
 
   const cutoff = new Date('2026-04-19T00:00:00Z')
-  const currentUrl = window.location.href.split('?')[0].split('#')[0]
   const visibleComments = useMemo(() => comments.filter((c) => {
     if (new Date(c.createdAt) < cutoff) return false
     const commentUrl = c.pageUrl.split('?')[0].split('#')[0]


### PR DESCRIPTION
## Summary

- Pins from other pages still followed users in SPAs because `currentUrl` was captured once at render, not updated on navigation
- Now patches `pushState`/`replaceState` and listens to `popstate` so the URL filter updates on every SPA navigation
- **This is the only change** — no API changes, no field renames, no cleanup

Fixes HubSync report: "comments from previous pages stay on the screen even as you navigate to another page"

## Test plan

- [ ] Navigate between pages in HubSync — pins only show on the page where they were created
- [ ] Use browser back/forward — pins update correctly
- [ ] Create a new pin — appears only on current page

🤖 Generated with [Claude Code](https://claude.com/claude-code)