### PR TITLE
Fix positon pins  and origin

### DIFF
--- a/api/_lib/http.ts
+++ b/api/_lib/http.ts
@@ -42,15 +42,6 @@ export function getStringQuery(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
-export function isOriginAllowed(req: VercelRequest, project: { allowedOrigins?: string[] | null }) {
-  const origin = typeof req.headers.origin === 'string' ? req.headers.origin : null
-  if (!origin) return true
-  const allowed = project.allowedOrigins || []
-  if (allowed.length === 0) return true
-  if (allowed.includes('*')) return true
-  return allowed.includes(origin)
-}
-
 export function getBearerToken(req: VercelRequest): string | undefined {
   const auth = req.headers.authorization
   if (typeof auth === 'string' && auth.startsWith('Bearer ')) {

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -21,7 +21,6 @@ type ProjectRow = {
   public_key: string
   slug: string
   name: string
-  allowed_origins: string[] | null
   created_at: string
   updated_at: string
 }
@@ -94,7 +93,6 @@ function mapProject(row: ProjectRow) {
     publicKey: row.public_key,
     slug: row.slug,
     name: row.name,
-    allowedOrigins: row.allowed_origins || [],
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -158,7 +156,7 @@ export async function listProjects() {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('projects')
-    .select('public_key, slug, name, allowed_origins, created_at, updated_at')
+    .select('public_key, slug, name, created_at, updated_at')
     .order('created_at', { ascending: true })
 
   if (error) throw new Error(error.message)
@@ -169,7 +167,7 @@ export async function getProject(projectKey: string) {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('projects')
-    .select('public_key, slug, name, allowed_origins, created_at, updated_at')
+    .select('public_key, slug, name, created_at, updated_at')
     .eq('public_key', projectKey)
     .maybeSingle()
 

--- a/api/v1/public/comments.test.ts
+++ b/api/v1/public/comments.test.ts
@@ -99,12 +99,11 @@ describe('api/v1/public/comments', () => {
     expect(res.statusCode).toBe(404)
   })
 
-  it('creates a public comment when the origin is allowed', async () => {
+  it('creates a public comment', async () => {
     vi.mocked(getProject).mockResolvedValue({
       publicKey: 'demo-project',
       slug: 'demo-project',
       name: 'Demo',
-      allowedOrigins: ['https://example.com'],
       createdAt: '',
       updatedAt: '',
     })

--- a/api/v1/public/comments.ts
+++ b/api/v1/public/comments.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createPublicComment, getProject, listComments, updateReviewStatus } from '../../_lib/store.js'
-import { getStringQuery, handleOptions, isOriginAllowed, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
 import type { ReviewStatus } from '../../_lib/status.js'
 import { getSupabase } from '../../_lib/supabase.js'
 
@@ -101,10 +101,6 @@ async function handlePost(req: VercelRequest, res: VercelResponse) {
     const project = await getProject(resolvedProjectKey)
     if (!project) {
       return jsonError(req, res, 404, 'Project not found')
-    }
-
-    if (!isOriginAllowed(req, project)) {
-      return jsonError(req, res, 403, 'Origin not allowed for this project')
     }
 
     let imageUrl: string | null = null

--- a/api/v1/public/project.ts
+++ b/api/v1/public/project.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createShare, getProject, getProjectShare } from '../../_lib/store.js'
 import { encryptToken, generateAccessToken, generateSlug, hashToken } from '../../_lib/tokens.js'
 import { decryptToken } from '../../_lib/tokens.js'
-import { getAppUrl, getStringQuery, handleOptions, isOriginAllowed, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+import { getAppUrl, getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
@@ -14,10 +14,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const project = await getProject(projectKey)
     if (!project) return jsonError(req, res, 404, 'Project not found')
-
-    if (!isOriginAllowed(req, project)) {
-      return jsonError(req, res, 403, 'Origin not allowed for this project')
-    }
 
     let share = await getProjectShare(projectKey)
     let token: string

--- a/apps/dashboard/api.ts
+++ b/apps/dashboard/api.ts
@@ -2,7 +2,6 @@ export interface Project {
   publicKey: string
   slug: string
   name: string
-  allowedOrigins: string[]
   createdAt: string
   updatedAt: string
 }

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -113,9 +113,9 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
   const [pillPos, setPillPos] = useState({ x: window.innerWidth - 72, y: window.innerHeight - 200 })
   const dragging = useRef(false)
 
-  // Re-render on viewport resize, scroll, and body size changes so pins re-anchor
-  // to content reflow (lazy images, accordions, font swap). Safe to observe body
-  // because pins render position:fixed and don't contribute to scrollHeight.
+  // Pins/popovers use position:fixed, so their viewport coords must be recomputed
+  // on scroll (and on resize / body reflow, which shift the page-percent mapping).
+  // RAF-coalesced and gated by needsPositionSyncRef so idle pages stay cheap.
   const [, forceUpdate] = useState(0)
   const needsPositionSyncRef = useRef(false)
   useEffect(() => {

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -53,30 +53,9 @@ function fromPagePercent(x: number, y: number) {
   }
 }
 
-// Anchor pin to its target element via stored selector. Falls back to percent/pixel
-// coords when the selector no longer resolves (DOM changed since capture).
-const STACK_OFFSET = 22 // px shift per additional pin sharing the same selector
-
-function pinPagePos(selector: string | undefined, x: number, y: number, stackIndex = 0): { pageX: number; pageY: number; anchored: boolean } {
-  if (selector) {
-    try {
-      const el = document.querySelector(selector) as HTMLElement | null
-      if (el) {
-        const rect = el.getBoundingClientRect()
-        if (rect.width > 0 && rect.height > 0) {
-          return {
-            pageX: rect.right + window.scrollX - stackIndex * STACK_OFFSET,
-            pageY: rect.top + window.scrollY,
-            anchored: true,
-          }
-        }
-      }
-    } catch {
-      // invalid selector — fall through
-    }
-  }
+function fromPagePercentFixed(x: number, y: number) {
   const { pageX, pageY } = fromPagePercent(x, y)
-  return { pageX, pageY, anchored: false }
+  return { fixedX: pageX - window.scrollX, fixedY: pageY - window.scrollY }
 }
 
 const WIDGET_ATTR = 'data-fw'
@@ -134,24 +113,36 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
   const [pillPos, setPillPos] = useState({ x: window.innerWidth - 72, y: window.innerHeight - 200 })
   const dragging = useRef(false)
 
-  // Re-render on resize / page reflow so fromPagePercent recalculates pin positions.
-  // ResizeObserver on body catches lazy content / images / accordions that grow scrollHeight.
+  // Re-render on viewport resize, scroll, and body size changes so pins re-anchor
+  // to content reflow (lazy images, accordions, font swap). Safe to observe body
+  // because pins render position:fixed and don't contribute to scrollHeight.
   const [, forceUpdate] = useState(0)
+  const needsPositionSyncRef = useRef(false)
   useEffect(() => {
+    let raf = 0
+    const bump = () => {
+      if (!needsPositionSyncRef.current) return
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => forceUpdate(n => n + 1))
+    }
+
     function onResize() {
-      forceUpdate(n => n + 1)
+      bump()
       setPillPos(prev => ({
         x: Math.max(0, Math.min(window.innerWidth - 48, prev.x)),
         y: Math.max(0, Math.min(window.innerHeight - 160, prev.y)),
       }))
     }
     window.addEventListener('resize', onResize)
+    window.addEventListener('scroll', bump, { passive: true })
 
-    const ro = new ResizeObserver(() => forceUpdate(n => n + 1))
+    const ro = new ResizeObserver(bump)
     ro.observe(document.body)
 
     return () => {
+      cancelAnimationFrame(raf)
       window.removeEventListener('resize', onResize)
+      window.removeEventListener('scroll', bump)
       ro.disconnect()
     }
   }, [])
@@ -484,15 +475,14 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
     }
   }
 
-  // --- Popover position (% coords → page-absolute; clamp to viewport at open, anchor to page so it scrolls with pin) ---
+  // Popover position — viewport-relative (fixed) so it doesn't extend scrollHeight.
+  // Re-renders on scroll via the bump listener, keeping it anchored to the pin.
   const popoverStyle = (): React.CSSProperties => {
     if (!target) return { display: 'none' }
     const pad = 16
     const popW = 300
     const popH = 180
-    const { pageX, pageY } = fromPagePercent(target.x, target.y)
-    const fixedX = pageX - window.scrollX
-    const fixedY = pageY - window.scrollY
+    const { fixedX, fixedY } = fromPagePercentFixed(target.x, target.y)
     let leftFixed = fixedX + pad
     let topFixed = fixedY + pad
     if (leftFixed + popW > window.innerWidth) leftFixed = fixedX - popW - pad
@@ -500,29 +490,26 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
     if (leftFixed < pad) leftFixed = pad
     if (topFixed < pad) topFixed = pad
     return {
-      position: 'absolute',
-      left: leftFixed + window.scrollX,
-      top: topFixed + window.scrollY,
+      position: 'fixed',
+      left: leftFixed,
+      top: topFixed,
       zIndex: 2147483646,
     }
   }
 
-  // --- Pin popover position for viewing existing comments ---
   const pinPopoverStyle = (c: Comment): React.CSSProperties => {
     const pad = 16
     const popW = 280
-    const { pageX, pageY } = pinPagePos(c.selector, c.x, c.y, stackIndices.get(c.id) ?? 0)
-    const fixedX = pageX - window.scrollX
-    const fixedY = pageY - window.scrollY
+    const { fixedX, fixedY } = fromPagePercentFixed(c.x, c.y)
     let leftFixed = fixedX + pad
     let topFixed = fixedY - 20
     if (leftFixed + popW > window.innerWidth) leftFixed = fixedX - popW - pad
     if (leftFixed < pad) leftFixed = pad
     if (topFixed < pad) topFixed = fixedY + 40
     return {
-      position: 'absolute',
-      left: leftFixed + window.scrollX,
-      top: topFixed + window.scrollY,
+      position: 'fixed',
+      left: leftFixed,
+      top: topFixed,
       zIndex: 2147483646,
     }
   }
@@ -542,17 +529,7 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
   }), [visibleComments])
   const commentCount = visibleComments.length
 
-  // Per-comment stack index: pins sharing a selector cascade right so they don't overlap.
-  const stackIndices = useMemo(() => {
-    const m = new Map<string, number>()
-    const counts = new Map<string, number>()
-    for (const c of visibleComments) {
-      const n = counts.get(c.selector) ?? 0
-      m.set(c.id, n)
-      counts.set(c.selector, n + 1)
-    }
-    return m
-  }, [visibleComments])
+  needsPositionSyncRef.current = commentCount > 0 || mode !== 'idle' || !!target
 
   return (
     <div {...{ [WIDGET_ATTR]: '' }}>
@@ -805,14 +782,14 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
 
       {/* New comment pin at clicked position */}
       {mode === 'commenting' && target && (() => {
-        const { pageX, pageY } = fromPagePercent(target.x, target.y)
+        const { fixedX, fixedY } = fromPagePercentFixed(target.x, target.y)
         return (
         <div
           {...{ [WIDGET_ATTR]: '' }}
           style={{
-            position: 'absolute',
-            left: pageX - 16,
-            top: pageY - 40,
+            position: 'fixed',
+            left: fixedX - 16,
+            top: fixedY - 40,
             zIndex: 2147483646,
             pointerEvents: 'none',
           }}
@@ -829,7 +806,7 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
 
       {/* Persisted comment pins */}
       {visibleComments.map((c, i) => {
-        const { pageX: pinPageX, pageY: pinPageY } = pinPagePos(c.selector, c.x, c.y, stackIndices.get(c.id) ?? 0)
+        const { fixedX: pinFixedX, fixedY: pinFixedY } = fromPagePercentFixed(c.x, c.y)
         const pinNumber = visibleComments.length - i
         const isSelected = selectedPin === c.id
         const isHovered = hoveredPin === c.id && !isSelected
@@ -848,9 +825,9 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
               onMouseEnter={() => setHoveredPin(c.id)}
               onMouseLeave={() => setHoveredPin(null)}
               style={{
-                position: 'absolute',
-                left: pinPageX - 16,
-                top: pinPageY - 40,
+                position: 'fixed',
+                left: pinFixedX - 16,
+                top: pinFixedY - 40,
                 zIndex: isSelected ? 2147483646 : isHovered ? 2147483642 : 2147483640,
                 cursor: 'pointer',
                 transition: 'transform 0.15s',
@@ -869,9 +846,9 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
             {isHovered && (
               <div
                 style={{
-                  position: 'absolute',
-                  left: pinPageX - 16,
-                  top: pinPageY - 78,
+                  position: 'fixed',
+                  left: pinFixedX - 16,
+                  top: pinFixedY - 78,
                   zIndex: 2147483643,
                   pointerEvents: 'none',
                   animation: 'fw-tooltip-in 0.15s ease both',


### PR DESCRIPTION

## Summary

- Comment pins now stay in the right place as you scroll, resize, or when page content shifts around them.
- Removed the per-project origin allowlist — the widget can now post comments from any site using a valid project key.

## Notes

- Origin check was the only app-level gate; CORS was already open. Rate limiting is now the sole abuse guardrail.
- The `allowed_origins` database column is left alone — drop in a follow-up migration.

