### PR TITLE
Log screenshot capture failures

### DIFF
--- a/src/lib/screenshotCapture.ts
+++ b/src/lib/screenshotCapture.ts
@@ -27,8 +27,16 @@ export async function captureElement(el: HTMLElement): Promise<Blob | null> {
       windowHeight: document.documentElement.offsetHeight,
       ignoreElements: (node) => node.hasAttribute('data-fw'),
     })
-    return new Promise((resolve) => canvas.toBlob(resolve, 'image/png'))
-  } catch {
+    return new Promise((resolve) => {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          console.warn('[FeedbackWidget] Screenshot capture failed: canvas.toBlob() returned null')
+        }
+        resolve(blob)
+      }, 'image/png')
+    })
+  } catch (error) {
+    console.warn('[FeedbackWidget] Screenshot capture failed:', error)
     return null
   }
 }


### PR DESCRIPTION
## Summary

- Log screenshot capture exceptions instead of silently returning `null`.
- Log when `canvas.toBlob()` returns `null`, which also results in a missing screenshot payload.

## Verification

- `npm run typecheck`
