### PR TITLE
chore: wire up Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,13 @@ jobs:
             "@types/react-dom@$REACT_MAJOR"
       - run: bun run typecheck
       - run: bun run test:coverage
+      - name: Upload coverage to Codecov
+        if: matrix.react == '19'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
       - run: bun run build
       - name: Enforce bundle size ceiling
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @thedesignproject/feedback-widget
 
+[![codecov](https://codecov.io/gh/thedesignproject/feedback-widget/branch/main/graph/badge.svg)](https://codecov.io/gh/thedesignproject/feedback-widget)
+
 Visual feedback capture for React sites, plus a private reviewer console and a Proof-style agent bridge.
 
 ## What changed

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     globals: false,
     setupFiles: ['./src/__tests__/setup.ts'],
     coverage: {
-      reporter: ['text', 'text-summary'],
+      reporter: ['text', 'text-summary', 'lcov'],
       include: ['src/**/*.{ts,tsx}', 'api/**/*.ts'],
       exclude: ['src/__tests__/**', '**/*.test.*', '**/*.d.ts'],
     },


### PR DESCRIPTION
## Summary
- Emit `lcov` reporter from vitest so `coverage/lcov.info` lands on disk
- Upload coverage to Codecov from the React 19 leg of the CI matrix only (avoids double-uploading identical coverage from the React 18 leg)
- Add Codecov badge to the README

`CODECOV_TOKEN` has been set as a repo secret. `fail_ci_if_error: false` so a Codecov outage doesn't redden CI — coverage is observability here, not a merge gate.

## Test plan
- [ ] CI passes on this branch
- [ ] Codecov upload step runs only on the `react: '19'` matrix leg
- [ ] After merge to `main`, badge in README resolves to a coverage percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)