### PR TITLE
Bump package version to 0.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thedesignproject/feedback-widget",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Visual feedback widget for React apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Update `package.json` to `0.3.8` to match the published `v0.3.8` tag.

## Verification

- `npm run typecheck`

## Release

- Published by CI from tag `v0.3.8`: https://github.com/thedesignproject/feedback-widget/actions/runs/24909404030
- npm latest: `@thedesignproject/feedback-widget@0.3.8`
