### PR TITLE
feat: implement project and comment data fetching hooks and status up…

### DIFF
--- a/api/_lib/status.ts
+++ b/api/_lib/status.ts
@@ -1,5 +1,6 @@
 export type ReviewStatus = 'open' | 'accepted' | 'rejected'
-export type ImplementationStatus = 'unassigned' | 'claimed' | 'in_progress' | 'blocked' | 'done'
+export const IMPLEMENTATION_STATUSES = ['unassigned', 'claimed', 'in_progress', 'blocked', 'done'] as const
+export type ImplementationStatus = typeof IMPLEMENTATION_STATUSES[number]
 
 export function fromLegacyStatus(status: string | null | undefined): ReviewStatus {
   if (status === 'approved' || status === 'accepted') return 'accepted'

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -165,6 +165,72 @@ export async function listProjects() {
   return (data || []).map((row) => mapProject(row as ProjectRow))
 }
 
+function slugify(name: string) {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+}
+
+function randomSuffix() {
+  return Math.random().toString(36).slice(2, 8)
+}
+
+export async function createProject(input: { name: string }) {
+  const trimmed = input.name.trim()
+  if (!trimmed) throw new Error('Project name required')
+
+  const supabase = getSupabase()
+  const baseSlug = slugify(trimmed) || `project-${randomSuffix()}`
+
+  let slug = baseSlug
+  let projectData: ProjectRow | null = null
+  let lastError: { code?: string; message: string } | null = null
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const { data, error } = await supabase
+      .from('projects')
+      .insert([{
+        public_key: slug,
+        slug,
+        name: trimmed,
+        allowed_origins: [],
+      }] as never)
+      .select('public_key, slug, name, created_at, updated_at')
+      .single()
+
+    if (!error) {
+      projectData = data as ProjectRow
+      break
+    }
+
+    // 23505 = unique_violation. Retry with new suffix; bail on anything else.
+    if (error.code !== '23505') throw new Error(error.message)
+    lastError = error
+    slug = `${baseSlug}-${randomSuffix()}`
+  }
+
+  if (!projectData) {
+    throw new Error(lastError?.message || 'Could not allocate unique project slug')
+  }
+
+  const { error: repoError } = await supabase
+    .from('project_repo_configs')
+    .insert([{
+      project_key: slug,
+      default_branch: 'main',
+    }] as never)
+
+  if (repoError) {
+    await supabase.from('projects').delete().eq('public_key', slug)
+    throw new Error(repoError.message)
+  }
+
+  return mapProject(projectData)
+}
+
 export async function getProject(projectKey: string) {
   const supabase = getSupabase()
   const { data, error } = await supabase

--- a/api/v1/comments/[commentId]/implementation-status.ts
+++ b/api/v1/comments/[commentId]/implementation-status.ts
@@ -1,0 +1,41 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireReviewer } from '../../../_lib/auth.js'
+import { createFeedbackEvent, findActiveSharesForComment, updateImplementationStatus } from '../../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
+import { IMPLEMENTATION_STATUSES, type ImplementationStatus } from '../../../_lib/status.js'
+
+const VALID_STATUSES = new Set<ImplementationStatus>(IMPLEMENTATION_STATUSES)
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['PATCH', 'OPTIONS'])) return
+  if (req.method !== 'PATCH') return methodNotAllowed(req, res, ['PATCH', 'OPTIONS'])
+  if (!requireReviewer(req, res)) return
+
+  try {
+    const commentId = getStringQuery(req.query.commentId)
+    const implementationStatus = req.body?.implementationStatus as ImplementationStatus | undefined
+
+    if (!commentId) return jsonError(req, res, 400, 'Missing commentId')
+    if (!implementationStatus || !VALID_STATUSES.has(implementationStatus)) {
+      return jsonError(req, res, 400, `implementationStatus must be one of: ${IMPLEMENTATION_STATUSES.join(', ')}`)
+    }
+
+    const [comment, activeShares] = await Promise.all([
+      updateImplementationStatus(commentId, { implementationStatus }),
+      findActiveSharesForComment(commentId),
+    ])
+    await Promise.all(activeShares.map((share) => createFeedbackEvent({
+      shareId: share.id,
+      commentId,
+      actorType: 'reviewer',
+      actorId: 'reviewer',
+      eventType: 'comment.implementation_changed',
+      payload: { implementationStatus },
+    })))
+
+    setCors(req, res, ['PATCH', 'OPTIONS'])
+    return res.status(200).json(comment)
+  } catch (error) {
+    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+  }
+}

--- a/api/v1/projects/index.ts
+++ b/api/v1/projects/index.ts
@@ -1,19 +1,29 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { requireReviewer } from '../../_lib/auth.js'
 import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
-import { listProjects } from '../../_lib/store.js'
+import { createProject, listProjects } from '../../_lib/store.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
-  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  if (handleOptions(req, res, ['GET', 'POST', 'OPTIONS'])) return
+  if (req.method !== 'GET' && req.method !== 'POST') return methodNotAllowed(req, res, ['GET', 'POST', 'OPTIONS'])
   if (!requireReviewer(req, res)) return
 
   try {
-    const projects = await listProjects()
-    setCors(req, res, ['GET', 'OPTIONS'])
-    return res.status(200).json(projects)
+    if (req.method === 'GET') {
+      const projects = await listProjects()
+      setCors(req, res, ['GET', 'POST', 'OPTIONS'])
+      return res.status(200).json(projects)
+    }
+
+    const body = (req.body ?? {}) as { name?: unknown }
+    const rawName = typeof body.name === 'string' ? body.name.trim() : ''
+    if (!rawName) return jsonError(req, res, 400, 'Missing name')
+    if (rawName.length > 80) return jsonError(req, res, 400, 'Name too long')
+
+    const project = await createProject({ name: rawName })
+    setCors(req, res, ['GET', 'POST', 'OPTIONS'])
+    return res.status(201).json(project)
   } catch (error) {
     return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
   }
 }
-

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -1,0 +1,8 @@
+# For local run, dashboard reads env from repo root .env (one level up).
+# This file documents only what the dashboard itself consumes.
+
+# Base URL of feedback-widget API
+VITE_API_BASE=https://your-deployment.vercel.app/api
+
+# Reviewer token seed for dashboard UI auth
+VITE_REVIEWER_TOKEN=replace-me

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { cn } from './lib/utils'
+import type { CommentRecord } from './api'
+import { updateImplementationStatus as apiUpdateImpl, updateReviewStatus as apiUpdateReview } from './api'
+import { useProjects } from './hooks/useProjects'
+import { useComments } from './hooks/useComments'
+
+const API_BASE = import.meta.env.VITE_API_BASE || '/api'
+const REVIEWER_TOKEN = import.meta.env.VITE_REVIEWER_TOKEN || ''
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -28,12 +35,6 @@ interface Comment {
   screenshotUrl: string | null
 }
 
-interface Project {
-  id: string
-  name: string
-  commentCount: number
-}
-
 interface AgentEvent {
   id: number
   type: string
@@ -42,14 +43,7 @@ interface AgentEvent {
   agentId: string
 }
 
-// ─── Fake Data ──────────────────────────────────────────────────────
-
-const PROJECTS: Project[] = [
-  { id: 'hubsync', name: 'HubSync', commentCount: 9 },
-  { id: 'imera', name: 'Imera', commentCount: 4 },
-  { id: 'purespectrum', name: 'PureSpectrum', commentCount: 2 },
-  { id: 'flint-studio', name: 'Flint Studio', commentCount: 0 },
-]
+// ─── Static / Mock Data (non-Supabase) ──────────────────────────────
 
 const AGENTS = [
   { id: 'claude-code', name: 'Claude Code', hint: 'Paste link in chat' },
@@ -60,81 +54,6 @@ const AGENTS = [
 ]
 
 const AUTHOR_COLORS = ['#6366F1', '#8B5CF6', '#EC4899', '#F59E0B', '#10B981', '#0EA5E9']
-
-const FAKE_COMMENTS: Comment[] = [
-  {
-    id: '1', projectId: 'hubsync', pageUrl: '/workspaces', selector: 'section.hero > button.cta',
-    x: 340, y: 180, body: 'This primary CTA feels lost against the hero image. Can we increase contrast or add a subtle shadow?',
-    reviewStatus: 'open', implementationStatus: 'unassigned', claimedByAgentId: null,
-    createdAt: '2026-04-21T14:23:00Z', updatedAt: '2026-04-21T14:23:00Z',
-    author: 'Dianne R.', authorInitial: 'D', authorColor: '#EC4899',
-    screenshotUrl: null,
-  },
-  {
-    id: '2', projectId: 'hubsync', pageUrl: '/workspaces', selector: 'nav.header > ul.nav-items',
-    x: 120, y: 45, body: 'Header nav items are too tight on tablet. On my iPad Pro, "Resources" and "Pricing" overlap.',
-    reviewStatus: 'accepted', implementationStatus: 'claimed', claimedByAgentId: 'claude-code',
-    createdAt: '2026-04-21T13:15:00Z', updatedAt: '2026-04-21T15:30:00Z',
-    author: 'Agustín V.', authorInitial: 'A', authorColor: '#6366F1',
-    screenshotUrl: null,
-  },
-  {
-    id: '3', projectId: 'hubsync', pageUrl: '/workspaces', selector: 'div.empty-state > img',
-    x: 400, y: 320, body: 'Empty state illustration looks off-brand. Can we swap for the new abstract set from the library?',
-    reviewStatus: 'accepted', implementationStatus: 'in_progress', claimedByAgentId: 'claude-code',
-    createdAt: '2026-04-21T12:40:00Z', updatedAt: '2026-04-21T16:00:00Z',
-    author: 'Agustín V.', authorInitial: 'A', authorColor: '#6366F1',
-    screenshotUrl: null,
-  },
-  {
-    id: '4', projectId: 'hubsync', pageUrl: '/workspaces', selector: 'table.data-grid > tr:hover',
-    x: 200, y: 420, body: 'Table row hover states are invisible on Safari. The gray is too close to the background.',
-    reviewStatus: 'open', implementationStatus: 'unassigned', claimedByAgentId: null,
-    createdAt: '2026-04-21T11:55:00Z', updatedAt: '2026-04-21T11:55:00Z',
-    author: 'Lara M.', authorInitial: 'L', authorColor: '#F59E0B',
-    screenshotUrl: null,
-  },
-  {
-    id: '5', projectId: 'hubsync', pageUrl: '/settings', selector: 'button.sync-now',
-    x: 560, y: 290, body: '"Sync now" button is too small — I keep missing the tap target on mobile.',
-    reviewStatus: 'rejected', implementationStatus: 'unassigned', claimedByAgentId: null,
-    createdAt: '2026-04-21T10:30:00Z', updatedAt: '2026-04-21T14:00:00Z',
-    author: 'Tomás O.', authorInitial: 'T', authorColor: '#10B981',
-    screenshotUrl: null,
-  },
-  {
-    id: '6', projectId: 'hubsync', pageUrl: '/workspaces', selector: 'div.tooltip',
-    x: 480, y: 150, body: 'Tooltip is clipped at the edge of the viewport — needs collision detection.',
-    reviewStatus: 'accepted', implementationStatus: 'done', claimedByAgentId: 'claude-code',
-    createdAt: '2026-04-20T16:20:00Z', updatedAt: '2026-04-21T09:00:00Z',
-    author: 'Dianne R.', authorInitial: 'D', authorColor: '#EC4899',
-    screenshotUrl: null,
-  },
-  {
-    id: '7', projectId: 'hubsync', pageUrl: '/onboarding', selector: 'div.checklist',
-    x: 300, y: 500, body: 'The onboarding checklist takes up too much real estate. Can we collapse completed steps?',
-    reviewStatus: 'open', implementationStatus: 'unassigned', claimedByAgentId: null,
-    createdAt: '2026-04-20T14:10:00Z', updatedAt: '2026-04-20T14:10:00Z',
-    author: 'Lara M.', authorInitial: 'L', authorColor: '#F59E0B',
-    screenshotUrl: null,
-  },
-  {
-    id: '8', projectId: 'hubsync', pageUrl: '/workspaces', selector: 'div.date-picker',
-    x: 150, y: 380, body: 'Date picker jumps around when switching months. Feels janky, probably a layout shift.',
-    reviewStatus: 'open', implementationStatus: 'unassigned', claimedByAgentId: null,
-    createdAt: '2026-04-20T11:00:00Z', updatedAt: '2026-04-20T11:00:00Z',
-    author: 'Agustín V.', authorInitial: 'A', authorColor: '#6366F1',
-    screenshotUrl: null,
-  },
-  {
-    id: '9', projectId: 'hubsync', pageUrl: '/settings', selector: 'form.profile > input.email',
-    x: 420, y: 200, body: 'Email validation error message appears below the fold. User has to scroll to see it.',
-    reviewStatus: 'accepted', implementationStatus: 'unassigned', claimedByAgentId: null,
-    createdAt: '2026-04-19T18:00:00Z', updatedAt: '2026-04-21T10:00:00Z',
-    author: 'Tomás O.', authorInitial: 'T', authorColor: '#10B981',
-    screenshotUrl: null,
-  },
-]
 
 const FAKE_AGENT_EVENTS: AgentEvent[] = [
   { id: 1, type: 'claim', description: 'Claimed comment: "Sync now button too small"', timestamp: '2026-04-21T16:02:00Z', agentId: 'claude-code' },
@@ -155,6 +74,71 @@ function timeAgo(iso: string) {
 
 function truncateUrl(url: string) {
   return url.startsWith('/') ? url : url.replace(/^https?:\/\/[^/]+/, '')
+}
+
+function buildIntegrationPrompt(projectId: string, apiBase: string) {
+  return `Install the Design Project feedback widget so reviewers can leave visual feedback in this app.
+
+1. Install the package:
+
+   npm install @thedesignproject/feedback-widget
+
+2. Mount <FeedbackWidget /> in the root React component (e.g. App.tsx or a top-level layout) so it appears on every page:
+
+   import { FeedbackWidget } from '@thedesignproject/feedback-widget'
+
+   export default function App() {
+     return (
+       <>
+         {/* existing app */}
+         <FeedbackWidget
+           apiBase="${apiBase}"
+           projectId="${projectId}"
+         />
+       </>
+     )
+   }
+
+The widget injects a floating pin tool. Reviewers click anywhere on the page to drop a pin and attach a comment + screenshot, which appear in this dashboard.
+
+Use these exact config values:
+- apiBase:   ${apiBase}
+- projectId: ${projectId}
+
+Follow the codebase's existing conventions (TypeScript, formatter, project structure). Don't refactor unrelated code.`
+}
+
+function hashString(s: string) {
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0
+  return h
+}
+
+function authorColorFor(name: string) {
+  return AUTHOR_COLORS[hashString(name) % AUTHOR_COLORS.length]
+}
+
+function mapServerComment(record: CommentRecord): Comment {
+  const author = record.authorName?.trim() || 'Anonymous'
+  const initial = author.charAt(0).toUpperCase() || '?'
+  return {
+    id: record.id,
+    projectId: record.projectId,
+    pageUrl: record.pageUrl,
+    selector: record.selector || '',
+    x: record.x,
+    y: record.y,
+    body: record.body,
+    reviewStatus: record.reviewStatus,
+    implementationStatus: record.implementationStatus,
+    claimedByAgentId: record.claimedByAgentId,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    author,
+    authorInitial: initial,
+    authorColor: authorColorFor(author),
+    screenshotUrl: record.imageUrl,
+  }
 }
 
 function isInactive(c: Comment) {
@@ -178,11 +162,12 @@ const DISPLAY_STATUS_LABELS: Record<DisplayStatus, string> = {
 // ─── App ────────────────────────────────────────────────────────────
 
 export function App() {
-  const [projects, setProjects] = useState(PROJECTS)
-  const [selectedProject, setSelectedProject] = useState('hubsync')
+  const { projects, loading: projectsLoading, error: projectsError, createProject } = useProjects(API_BASE, REVIEWER_TOKEN)
+  const [selectedProject, setSelectedProject] = useState<string>('')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
-  const [selectedCommentId, setSelectedCommentId] = useState<string>('3')
-  const [comments, setComments] = useState(FAKE_COMMENTS)
+  const [selectedCommentId, setSelectedCommentId] = useState<string>('')
+  const { comments: serverComments, loading: commentsLoading, error: commentsError, refresh: refreshComments } = useComments(API_BASE, REVIEWER_TOKEN, selectedProject || null)
+  const [comments, setComments] = useState<Comment[]>([])
   const [agentConnected] = useState(true)
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [cmdOpen, setCmdOpen] = useState(false)
@@ -191,6 +176,8 @@ export function App() {
   const [agentDropdownOpen, setAgentDropdownOpen] = useState(false)
   const [bulkMode, setBulkMode] = useState(false)
   const [bulkSelectedIds, setBulkSelectedIds] = useState<Set<string>>(new Set())
+  const [addProjectError, setAddProjectError] = useState<string | null>(null)
+  const [addProjectBusy, setAddProjectBusy] = useState(false)
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     if (typeof window === 'undefined') return 'dark'
     try { return (localStorage.getItem('dashboard-theme') as 'light' | 'dark') || 'dark' } catch { return 'dark' }
@@ -209,9 +196,19 @@ export function App() {
     return () => clearInterval(t)
   }, [])
 
-  const projectComments = useMemo(() =>
-    comments.filter((c) => c.projectId === selectedProject),
-  [comments, selectedProject])
+  useEffect(() => {
+    if (!selectedProject && projects.length > 0) {
+      setSelectedProject(projects[0].publicKey)
+    }
+  }, [projects, selectedProject])
+
+  useEffect(() => {
+    const next = serverComments.map(mapServerComment)
+    setComments(next)
+    setSelectedCommentId((current) => (current && next.some((c) => c.id === current) ? current : ''))
+  }, [serverComments])
+
+  const projectComments = comments
 
   const filteredComments = useMemo(() => {
     const filtered = statusFilter === 'all'
@@ -233,17 +230,30 @@ export function App() {
     { all: 0, open: 0, ready: 0, done: 0, rejected: 0 },
   ), [projectComments])
 
-  const handleReviewStatus = useCallback((id: string, status: ReviewStatus) => {
+  const handleReviewStatus = useCallback(async (id: string, status: ReviewStatus) => {
     setComments((prev) => prev.map((c) => c.id === id ? { ...c, reviewStatus: status, updatedAt: new Date().toISOString() } : c))
-  }, [])
+    try {
+      await apiUpdateReview(API_BASE, REVIEWER_TOKEN, id, status)
+    } catch (err) {
+      console.error('Failed to update review status:', err)
+      refreshComments()
+    }
+  }, [refreshComments])
 
-  const handleToggleDone = useCallback((id: string) => {
-    setComments((prev) => prev.map((c) => c.id === id ? {
-      ...c,
-      implementationStatus: (c.implementationStatus === 'done' ? 'unassigned' : 'done') as ImplStatus,
-      updatedAt: new Date().toISOString(),
-    } : c))
-  }, [])
+  const handleToggleDone = useCallback(async (id: string) => {
+    const current = comments.find((c) => c.id === id)
+    if (!current) return
+    const nextStatus: ImplStatus = current.implementationStatus === 'done' ? 'unassigned' : 'done'
+    setComments((prev) => prev.map((c) => c.id === id
+      ? { ...c, implementationStatus: nextStatus, updatedAt: new Date().toISOString() }
+      : c))
+    try {
+      await apiUpdateImpl(API_BASE, REVIEWER_TOKEN, id, nextStatus)
+    } catch (err) {
+      console.error('Failed to update implementation status:', err)
+      refreshComments()
+    }
+  }, [comments, refreshComments])
 
   const toggleReview = useCallback((c: Comment, target: 'accepted' | 'rejected') => {
     handleReviewStatus(c.id, c.reviewStatus === target ? 'open' : target)
@@ -263,18 +273,36 @@ export function App() {
     setBulkSelectedIds(new Set())
   }, [])
 
-  const applyBulkAction = useCallback((action: 'ready' | 'done' | 'reject') => {
-    const ids = bulkSelectedIds
-    if (ids.size === 0) return
+  const applyBulkAction = useCallback(async (action: 'ready' | 'done' | 'reject') => {
+    const ids = Array.from(bulkSelectedIds)
+    if (ids.length === 0) return
+    const idSet = new Set(ids)
+
     setComments((prev) => prev.map((c) => {
-      if (!ids.has(c.id)) return c
+      if (!idSet.has(c.id)) return c
       const ts = new Date().toISOString()
       if (action === 'ready') return { ...c, reviewStatus: 'accepted' as ReviewStatus, updatedAt: ts }
       if (action === 'done') return { ...c, reviewStatus: 'accepted' as ReviewStatus, implementationStatus: 'done' as ImplStatus, updatedAt: ts }
       return { ...c, reviewStatus: 'rejected' as ReviewStatus, updatedAt: ts }
     }))
     exitBulkMode()
-  }, [bulkSelectedIds, exitBulkMode])
+
+    const calls: Promise<unknown>[] = ids.flatMap((id) => {
+      if (action === 'ready') return [apiUpdateReview(API_BASE, REVIEWER_TOKEN, id, 'accepted')]
+      if (action === 'reject') return [apiUpdateReview(API_BASE, REVIEWER_TOKEN, id, 'rejected')]
+      return [
+        apiUpdateReview(API_BASE, REVIEWER_TOKEN, id, 'accepted'),
+        apiUpdateImpl(API_BASE, REVIEWER_TOKEN, id, 'done'),
+      ]
+    })
+
+    const results = await Promise.allSettled(calls)
+    const failed = results.filter((r) => r.status === 'rejected')
+    if (failed.length > 0) {
+      console.error(`Bulk ${action}: ${failed.length}/${calls.length} calls failed`, failed)
+      refreshComments()
+    }
+  }, [bulkSelectedIds, exitBulkMode, refreshComments])
 
   const toggleSelectAllVisible = useCallback(() => {
     const visibleIds = filteredComments.map((c) => c.id)
@@ -358,15 +386,21 @@ export function App() {
     setCmdOpen(false)
   }, [selectedComment, toggleReview, handleToggleDone, selectFilter])
 
-  const handleAddProject = useCallback((name: string) => {
-    const id = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-    if (!id || projects.some((p) => p.id === id)) return
-    setProjects((prev) => [...prev, { id, name, commentCount: 0 }])
-    setSelectedProject(id)
-    setStatusFilter('all')
-    setSelectedCommentId('')
-    setAddProjectOpen(false)
-  }, [projects])
+  const handleAddProject = useCallback(async (name: string) => {
+    setAddProjectError(null)
+    setAddProjectBusy(true)
+    try {
+      const project = await createProject(name)
+      setSelectedProject(project.publicKey)
+      setStatusFilter('all')
+      setSelectedCommentId('')
+      setAddProjectOpen(false)
+    } catch (err) {
+      setAddProjectError(err instanceof Error ? err.message : 'Failed to create project')
+    } finally {
+      setAddProjectBusy(false)
+    }
+  }, [createProject])
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">
@@ -385,30 +419,41 @@ export function App() {
         <div className="w-px h-5 bg-border" />
 
         <nav className="flex items-center gap-1 flex-1 overflow-auto">
-          {projects.map((p) => (
-            <button
-              key={p.id}
-              onClick={() => { setSelectedProject(p.id); setStatusFilter('all'); setSelectedCommentId('') }}
-              className={cn(
-                'px-3 py-1.5 rounded-md text-xs font-semibold transition-all whitespace-nowrap',
-                selectedProject === p.id
-                  ? 'bg-primary text-primary-foreground'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-              )}
-            >
-              {p.name}
-              {p.commentCount > 0 && (
-                <span className={cn(
-                  'ml-1.5 text-[10px] font-bold px-1.5 py-0.5 rounded-full',
-                  selectedProject === p.id
-                    ? 'bg-primary-foreground/20 text-primary-foreground'
-                    : 'bg-muted text-muted-foreground'
-                )}>
-                  {p.commentCount}
-                </span>
-              )}
-            </button>
-          ))}
+          {projectsLoading && projects.length === 0 ? (
+            <span className="text-xs text-muted-foreground px-2">Loading projects…</span>
+          ) : projectsError ? (
+            <span className="text-xs text-status-rejected px-2">{projectsError}</span>
+          ) : projects.length === 0 ? (
+            <span className="text-xs text-muted-foreground px-2">No projects yet</span>
+          ) : (
+            projects.map((p) => {
+              const isActive = selectedProject === p.publicKey
+              const count = isActive ? comments.length : null
+              return (
+                <button
+                  key={p.publicKey}
+                  onClick={() => { setSelectedProject(p.publicKey); setStatusFilter('all'); setSelectedCommentId('') }}
+                  className={cn(
+                    'px-3 py-1.5 rounded-md text-xs font-semibold transition-all whitespace-nowrap',
+                    isActive
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+                  )}
+                >
+                  {p.name}
+                  {isActive && commentsLoading ? (
+                    <span className="ml-1.5 inline-flex items-center">
+                      <Spinner size={11} strokeWidth={3} className="" />
+                    </span>
+                  ) : count !== null && count > 0 ? (
+                    <span className="ml-1.5 text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-primary-foreground/20 text-primary-foreground">
+                      {count}
+                    </span>
+                  ) : null}
+                </button>
+              )
+            })
+          )}
 
           <div data-add-project className="relative">
             <button
@@ -427,6 +472,8 @@ export function App() {
               <AddProjectPopover
                 onAdd={handleAddProject}
                 onClose={() => setAddProjectOpen(false)}
+                busy={addProjectBusy}
+                error={addProjectError}
               />
             )}
           </div>
@@ -552,7 +599,17 @@ export function App() {
           )}
 
           <div className="flex-1 overflow-y-auto">
-            {filteredComments.length === 0 ? (
+            {commentsLoading ? (
+              <div className="flex flex-col items-center justify-center h-full text-center px-8 gap-3">
+                <Spinner />
+                <p className="text-xs text-muted-foreground">Loading comments…</p>
+              </div>
+            ) : commentsError ? (
+              <div className="flex flex-col items-center justify-center h-full text-center px-8">
+                <p className="text-sm font-semibold text-status-rejected mb-1">Failed to load</p>
+                <p className="text-xs text-muted-foreground">{commentsError}</p>
+              </div>
+            ) : filteredComments.length === 0 ? (
               <div className="flex flex-col items-center justify-center h-full text-center px-8">
                 <div className="w-10 h-10 rounded-xl bg-muted flex items-center justify-center mb-3">
                   <ChatIcon className="text-muted-foreground" />
@@ -667,35 +724,20 @@ export function App() {
                 <div key={selectedComment.id} className="max-w-2xl mx-auto px-8 py-8 detail-enter">
 
                   {selectedComment.screenshotUrl ? (
-                    <div className="relative rounded-xl border border-border overflow-hidden mb-6 group">
-                      <img
-                        src={selectedComment.screenshotUrl}
-                        alt={`Screenshot of ${selectedComment.pageUrl}`}
-                        className="w-full aspect-video object-cover bg-muted/40 grayscale transition-[filter] duration-500 group-hover:grayscale-0"
-                        draggable={false}
-                      />
-                      {/* Darkened overlay for pin visibility */}
-                      <div className="absolute inset-0 bg-black/10 pointer-events-none" />
-                      <div
-                        className="absolute pointer-events-none"
-                        style={{ left: `${(selectedComment.x / 700) * 100}%`, top: `${(selectedComment.y / 500) * 100}%` }}
+                    <div className="rounded-xl border border-border overflow-hidden mb-6 bg-muted/40 flex items-center justify-center">
+                      <a
+                        href={selectedComment.screenshotUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block"
                       >
-                        <div className="relative -translate-x-1/2 -translate-y-1/2 pin-marker">
-                          <div className="pin-float">
-                            <div className="absolute inset-0 rounded-full animate-pulse-ring" style={{ background: selectedComment.authorColor, opacity: 0.3 }} />
-                            <div
-                              className="w-9 h-9 rounded-full flex items-center justify-center text-white text-xs font-bold pin-dot-shadow border-2 border-white/90"
-                              style={{ background: `linear-gradient(135deg, ${selectedComment.authorColor}, ${selectedComment.authorColor}99)` }}
-                            >
-                              {selectedComment.authorInitial}
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                      <div className="absolute bottom-3 left-3 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-black/60 backdrop-blur-sm border border-white/10">
-                        <SelectorIcon size={12} />
-                        <span className="text-[11px] font-mono text-white/80">{selectedComment.selector}</span>
-                      </div>
+                        <img
+                          src={selectedComment.screenshotUrl}
+                          alt={`Screenshot of ${selectedComment.pageUrl}`}
+                          className="max-w-full max-h-[520px] w-auto h-auto object-contain"
+                          draggable={false}
+                        />
+                      </a>
                     </div>
                   ) : (
                     <div className="rounded-xl border border-border bg-card p-5 mb-6">
@@ -793,6 +835,14 @@ export function App() {
                 </div>
               </div>
             </>
+          ) : selectedProject && !commentsLoading && !commentsError && projectComments.length === 0 ? (
+            <div className="flex-1 flex flex-col items-center justify-center text-center px-8">
+              <p className="text-base font-semibold text-foreground mb-1">No feedback yet</p>
+              <p className="text-sm text-muted-foreground max-w-sm mb-6">
+                Mount the widget in your app to start collecting visual feedback. Reviewers can drop pins on any page and their comments land here.
+              </p>
+              <AddToCodeButton projectId={selectedProject} apiBase={API_BASE} variant="large" />
+            </div>
           ) : (
             <div className="flex-1 flex flex-col items-center justify-center text-center px-8">
               <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center mb-4">
@@ -825,6 +875,16 @@ export function App() {
               </div>
               <p className="text-xs text-muted-foreground">Let AI agents fix your Ready for Agent items automatically</p>
             </div>
+
+            {selectedProject && (
+              <div className="px-4 py-3 border-b border-sidebar-border">
+                <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider mb-2">Install widget</p>
+                <AddToCodeButton projectId={selectedProject} apiBase={API_BASE} variant="compact" />
+                <p className="text-[10px] text-muted-foreground mt-2 leading-relaxed">
+                  Copies a setup prompt with package, mount snippet, and this project's credentials.
+                </p>
+              </div>
+            )}
 
             {/* Session link — the core handoff */}
             <div className="px-4 py-4 border-b border-sidebar-border animate-fade-in">
@@ -1184,7 +1244,12 @@ function CommandPalette({ onClose, comments, onSelect, onAction, selectedComment
   )
 }
 
-function AddProjectPopover({ onAdd, onClose }: { onAdd: (name: string) => void; onClose: () => void }) {
+function AddProjectPopover({ onAdd, onClose, busy, error }: {
+  onAdd: (name: string) => void
+  onClose: () => void
+  busy?: boolean
+  error?: string | null
+}) {
   const [name, setName] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -1206,6 +1271,8 @@ function AddProjectPopover({ onAdd, onClose }: { onAdd: (name: string) => void; 
     }
   }, [onClose])
 
+  const canSubmit = !!name.trim() && !busy
+
   return (
     <div
       data-add-project
@@ -1216,7 +1283,7 @@ function AddProjectPopover({ onAdd, onClose }: { onAdd: (name: string) => void; 
         <form
           onSubmit={(e) => {
             e.preventDefault()
-            if (name.trim()) onAdd(name.trim())
+            if (canSubmit) onAdd(name.trim())
           }}
         >
           <input
@@ -1225,25 +1292,29 @@ function AddProjectPopover({ onAdd, onClose }: { onAdd: (name: string) => void; 
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Project name"
-            className="w-full px-3 py-2 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-colors"
+            disabled={busy}
+            className="w-full px-3 py-2 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-colors disabled:opacity-50"
             autoComplete="off"
             spellCheck={false}
           />
+          {error && (
+            <p className="mt-2 text-[11px] text-status-rejected">{error}</p>
+          )}
           <div className="flex items-center justify-between mt-3">
             <p className="text-[10px] text-muted-foreground">
               Paste your snippet after creating
             </p>
             <button
               type="submit"
-              disabled={!name.trim()}
+              disabled={!canSubmit}
               className={cn(
                 'px-3 py-1.5 rounded-md text-xs font-semibold transition-all btn-press',
-                name.trim()
+                canSubmit
                   ? 'bg-primary text-primary-foreground hover:opacity-90'
                   : 'bg-muted text-muted-foreground cursor-not-allowed'
               )}
             >
-              Create
+              {busy ? 'Creating…' : 'Create'}
             </button>
           </div>
         </form>
@@ -1321,6 +1392,91 @@ function ActionBtn({ children, variant, active, onClick, shortcut, disabled }: {
     >
       {children}
     </button>
+  )
+}
+
+function AddToCodeButton({ projectId, apiBase, variant = 'compact' }: {
+  projectId: string
+  apiBase: string
+  variant?: 'compact' | 'large'
+}) {
+  const [copied, setCopied] = useState(false)
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => {
+    if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
+  }, [])
+
+  const handleCopy = useCallback(async () => {
+    const prompt = buildIntegrationPrompt(projectId, apiBase)
+    try {
+      await navigator.clipboard.writeText(prompt)
+      setCopied(true)
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error('Clipboard write failed:', err)
+    }
+  }, [projectId, apiBase])
+
+  if (variant === 'large') {
+    return (
+      <div className="w-full max-w-md mx-auto rounded-2xl border border-border bg-card p-6 text-left">
+        <div className="flex items-center gap-2.5 mb-1">
+          <div className="w-7 h-7 rounded-lg bg-primary/10 flex items-center justify-center">
+            <BotIcon size={15} className="text-primary" />
+          </div>
+          <p className="text-sm font-bold text-foreground">Add widget to your code</p>
+        </div>
+        <p className="text-xs text-muted-foreground mb-4 leading-relaxed">
+          Copy a setup prompt for any AI coding agent. It includes the npm package, mount snippet, and this project's credentials.
+        </p>
+        <div className="rounded-md bg-muted/60 border border-border px-3 py-2 mb-4 space-y-1">
+          <div className="flex items-center gap-2 text-[11px] font-mono text-muted-foreground">
+            <span className="opacity-60 w-[60px] shrink-0">project</span>
+            <span className="text-foreground truncate">{projectId}</span>
+          </div>
+          <div className="flex items-center gap-2 text-[11px] font-mono text-muted-foreground">
+            <span className="opacity-60 w-[60px] shrink-0">apiBase</span>
+            <span className="text-foreground truncate">{apiBase}</span>
+          </div>
+        </div>
+        <button
+          onClick={handleCopy}
+          className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-primary text-primary-foreground text-xs font-semibold hover:opacity-90 transition-opacity btn-press"
+        >
+          {copied ? <CheckIcon size={13} /> : <CopyIcon size={13} />}
+          {copied ? 'Copied to clipboard' : 'Copy install prompt'}
+        </button>
+        <p className="text-[10px] text-muted-foreground mt-3 leading-relaxed">
+          Paste it into your AI coding agent inside the project repo.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-border bg-card text-foreground text-xs font-semibold hover:bg-accent transition-colors btn-press"
+      title="Copy a setup prompt for your AI coding agent with this project's credentials"
+    >
+      {copied ? <CheckIcon size={13} /> : <CopyIcon size={13} />}
+      {copied ? 'Copied' : 'Add to code'}
+    </button>
+  )
+}
+
+function Spinner({ size = 20, strokeWidth = 2.5, className = 'text-muted-foreground' }: {
+  size?: number
+  strokeWidth?: number
+  className?: string
+}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className={cn('animate-spin', className)}>
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth={strokeWidth} opacity="0.25" />
+      <path d="M21 12a9 9 0 0 0-9-9" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" />
+    </svg>
   )
 }
 

--- a/apps/dashboard/api.ts
+++ b/apps/dashboard/api.ts
@@ -17,6 +17,8 @@ export interface CommentRecord {
   reviewStatus: 'open' | 'accepted' | 'rejected'
   implementationStatus: 'unassigned' | 'claimed' | 'in_progress' | 'blocked' | 'done'
   claimedByAgentId: string | null
+  imageUrl: string | null
+  authorName: string | null
   createdAt: string
   updatedAt: string
 }
@@ -89,12 +91,18 @@ function authHeaders(reviewerToken?: string) {
 
 async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, init)
+  const text = await response.text()
+
   if (!response.ok) {
-    const payload = await response.text()
-    throw new Error(payload || `Request failed with ${response.status}`)
+    throw new Error(text || `Request failed with ${response.status}`)
   }
 
-  return response.json() as Promise<T>
+  try {
+    return JSON.parse(text) as T
+  } catch {
+    const preview = text.slice(0, 80).replace(/\s+/g, ' ').trim()
+    throw new Error(`Expected JSON from ${url} but got: ${preview || '(empty body)'}. Is the API server running?`)
+  }
 }
 
 export function listProjects(apiBase: string, reviewerToken: string) {
@@ -102,6 +110,17 @@ export function listProjects(apiBase: string, reviewerToken: string) {
     headers: {
       ...authHeaders(reviewerToken),
     },
+  })
+}
+
+export function createProject(apiBase: string, reviewerToken: string, name: string) {
+  return requestJson<Project>(`${apiBase}/v1/projects`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(reviewerToken),
+    },
+    body: JSON.stringify({ name }),
   })
 }
 
@@ -124,6 +143,17 @@ export function updateReviewStatus(apiBase: string, reviewerToken: string, comme
       ...authHeaders(reviewerToken),
     },
     body: JSON.stringify({ reviewStatus }),
+  })
+}
+
+export function updateImplementationStatus(apiBase: string, reviewerToken: string, commentId: string, implementationStatus: CommentRecord['implementationStatus']) {
+  return requestJson<CommentRecord>(`${apiBase}/v1/comments/${encodeURIComponent(commentId)}/implementation-status`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(reviewerToken),
+    },
+    body: JSON.stringify({ implementationStatus }),
   })
 }
 

--- a/apps/dashboard/hooks/useComments.ts
+++ b/apps/dashboard/hooks/useComments.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { listComments, type CommentRecord } from '../api'
+
+export interface UseCommentsResult {
+  comments: CommentRecord[]
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+}
+
+export function useComments(apiBase: string, reviewerToken: string, projectId: string | null): UseCommentsResult {
+  const [comments, setComments] = useState<CommentRecord[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const activeProjectRef = useRef<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    activeProjectRef.current = projectId
+
+    if (!projectId) {
+      setComments([])
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await listComments(apiBase, reviewerToken, projectId)
+      // Race guard: drop response if user switched projects mid-flight.
+      if (activeProjectRef.current !== projectId) return
+      setComments(data)
+    } catch (err) {
+      if (activeProjectRef.current !== projectId) return
+      setError(err instanceof Error ? err.message : 'Failed to load comments')
+    } finally {
+      if (activeProjectRef.current === projectId) setLoading(false)
+    }
+  }, [apiBase, reviewerToken, projectId])
+
+  // Clear previous project's data before the next fetch lands.
+  useEffect(() => {
+    setComments([])
+    setLoading(!!projectId)
+  }, [projectId])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  return { comments, loading, error, refresh }
+}

--- a/apps/dashboard/hooks/useProjects.ts
+++ b/apps/dashboard/hooks/useProjects.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from 'react'
+import { createProject as apiCreateProject, listProjects, type Project } from '../api'
+
+export interface UseProjectsResult {
+  projects: Project[]
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+  createProject: (name: string) => Promise<Project>
+}
+
+export function useProjects(apiBase: string, reviewerToken: string): UseProjectsResult {
+  const [projects, setProjects] = useState<Project[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await listProjects(apiBase, reviewerToken)
+      setProjects(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load projects')
+    } finally {
+      setLoading(false)
+    }
+  }, [apiBase, reviewerToken])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const createProject = useCallback(async (name: string) => {
+    const project = await apiCreateProject(apiBase, reviewerToken, name)
+    setProjects((prev) => [...prev, project])
+    return project
+  }, [apiBase, reviewerToken])
+
+  return { projects, loading, error, refresh, createProject }
+}

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -5,6 +5,7 @@ import path from 'path'
 
 export default defineConfig({
   root: __dirname,
+  envDir: path.resolve(__dirname, '../..'),
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -45,7 +45,7 @@ export function App() {
             </div>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            <a href="#" style={{ fontSize: 13, color: '#888', textDecoration: 'none', fontWeight: 500 }}>Log in</a>
+            <a href="#login" style={{ fontSize: 13, color: '#888', textDecoration: 'none', fontWeight: 500 }}>Log in</a>
             <button className="fw-cta-primary" style={{
               padding: '8px 18px', fontSize: 13, fontWeight: 600, color: '#fff', background: '#111',
               border: 'none', borderRadius: 8, cursor: 'pointer',
@@ -466,7 +466,7 @@ export function App() {
           <span style={{ fontSize: 13, color: '#444' }}>Feedback Widget &copy; 2026</span>
           <div style={{ display: 'flex', gap: 24 }}>
             {['GitHub', 'Docs', 'Twitter', 'Contact'].map((t) => (
-              <a key={t} href="#" style={{ fontSize: 13, color: '#555', textDecoration: 'none' }}>{t}</a>
+              <a key={t} href={`#${t.toLowerCase()}`} style={{ fontSize: 13, color: '#555', textDecoration: 'none' }}>{t}</a>
             ))}
           </div>
         </footer>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   ],
   "scripts": {
     "dev": "vite --config demo/vite.config.ts",
-    "dev:dashboard": "vite --config apps/dashboard/vite.config.ts",
+    "dev:dashboard": "bash -c 'trap \"kill 0\" EXIT INT TERM; bunx vercel dev --listen 3000 & vite --config apps/dashboard/vite.config.ts'",
+    "dev:dashboard:ui-only": "vite --config apps/dashboard/vite.config.ts",
     "typecheck": "tsc --project tsconfig.check.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/src/components/VTooltipMenu.tsx
+++ b/src/components/VTooltipMenu.tsx
@@ -2,6 +2,7 @@ import {
   motion,
   type MotionValue,
   useMotionTemplate,
+  useReducedMotion,
   useSpring,
 } from 'framer-motion'
 import React, { createContext, useCallback, useContext, useEffect, useReducer, useRef } from 'react'
@@ -49,16 +50,22 @@ export function VtooltipRoot({
   const contentMapRef = useRef<Map<number, React.ReactNode>>(new Map())
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0)
 
+  const prefersReducedMotion = useReducedMotion()
   const tooltipPosition = useSpring(0, { stiffness: 350, damping: 30 })
   const clipPathTop = useSpring(0, springConfig)
   const clipPathBottom = useSpring(79, springConfig)
   const opacity = useSpring(0, { stiffness: 300, damping: 30, mass: 0.8 })
 
+  const setMV = (mv: MotionValue<number>, v: number) => {
+    if (prefersReducedMotion) mv.jump(v)
+    else mv.set(v)
+  }
+
   const calculateClipPath = (index: number | null) => {
     if (index === null) {
-      clipPathTop.set(0)
-      clipPathBottom.set(0)
-      opacity.set(0)
+      setMV(clipPathTop, 0)
+      setMV(clipPathBottom, 0)
+      setMV(opacity, 0)
       return
     }
 
@@ -77,9 +84,9 @@ export function VtooltipRoot({
       0,
     )
 
-    clipPathTop.set(totalHeight > 0 ? (topHeight / totalHeight) * 100 : 20)
-    clipPathBottom.set(totalHeight > 0 ? (bottomHeight / totalHeight) * 100 : 20)
-    opacity.set(1)
+    setMV(clipPathTop, totalHeight > 0 ? (topHeight / totalHeight) * 100 : 20)
+    setMV(clipPathBottom, totalHeight > 0 ? (bottomHeight / totalHeight) * 100 : 20)
+    setMV(opacity, 1)
   }
 
   const onMouseEnterOnIcon = (e: React.MouseEvent<HTMLButtonElement>, index: number) => {
@@ -94,14 +101,14 @@ export function VtooltipRoot({
       }
       const centerY = activeIcon.top + activeIcon.height / 2
       const activePos = (parentTooltip.top || 0) + heightBefore + activeTooltip.height / 2
-      tooltipPosition.set(centerY - activePos)
+      setMV(tooltipPosition, centerY - activePos)
     }
 
     calculateClipPath(index)
   }
 
   const onMouseLeave = () => {
-    opacity.set(0)
+    setMV(opacity, 0)
   }
 
   const setIconRef = (index: number, el: HTMLButtonElement | null) => {


### PR DESCRIPTION
# Wire dashboard to real API + project creation

- Replace mock project/comment data with live API via new `useProjects` / `useComments` hooks
- Add `POST /v1/projects` with slug generation and unique-violation retry
- Add `PATCH /v1/comments/[commentId]/implementation-status` endpoint
- Export `IMPLEMENTATION_STATUSES` as runtime const so handler validation and types stay in sync
- Add "Add to code/copy install prompt" buttons that copies an AI-agent install prompt with the project's `apiBase` + `projectId`
<img width="668" height="538" alt="image" src="https://github.com/user-attachments/assets/cd37166a-4ce5-4369-9bd6-7abaa9e2951c" />

- Make `requestJson` surface non-JSON responses with a clearer error
- Run `vercel dev` + `vite` together under `npm run dev:dashboard`; point Vite `envDir` at repo root so `VITE_*` is shared
- Persist selected comment across refreshes when the id still exists
