### PR TITLE
Bump package version to 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-04-24
+
 ### Added
 - `api/comments.ts` handles both `GET` and `POST` on one route.
 - Handler unit tests (vitest) covering method dispatch, validation, and the silent-RLS failure mode.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thedesignproject/feedback-widget",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Visual feedback widget for React apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump package.json to 0.3.7
- Move current changelog notes under the 0.3.7 release heading

## Verification
- bun run typecheck
- bun run test
- bun run build
- Publish workflow succeeded for v0.3.7