### PR TITLE
Fix cross-origin widget API CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,23 @@ export default function App() {
 | Prop | Type | Required | Description |
 | --- | --- | --- | --- |
 | `projectId` | `string` | yes | Namespace for comments. All comments are scoped by this value. |
-| `apiBase` | `string` | yes | Base URL of the backend that serves `GET /comments` and `POST /comments`. |
+| `apiBase` | `string` | yes | Base URL of the backend that serves the widget API. For this repo's Vercel functions, use `https://<your-deployment>/api`. |
 
 ## Backend setup (reference implementation)
 
-The widget expects these HTTP endpoints at `apiBase`:
+The current widget calls these HTTP endpoints at `apiBase`:
 
-- `GET /comments?projectId=…` → returns `Comment[]` ordered by newest first.
-- `POST /comments` with JSON body `{ projectId, url, x, y, element, comment }` → inserts a row and returns `{ success: true }`.
-- `PATCH /comments` with JSON body `{ id, status?, comment? }` → updates a comment (used by the reviewer sidebar for resolve / edit).
-- `DELETE /comments?id=<uuid>` → deletes a single comment (used by the reviewer sidebar).
-- `DELETE /comments?projectId=smoke-*` → bulk delete, token-gated for the CI smoke workflow only (see `SMOKE_CLEANUP_TOKEN`).
+- `GET /v1/public/comments?projectKey=…` → returns `Comment[]` ordered by newest first.
+- `POST /v1/public/comments` with JSON body `{ projectKey, pageUrl, x, y, selector, body }` → inserts a row and returns the created comment.
+- `PATCH /v1/public/comments` with JSON body `{ id, reviewStatus?, body? }` → updates a comment (used by the reviewer sidebar for resolve / edit).
 
-`api/comments.ts` in this repo implements both on a single Vercel serverless function backed by Supabase Postgres. To stand up a copy:
+The reference backend also keeps a legacy `/comments` proxy for older widget versions:
+
+- `GET /comments?projectId=…`
+- `POST /comments` with JSON body `{ projectId, url, x, y, element, comment }`
+- `PATCH /comments` with JSON body `{ id, status?, comment? }`
+
+`api/v1/public/comments.ts` implements the current endpoint, and `api/comments.ts` proxies the legacy shape into it. Both are backed by Supabase Postgres. To stand up a copy:
 
 1. Create a Supabase project and run `supabase/schema.sql` to create the `comments` table.
 2. Enable Row Level Security on the `comments` table. With no policies defined, anon keys are denied everything by default — the API uses the `service_role` key which bypasses RLS.
@@ -65,14 +69,14 @@ This is one working setup, not the only one. Anything that implements the endpoi
 
 ## Security
 
-In v0, reviewer operations (`PATCH /comments` and `DELETE /comments?id=`) are **unauthenticated**. Anyone who can reach `apiBase` and knows a comment's UUID can edit or delete that row. The bulk `DELETE ?projectId=` path is gated by `SMOKE_CLEANUP_TOKEN` and scoped to `smoke-*` projectIds, so it cannot be used to wipe real projects.
+In v0, reviewer operations (`PATCH /comments`) are **unauthenticated**. Anyone who can reach `apiBase` and knows a comment's UUID can edit that row.
 
 Until proper reviewer auth lands, deploy reviewer UIs (the sidebar) behind your own authentication layer — do not expose them on public pages. Tracked in [issue #28](https://github.com/thedesignproject/feedback-widget/issues/28).
 
 ## Requirements
 
 - React 18 or 19 on the consuming app.
-- A backend implementing the two endpoints above.
+- A backend implementing the endpoints above.
 
 ## Development
 

--- a/__tests__/api/v1/public/comments.test.ts
+++ b/__tests__/api/v1/public/comments.test.ts
@@ -6,14 +6,18 @@ process.env.SUPABASE_KEY = 'test-key'
 
 const mockSelect = vi.fn()
 const mockInsert = vi.fn()
+const mockUpdate = vi.fn()
 const mockEq = vi.fn()
 const mockOrder = vi.fn()
+const mockUpdateEq = vi.fn()
+const mockUpdateSelect = vi.fn()
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({
     from: vi.fn(() => ({
       select: mockSelect,
       insert: mockInsert,
+      update: mockUpdate,
     })),
   })),
 }))
@@ -62,20 +66,46 @@ const call = (req: unknown, res: unknown) =>
 beforeEach(() => {
   mockSelect.mockReset()
   mockInsert.mockReset()
+  mockUpdate.mockReset()
   mockEq.mockReset()
   mockOrder.mockReset()
+  mockUpdateEq.mockReset()
+  mockUpdateSelect.mockReset()
 
   // Default chain for GET: from().select().eq().order()
   mockOrder.mockResolvedValue({ data: [], error: null })
   mockEq.mockReturnValue({ order: mockOrder })
   mockSelect.mockReturnValue({ eq: mockEq })
+
+  // Default chain for PATCH: from().update().eq().select()
+  mockUpdateSelect.mockResolvedValue({ data: [], error: null })
+  mockUpdateEq.mockReturnValue({ select: mockUpdateSelect })
+  mockUpdate.mockReturnValue({ eq: mockUpdateEq })
 })
 
 describe('api/v1/public/comments', () => {
+  it('answers CORS preflight for cross-origin PATCH requests', async () => {
+    const res = mockRes()
+    await call(mockReq({
+      method: 'OPTIONS',
+      headers: {
+        origin: 'https://client.example',
+        'access-control-request-headers': 'content-type, x-client-version',
+      },
+    }), res)
+
+    expect(res.statusCode).toBe(204)
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('*')
+    expect(res.headers['Access-Control-Allow-Methods']).toContain('PATCH')
+    expect(res.headers['Access-Control-Allow-Headers']).toBe('content-type, x-client-version')
+    expect(res.headers['Access-Control-Max-Age']).toBe('86400')
+  })
+
   it('returns 400 when projectKey is missing on GET', async () => {
     const res = mockRes()
     await call(mockReq({ method: 'GET', query: {} }), res)
     expect(res.statusCode).toBe(400)
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('*')
   })
 
   it('returns 400 when required POST fields are missing', async () => {
@@ -115,5 +145,34 @@ describe('api/v1/public/comments', () => {
     expect(res.statusCode).toBe(201)
     expect((res.body as Record<string, unknown>).projectId).toBe('demo-project')
     expect((res.body as Record<string, unknown>).body).toBe('Hello')
+    expect((res.body as Record<string, unknown>).reviewStatus).toBe('open')
+  })
+
+  it('updates a comment review status', async () => {
+    const row = {
+      id: 'comment-1',
+      project_id: 'demo-project',
+      url: 'https://example.com',
+      element: 'body',
+      x: 10,
+      y: 20,
+      comment: 'Hello',
+      status: 'approved',
+      created_at: '2026-04-22T00:00:00Z',
+    }
+    mockUpdateSelect.mockResolvedValue({ data: [row], error: null })
+
+    const res = mockRes()
+    await call(mockReq({
+      method: 'PATCH',
+      headers: { origin: 'https://example.com' },
+      body: { id: 'comment-1', reviewStatus: 'accepted' },
+    }), res)
+
+    expect(mockUpdate).toHaveBeenCalledWith({ status: 'approved' })
+    expect(mockUpdateEq).toHaveBeenCalledWith('id', 'comment-1')
+    expect(res.statusCode).toBe(200)
+    expect((res.body as Record<string, unknown>).reviewStatus).toBe('accepted')
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('*')
   })
 })

--- a/api/_cors.ts
+++ b/api/_cors.ts
@@ -1,0 +1,19 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+
+export const CORS_METHODS = ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'] as const
+
+const DEFAULT_ALLOWED_HEADERS = 'Content-Type, Authorization'
+
+function headerValue(value: string | string[] | undefined) {
+  if (Array.isArray(value)) return value.join(', ')
+  return value
+}
+
+export function setCors(req: VercelRequest, res: VercelResponse) {
+  const requestedHeaders = headerValue(req.headers['access-control-request-headers'])
+
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', CORS_METHODS.join(', '))
+  res.setHeader('Access-Control-Allow-Headers', requestedHeaders || DEFAULT_ALLOWED_HEADERS)
+  res.setHeader('Access-Control-Max-Age', '86400')
+}

--- a/api/v1/public/comments.ts
+++ b/api/v1/public/comments.ts
@@ -1,8 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createClient } from '@supabase/supabase-js'
+import { setCors } from '../../_cors.js'
 
-const METHODS = ['GET', 'POST', 'OPTIONS']
-const SELECT_COLS = 'id, project_id, url, x, y, element, comment, created_at'
+const SELECT_COLS = 'id, project_id, url, x, y, element, comment, status, created_at'
+type ReviewStatus = 'open' | 'accepted' | 'rejected'
 
 function getSupabase() {
   const url = process.env.SUPABASE_URL
@@ -11,11 +12,17 @@ function getSupabase() {
   return createClient(url, key)
 }
 
-function setCors(req: VercelRequest, res: VercelResponse) {
-  const origin = typeof req.headers.origin === 'string' ? req.headers.origin : '*'
-  res.setHeader('Access-Control-Allow-Origin', origin)
-  res.setHeader('Access-Control-Allow-Methods', METHODS.join(', '))
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+function reviewStatusFromDb(value: unknown): ReviewStatus {
+  if (value === 'approved' || value === 'accepted') return 'accepted'
+  if (value === 'rejected') return 'rejected'
+  return 'open'
+}
+
+function dbStatusFromReview(value: unknown) {
+  if (value === 'open' || value === 'pending') return 'pending'
+  if (value === 'accepted' || value === 'approved') return 'approved'
+  if (value === 'rejected') return 'rejected'
+  return null
 }
 
 function mapRow(row: Record<string, unknown>) {
@@ -27,7 +34,7 @@ function mapRow(row: Record<string, unknown>) {
     x: row.x,
     y: row.y,
     body: row.comment,
-    reviewStatus: row.status ?? 'open',
+    reviewStatus: reviewStatusFromDb(row.status),
     createdAt: row.created_at,
   }
 }
@@ -37,6 +44,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') return res.status(204).end()
   if (req.method === 'GET') return handleGet(req, res)
   if (req.method === 'POST') return handlePost(req, res)
+  if (req.method === 'PATCH') return handlePatch(req, res)
   return res.status(405).json({ error: 'Method not allowed' })
 }
 
@@ -54,6 +62,37 @@ async function handleGet(req: VercelRequest, res: VercelResponse) {
 
     if (error) return res.status(500).json({ error: error.message })
     return res.status(200).json((data || []).map(mapRow))
+  } catch (error) {
+    return res.status(500).json({ error: error instanceof Error ? error.message : 'Unexpected error' })
+  }
+}
+
+async function handlePatch(req: VercelRequest, res: VercelResponse) {
+  try {
+    const { id, reviewStatus, status, body, comment } = req.body ?? {}
+    if (typeof id !== 'string' || !id) return res.status(400).json({ error: 'Missing id' })
+
+    const update: { status?: string; comment?: string } = {}
+    const nextStatus = dbStatusFromReview(reviewStatus ?? status)
+    if (nextStatus) update.status = nextStatus
+    if (typeof body === 'string') update.comment = body
+    if (typeof comment === 'string') update.comment = comment
+
+    if (Object.keys(update).length === 0) {
+      return res.status(400).json({ error: 'Missing fields to update' })
+    }
+
+    const supabase = getSupabase()
+    const { data, error } = await supabase
+      .from('comments')
+      .update(update as never)
+      .eq('id', id)
+      .select(SELECT_COLS)
+
+    if (error) return res.status(500).json({ error: error.message })
+    if (!data || data.length === 0) return res.status(404).json({ error: 'Comment not found' })
+
+    return res.status(200).json(mapRow(data[0]))
   } catch (error) {
     return res.status(500).json({ error: error instanceof Error ? error.message : 'Unexpected error' })
   }
@@ -86,4 +125,3 @@ async function handlePost(req: VercelRequest, res: VercelResponse) {
     return res.status(500).json({ error: error instanceof Error ? error.message : 'Unexpected error' })
   }
 }
-

--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -9,6 +9,7 @@ interface FetchCall {
 
 function mockFetch(
   postResponder?: (init?: RequestInit) => Response | Promise<Response>,
+  getResponder?: () => Response | Promise<Response>,
 ) {
   const calls: FetchCall[] = []
   const impl = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
@@ -18,10 +19,13 @@ function mockFetch(
         ? postResponder(init)
         : new Response(JSON.stringify({ success: true }), { status: 200 })
     }
+    if (init?.method === 'PATCH') {
+      return new Response(JSON.stringify({ success: true }), { status: 200 })
+    }
     if (init?.method === 'DELETE') {
       return new Response(JSON.stringify({ success: true }), { status: 200 })
     }
-    return new Response('[]', { status: 200 })
+    return getResponder ? getResponder() : new Response('[]', { status: 200 })
   })
   vi.stubGlobal('fetch', impl)
   return calls
@@ -132,6 +136,42 @@ describe('<FeedbackWidget />', () => {
     await waitFor(() =>
       expect(calls.some((c) => c.url.includes('projectKey=second'))).toBe(true),
     )
+  })
+
+  it('PATCHes review status through the public comments endpoint', async () => {
+    const pageUrl = window.location.href.split('?')[0].split('#')[0]
+    const calls = mockFetch(undefined, () => new Response(JSON.stringify([
+      {
+        id: 'comment-1',
+        projectId: 'proj',
+        pageUrl,
+        x: 20,
+        y: 30,
+        selector: 'body',
+        body: 'resolve me',
+        reviewStatus: 'open',
+        createdAt: '2026-04-22T00:00:00Z',
+      },
+    ]), { status: 200 }))
+
+    render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+
+    await waitFor(() => expect(document.body.textContent).toContain('resolve me'))
+    const resolveButton = await waitFor(() => {
+      const button = document.querySelector<HTMLButtonElement>('button[title="Mark as resolved"]')
+      if (!button) throw new Error('resolve button not mounted yet')
+      return button
+    })
+    fireEvent.click(resolveButton)
+
+    await waitFor(() => {
+      const patch = calls.find((c) => c.init?.method === 'PATCH')
+      expect(patch?.url).toBe('https://x.example/api/v1/public/comments')
+      expect(JSON.parse(String(patch?.init?.body))).toEqual({
+        id: 'comment-1',
+        reviewStatus: 'accepted',
+      })
+    })
   })
 
   describe('submit flow', () => {

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -9,6 +9,7 @@ interface FeedbackWidgetProps {
 }
 
 type Mode = 'idle' | 'selecting' | 'commenting'
+type ReviewStatus = 'open' | 'accepted' | 'rejected'
 
 interface ClickTarget {
   selector: string
@@ -25,7 +26,7 @@ interface Comment {
   y: number
   selector: string
   body: string
-  reviewStatus: string
+  reviewStatus: ReviewStatus
   createdAt: string
 }
 
@@ -48,6 +49,29 @@ function timeAgo(date: string): string {
   if (hours < 24) return `${hours}h ago`
   const days = Math.floor(hours / 24)
   return `${days}d ago`
+}
+
+function normalizeReviewStatus(value: unknown): ReviewStatus {
+  if (value === 'accepted' || value === 'rejected') return value
+  return 'open'
+}
+
+async function fetchProjectComments(apiBase: string, projectId: string): Promise<Comment[]> {
+  try {
+    const res = await fetch(`${apiBase}/v1/public/comments?projectKey=${encodeURIComponent(projectId)}`)
+    if (!res.ok) return []
+
+    const data: unknown = await res.json()
+    if (!Array.isArray(data)) return []
+
+    return data.map((comment) => ({
+      ...(comment as Comment),
+      reviewStatus: normalizeReviewStatus((comment as { reviewStatus?: unknown }).reviewStatus),
+    }))
+  } catch {
+    // Endpoint not ready yet; keep the widget usable with an empty sidebar.
+    return []
+  }
 }
 
 export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
@@ -102,19 +126,13 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
 
   // --- Fetch comments on mount ---
   useEffect(() => {
-    async function fetchComments() {
-      try {
-        const res = await fetch(`${apiBase}/v1/public/comments?projectKey=${encodeURIComponent(projectId)}`)
-        if (!res.ok) return
-        const data = await res.json()
-        if (Array.isArray(data)) {
-          setComments(data.map((c: any) => ({ ...c, reviewStatus: c.reviewStatus || 'open' })))
-        }
-      } catch {
-        // endpoint not ready yet — use empty array
-      }
+    let cancelled = false
+    fetchProjectComments(apiBase, projectId).then((nextComments) => {
+      if (!cancelled) setComments(nextComments)
+    })
+    return () => {
+      cancelled = true
     }
-    fetchComments()
   }, [projectId, apiBase])
 
   // --- Set crosshair cursor when selecting ---
@@ -335,17 +353,17 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
 
   async function patchReviewStatus(id: string, reviewStatus: string) {
     try {
-      await fetch(`${apiBase}/v1/comments/${id}/review-status`, {
+      await fetch(`${apiBase}/v1/public/comments`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reviewStatus }),
+        body: JSON.stringify({ id, reviewStatus }),
       })
     } catch (err) {
       console.warn('[FeedbackWidget] PATCH failed:', err)
     }
   }
 
-  function updateStatus(commentId: string, reviewStatus: 'accepted' | 'rejected') {
+  function updateStatus(commentId: string, reviewStatus: ReviewStatus) {
     setComments((prev) => prev.map((c) => c.id === commentId ? { ...c, reviewStatus } : c))
     patchReviewStatus(commentId, reviewStatus)
   }
@@ -1062,7 +1080,7 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
                       }}
                     >
                       <button
-                        onClick={() => { updateStatus(c.id, c.reviewStatus === 'accepted' ? 'open' as any : 'accepted'); setMenuOpenId(null) }}
+                        onClick={() => { updateStatus(c.id, c.reviewStatus === 'accepted' ? 'open' : 'accepted'); setMenuOpenId(null) }}
                         style={{ width: '100%', padding: '8px 14px', background: 'none', border: 'none', color: '#ccc', fontSize: 12, textAlign: 'left', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 8 }}
                         onMouseEnter={(e) => (e.currentTarget.style.background = '#333')}
                         onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}

--- a/vercel.json
+++ b/vercel.json
@@ -12,8 +12,9 @@
       "source": "/api/(.*)",
       "headers": [
         { "key": "Access-Control-Allow-Origin", "value": "*" },
-        { "key": "Access-Control-Allow-Methods", "value": "GET, POST, OPTIONS" },
-        { "key": "Access-Control-Allow-Headers", "value": "Content-Type" }
+        { "key": "Access-Control-Allow-Methods", "value": "GET, POST, PATCH, DELETE, OPTIONS" },
+        { "key": "Access-Control-Allow-Headers", "value": "Content-Type, Authorization" },
+        { "key": "Access-Control-Max-Age", "value": "86400" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- add shared CORS headers for Vercel API functions, including PATCH preflight support
- route widget review-status updates through the existing public comments endpoint
- add PATCH support to the public comments handler and update endpoint docs

## Verification
- npm run typecheck
- npm test
- npx -y react-doctor@latest . --verbose --diff
- npm run typecheck && npx vite build --config demo/vite.config.ts