### PR TITLE
fix(api): status translation, PATCH endpoint, CORS, legacy response

### DIFF
--- a/api/comments.ts
+++ b/api/comments.ts
@@ -3,19 +3,38 @@ import v1Handler from './v1/public/comments.js'
 
 /**
  * Legacy proxy — old widget versions still call /api/comments.
- * Maps old field names to v1 format and forwards to the real handler.
+ * Maps old field names to v1 format, forwards to the real handler,
+ * then maps the response back to old field names.
  * Remove once all clients are on the new widget.
  */
+
+function mapResponseToLegacy(data: unknown): unknown {
+  if (Array.isArray(data)) return data.map(mapResponseToLegacy)
+  if (data && typeof data === 'object') {
+    const d = data as Record<string, unknown>
+    return {
+      id: d.id,
+      project_id: d.projectId ?? d.project_id,
+      url: d.pageUrl ?? d.url,
+      x: d.x,
+      y: d.y,
+      element: d.selector ?? d.element,
+      comment: d.body ?? d.comment,
+      status: d.reviewStatus ?? d.status ?? 'pending',
+      created_at: d.createdAt ?? d.created_at,
+    }
+  }
+  return data
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  // GET: map ?projectId= to ?projectKey=
+  // Map request fields
   if (req.method === 'GET') {
     if (req.query.projectId && !req.query.projectKey) {
       req.query.projectKey = req.query.projectId
     }
-    return v1Handler(req, res)
   }
 
-  // POST: map old field names to v1 format
   if (req.method === 'POST') {
     const body = req.body ?? {}
     if (body.projectId && !body.projectKey) body.projectKey = body.projectId
@@ -23,9 +42,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (body.element && !body.selector) body.selector = body.element
     if (body.comment && !body.body) body.body = body.comment
     req.body = body
-    return v1Handler(req, res)
   }
 
-  // OPTIONS, PATCH, DELETE — forward as-is
+  // Intercept response to map fields back to legacy format
+  const origJson = res.json.bind(res)
+  res.json = (data: unknown) => origJson(mapResponseToLegacy(data))
+
   return v1Handler(req, res)
 }

--- a/api/v1/comments/[id]/review-status.ts
+++ b/api/v1/comments/[id]/review-status.ts
@@ -1,0 +1,46 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { createClient } from '@supabase/supabase-js'
+
+const VALID_STATUSES: Record<string, string> = {
+  open: 'pending',
+  accepted: 'approved',
+  rejected: 'rejected',
+}
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_KEY
+  if (!url || !key) throw new Error('Server misconfigured: missing Supabase credentials')
+  return createClient(url, key)
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const origin = typeof req.headers.origin === 'string' ? req.headers.origin : '*'
+  res.setHeader('Access-Control-Allow-Origin', origin)
+  res.setHeader('Access-Control-Allow-Methods', 'PATCH, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
+  if (req.method === 'OPTIONS') return res.status(204).end()
+  if (req.method !== 'PATCH') return res.status(405).json({ error: 'Method not allowed' })
+
+  try {
+    const id = typeof req.query.id === 'string' ? req.query.id : undefined
+    if (!id) return res.status(400).json({ error: 'Missing comment id' })
+
+    const { reviewStatus } = req.body ?? {}
+    if (typeof reviewStatus !== 'string' || !VALID_STATUSES[reviewStatus]) {
+      return res.status(400).json({ error: `reviewStatus must be one of: ${Object.keys(VALID_STATUSES).join(', ')}` })
+    }
+
+    const supabase = getSupabase()
+    const { error } = await supabase
+      .from('comments')
+      .update({ status: VALID_STATUSES[reviewStatus] })
+      .eq('id', id)
+
+    if (error) return res.status(500).json({ error: error.message })
+    return res.status(200).json({ success: true })
+  } catch (error) {
+    return res.status(500).json({ error: error instanceof Error ? error.message : 'Unexpected error' })
+  }
+}

--- a/api/v1/public/comments.ts
+++ b/api/v1/public/comments.ts
@@ -18,7 +18,14 @@ function setCors(req: VercelRequest, res: VercelResponse) {
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
 }
 
+const STATUS_MAP: Record<string, string> = {
+  pending: 'open',
+  approved: 'accepted',
+  rejected: 'rejected',
+}
+
 function mapRow(row: Record<string, unknown>) {
+  const dbStatus = typeof row.status === 'string' ? row.status : 'pending'
   return {
     id: row.id,
     projectId: row.project_id,
@@ -27,7 +34,7 @@ function mapRow(row: Record<string, unknown>) {
     x: row.x,
     y: row.y,
     body: row.comment,
-    reviewStatus: row.status ?? 'open',
+    reviewStatus: STATUS_MAP[dbStatus] ?? 'open',
     createdAt: row.created_at,
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,7 @@
       "source": "/api/(.*)",
       "headers": [
         { "key": "Access-Control-Allow-Origin", "value": "*" },
-        { "key": "Access-Control-Allow-Methods", "value": "GET, POST, OPTIONS" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET, POST, PATCH, OPTIONS" },
         { "key": "Access-Control-Allow-Headers", "value": "Content-Type" }
       ]
     }


### PR DESCRIPTION
## Summary

Fixes 4 issues found during codebase audit:

1. **Status value mismatch** — DB uses `pending/approved/rejected` but widget expects `open/accepted/rejected`. Added translation in `mapRow()`.
2. **Missing PATCH endpoint** — Widget calls `PATCH /v1/comments/{id}/review-status` to accept/reject comments but the endpoint didn't exist (404). Created it with proper validation and DB status translation.
3. **CORS missing PATCH** — `vercel.json` only allowed `GET, POST, OPTIONS`. Added `PATCH`.
4. **Legacy proxy response mapping** — Old widget clients calling `/api/comments` got v1 field names (`pageUrl`, `body`, `selector`) they don't understand. Now maps response back to old format (`url`, `comment`, `element`).

## Test plan

- [ ] `GET /api/v1/public/comments?projectKey=x` returns `reviewStatus: "open"` (not "pending")
- [ ] `GET /api/comments?projectId=x` returns old field names (`url`, `element`, `comment`)
- [ ] `PATCH /v1/comments/{id}/review-status` with `{"reviewStatus": "accepted"}` updates DB status to "approved"
- [ ] CORS preflight for PATCH requests succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)