### PR TITLE
Handle OKLab colors in screenshot capture

### DIFF
--- a/src/__tests__/screenshotCapture.test.ts
+++ b/src/__tests__/screenshotCapture.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { convertModernColorFunctions } from '../lib/screenshotCapture'
+
+describe('screenshot color conversion', () => {
+  it('converts oklab colors to rgb for html2canvas', () => {
+    expect(convertModernColorFunctions('oklab(1 0 0)')).toBe('rgb(255, 255, 255)')
+    expect(convertModernColorFunctions('oklab(0 0 0 / 50%)')).toBe('rgba(0, 0, 0, 0.5)')
+  })
+
+  it('converts oklch colors inside larger CSS values', () => {
+    expect(
+      convertModernColorFunctions('0 8px 24px oklch(0 0 0 / 25%)'),
+    ).toBe('0 8px 24px rgba(0, 0, 0, 0.25)')
+  })
+})

--- a/src/lib/screenshotCapture.ts
+++ b/src/lib/screenshotCapture.ts
@@ -1,6 +1,30 @@
 import { useCallback, useEffect, useState } from 'react'
 import html2canvas from 'html2canvas'
 
+const MODERN_COLOR_FUNCTION_RE = /\b(oklab|oklch)\(([^()]*)\)/gi
+const UNSUPPORTED_COLOR_RE = /\b(?:oklab|oklch)\(/i
+const OK_AXIS_PERCENT_SCALE = 0.4
+const COLOR_PROPERTIES = [
+  'background-color',
+  'background-image',
+  'border-bottom-color',
+  'border-left-color',
+  'border-right-color',
+  'border-top-color',
+  'box-shadow',
+  'caret-color',
+  'color',
+  'column-rule-color',
+  'fill',
+  'outline-color',
+  'stroke',
+  'text-decoration-color',
+  'text-emphasis-color',
+  'text-shadow',
+  '-webkit-text-fill-color',
+  '-webkit-text-stroke-color',
+]
+
 function fileToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
@@ -8,6 +32,117 @@ function fileToBase64(blob: Blob): Promise<string> {
     reader.onerror = reject
     reader.readAsDataURL(blob)
   })
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value))
+}
+
+function parseNumberToken(token: string, percentScale: number) {
+  if (token === 'none') return 0
+  if (token.endsWith('%')) return (Number.parseFloat(token) / 100) * percentScale
+  return Number.parseFloat(token)
+}
+
+function parseAlphaToken(token: string | undefined) {
+  if (!token || token === 'none') return 1
+  if (token.endsWith('%')) return clamp(Number.parseFloat(token) / 100, 0, 1)
+  return clamp(Number.parseFloat(token), 0, 1)
+}
+
+function parseHueToken(token: string) {
+  if (token === 'none') return 0
+  const value = Number.parseFloat(token)
+  if (token.endsWith('rad')) return value * (180 / Math.PI)
+  if (token.endsWith('grad')) return value * 0.9
+  if (token.endsWith('turn')) return value * 360
+  return value
+}
+
+function formatRgb(value: number) {
+  return Math.round(clamp(value, 0, 1) * 255)
+}
+
+function linearSrgbToSrgb(value: number) {
+  return value <= 0.0031308
+    ? 12.92 * value
+    : 1.055 * Math.pow(value, 1 / 2.4) - 0.055
+}
+
+function oklabToRgb(l: number, a: number, b: number, alpha: number) {
+  const lPrime = l + 0.3963377774 * a + 0.2158037573 * b
+  const mPrime = l - 0.1055613458 * a - 0.0638541728 * b
+  const sPrime = l - 0.0894841775 * a - 1.2914855480 * b
+
+  const l3 = lPrime ** 3
+  const m3 = mPrime ** 3
+  const s3 = sPrime ** 3
+
+  const r = linearSrgbToSrgb(4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3)
+  const g = linearSrgbToSrgb(-1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3)
+  const blue = linearSrgbToSrgb(-0.0041960863 * l3 - 0.7034186147 * m3 + 1.7076147010 * s3)
+
+  const channels = `${formatRgb(r)}, ${formatRgb(g)}, ${formatRgb(blue)}`
+  return alpha < 1 ? `rgba(${channels}, ${Number(alpha.toFixed(3))})` : `rgb(${channels})`
+}
+
+function parseModernColorFunction(name: string, body: string) {
+  const [rawChannels, rawAlpha] = body.split('/')
+  const channels = rawChannels.trim().split(/\s+/)
+  if (channels.length < 3) return null
+
+  const alpha = parseAlphaToken(rawAlpha?.trim())
+  let l = parseNumberToken(channels[0], 1)
+  let a = parseNumberToken(channels[1], OK_AXIS_PERCENT_SCALE)
+  let b = parseNumberToken(channels[2], OK_AXIS_PERCENT_SCALE)
+
+  if (name.toLowerCase() === 'oklch') {
+    const chroma = parseNumberToken(channels[1], OK_AXIS_PERCENT_SCALE)
+    const hue = parseHueToken(channels[2]) * (Math.PI / 180)
+    a = chroma * Math.cos(hue)
+    b = chroma * Math.sin(hue)
+  }
+
+  if (![l, a, b, alpha].every(Number.isFinite)) return null
+  l = clamp(l, 0, 1)
+
+  return oklabToRgb(l, a, b, alpha)
+}
+
+export function convertModernColorFunctions(value: string) {
+  return value.replace(MODERN_COLOR_FUNCTION_RE, (match, name: string, body: string) => {
+    return parseModernColorFunction(name, body) ?? match
+  })
+}
+
+function modernColorFallback(property: string) {
+  if (property === 'background-image' || property.endsWith('shadow')) return 'none'
+  if (property === 'background-color' || property.includes('border') || property.includes('outline')) return 'rgba(0, 0, 0, 0)'
+  return 'rgb(0, 0, 0)'
+}
+
+function sanitizeModernColorFunctions(clonedDocument: Document) {
+  const clonedWindow = clonedDocument.defaultView
+  if (!clonedWindow) return
+
+  const elements = [clonedDocument.documentElement, ...Array.from(clonedDocument.querySelectorAll('*'))]
+  for (const element of elements) {
+    const inlineStyle = (element as HTMLElement).style
+    if (!inlineStyle?.setProperty) continue
+
+    const computedStyle = clonedWindow.getComputedStyle(element)
+    for (const property of COLOR_PROPERTIES) {
+      const value = computedStyle.getPropertyValue(property)
+      if (!UNSUPPORTED_COLOR_RE.test(value)) continue
+
+      const converted = convertModernColorFunctions(value)
+      inlineStyle.setProperty(
+        property,
+        UNSUPPORTED_COLOR_RE.test(converted) ? modernColorFallback(property) : converted,
+        'important',
+      )
+    }
+  }
 }
 
 export async function captureElement(el: HTMLElement): Promise<Blob | null> {
@@ -26,6 +161,7 @@ export async function captureElement(el: HTMLElement): Promise<Blob | null> {
       windowWidth: document.documentElement.offsetWidth,
       windowHeight: document.documentElement.offsetHeight,
       ignoreElements: (node) => node.hasAttribute('data-fw'),
+      onclone: sanitizeModernColorFunctions,
     })
     return new Promise((resolve) => {
       canvas.toBlob((blob) => {


### PR DESCRIPTION
## Summary

- Convert computed `oklab()` / `oklch()` color values to sRGB in the cloned DOM before `html2canvas` parses styles.
- Cover color-bearing properties that can trigger the `unsupported color function "oklab"` capture failure, including shadows and backgrounds.
- Add focused conversion tests.

## Context

The new screenshot failure log exposed this localhost dashboard capture error:

```text
[FeedbackWidget] Screenshot capture failed: Error: Attempting to parse an unsupported color function "oklab"
```

`html2canvas@1.4.1` does not understand CSS Color 4 OKLab/OKLCH functions, which Tailwind/CSS can emit in modern local apps.

## Verification

- `npm run typecheck`
- `npm test`
- `npm run build`
- `npx -y react-doctor@latest . --verbose --diff`
