### PR TITLE
fix(smoke): point round-trip at a real project + add scoped DELETE for cleanup

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,13 +17,12 @@ jobs:
       - name: POST + GET round trip, then clean up
         env:
           DEPLOY_URL: ${{ github.event.deployment_status.environment_url }}
+          PROJECT_KEY: ${{ secrets.SMOKE_PROJECT_KEY }}
           CLEANUP_TOKEN: ${{ secrets.SMOKE_CLEANUP_TOKEN }}
           BYPASS_TOKEN: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          PROBE="smoke-$(date +%s)-${GITHUB_SHA:0:7}"
-          echo "Probing $DEPLOY_URL/api/comments with projectId=$PROBE"
 
           # Vercel Deployment Protection gates the per-deployment URL behind
           # SSO. The smoke job can't authenticate, so we pass the project's
@@ -34,15 +33,27 @@ jobs:
             exit 1
           fi
 
+          # The API requires projectKey to reference a real row in the
+          # projects table. Use a dedicated smoke project (seeded once in the
+          # DB, public_key stored as SMOKE_PROJECT_KEY secret) and identify
+          # each run by a unique marker in the comment body.
+          if [ -z "${PROJECT_KEY:-}" ]; then
+            echo "::error::SMOKE_PROJECT_KEY not set — seed a smoke project in the DB and store its public_key as a GH secret"
+            exit 1
+          fi
+          if [ -z "${CLEANUP_TOKEN:-}" ]; then
+            echo "::error::SMOKE_CLEANUP_TOKEN not set — required to purge probe rows after the round-trip"
+            exit 1
+          fi
+
+          MARKER="smoke-$(date +%s)-${GITHUB_SHA:0:7}"
+          echo "Probing $DEPLOY_URL/api/comments with projectKey=$PROJECT_KEY (marker=$MARKER)"
+
           cleanup() {
-            if [ -n "${CLEANUP_TOKEN:-}" ]; then
-              curl -sS -o /dev/null -w "cleanup: %{http_code}\n" \
-                -X DELETE "$DEPLOY_URL/api/comments?projectId=$PROBE" \
-                -H "x-vercel-protection-bypass: $BYPASS_TOKEN" \
-                -H "x-smoke-cleanup-token: $CLEANUP_TOKEN" || true
-            else
-              echo "::warning::SMOKE_CLEANUP_TOKEN not set — leaving probe row behind"
-            fi
+            curl -sS -o /dev/null -w "cleanup: %{http_code}\n" \
+              -X DELETE "$DEPLOY_URL/api/comments?projectKey=$PROJECT_KEY" \
+              -H "x-vercel-protection-bypass: $BYPASS_TOKEN" \
+              -H "x-smoke-cleanup-token: $CLEANUP_TOKEN" || true
           }
           trap cleanup EXIT
 
@@ -50,25 +61,24 @@ jobs:
             -X POST "$DEPLOY_URL/api/comments" \
             -H 'Content-Type: application/json' \
             -H "x-vercel-protection-bypass: $BYPASS_TOKEN" \
-            --data "{\"projectId\":\"$PROBE\",\"url\":\"https://smoke\",\"x\":1,\"y\":1,\"element\":\"body\",\"comment\":\"ci smoke test\"}")
-          if [ "$POST_RES" != "200" ]; then
+            --data "{\"projectKey\":\"$PROJECT_KEY\",\"url\":\"https://smoke\",\"x\":1,\"y\":1,\"element\":\"body\",\"comment\":\"$MARKER\"}")
+          if [ "$POST_RES" != "201" ]; then
             echo "::error::POST returned $POST_RES: $(cat /tmp/post.json)"
             exit 1
           fi
 
           GET_RES=$(curl -sS -o /tmp/get.json -w "%{http_code}" \
             -H "x-vercel-protection-bypass: $BYPASS_TOKEN" \
-            "$DEPLOY_URL/api/comments?projectId=$PROBE")
+            "$DEPLOY_URL/api/comments?projectKey=$PROJECT_KEY")
           if [ "$GET_RES" != "200" ]; then
             echo "::error::GET returned $GET_RES: $(cat /tmp/get.json)"
             exit 1
           fi
 
-          # Match on the unique probe id, not a shared string. A generic grep
-          # would false-positive against any prior row that happened to carry
-          # the same literal.
-          if ! grep -F -q -- "$PROBE" /tmp/get.json; then
-            echo "::error::Round-trip failed — POSTed row (projectId=$PROBE) not returned by GET"
+          # Match on the unique per-run marker so a stale row from a previous
+          # cleanup failure can't false-positive this run.
+          if ! grep -F -q -- "$MARKER" /tmp/get.json; then
+            echo "::error::Round-trip failed — POSTed row (marker=$MARKER) not returned by GET"
             cat /tmp/get.json
             exit 1
           fi

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -339,6 +339,16 @@ export async function listAcceptedCommentsByIds(projectKey: string, commentIds: 
   return (data || []).map((row) => mapComment(row as CommentRow))
 }
 
+export async function deleteCommentsForProject(projectKey: string) {
+  const supabase = getSupabase()
+  const { error } = await supabase
+    .from('comments')
+    .delete()
+    .eq('project_id', projectKey)
+
+  if (error) throw new Error(error.message)
+}
+
 export async function getComment(commentId: string) {
   const supabase = getSupabase()
   const { data, error } = await supabase

--- a/api/comments.ts
+++ b/api/comments.ts
@@ -7,8 +7,8 @@ import v1Handler from './v1/public/comments.js'
  * Remove once all clients are on the new widget.
  */
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  // GET: map ?projectId= to ?projectKey=
-  if (req.method === 'GET') {
+  // GET / DELETE: map ?projectId= to ?projectKey=
+  if (req.method === 'GET' || req.method === 'DELETE') {
     if (req.query.projectId && !req.query.projectKey) {
       req.query.projectKey = req.query.projectId
     }
@@ -26,6 +26,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return v1Handler(req, res)
   }
 
-  // OPTIONS, PATCH, DELETE — forward as-is
+  // OPTIONS, PATCH — forward as-is
   return v1Handler(req, res)
 }

--- a/api/v1/public/comments.test.ts
+++ b/api/v1/public/comments.test.ts
@@ -5,9 +5,10 @@ vi.mock('../../_lib/store.js', () => ({
   createPublicComment: vi.fn(),
   listComments: vi.fn(),
   updateReviewStatus: vi.fn(),
+  deleteCommentsForProject: vi.fn(),
 }))
 
-import { createPublicComment, getProject, listComments, updateReviewStatus } from '../../_lib/store.js'
+import { createPublicComment, deleteCommentsForProject, getProject, listComments, updateReviewStatus } from '../../_lib/store.js'
 import handler from './comments.js'
 
 interface MockRes {
@@ -54,6 +55,9 @@ beforeEach(() => {
   vi.mocked(createPublicComment).mockReset()
   vi.mocked(listComments).mockReset()
   vi.mocked(updateReviewStatus).mockReset()
+  vi.mocked(deleteCommentsForProject).mockReset()
+  delete process.env.SMOKE_CLEANUP_TOKEN
+  delete process.env.SMOKE_PROJECT_KEY
 })
 
 describe('api/v1/public/comments', () => {
@@ -147,6 +151,61 @@ describe('api/v1/public/comments', () => {
       body: 'Hello',
       imageUrl: null,
       authorName: null,
+    })
+  })
+
+  describe('DELETE (smoke cleanup)', () => {
+    it('returns 405 when cleanup is not configured on the server', async () => {
+      const res = mockRes()
+      await call(mockReq({ method: 'DELETE', query: { projectKey: 'smoke' }, headers: { 'x-smoke-cleanup-token': 'tok' } }), res)
+      expect(res.statusCode).toBe(405)
+      expect(deleteCommentsForProject).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when token is missing or wrong', async () => {
+      process.env.SMOKE_CLEANUP_TOKEN = 'expected'
+      process.env.SMOKE_PROJECT_KEY = 'smoke'
+
+      const noTokenRes = mockRes()
+      await call(mockReq({ method: 'DELETE', query: { projectKey: 'smoke' }, headers: {} }), noTokenRes)
+      expect(noTokenRes.statusCode).toBe(401)
+
+      const wrongTokenRes = mockRes()
+      await call(mockReq({ method: 'DELETE', query: { projectKey: 'smoke' }, headers: { 'x-smoke-cleanup-token': 'wrong' } }), wrongTokenRes)
+      expect(wrongTokenRes.statusCode).toBe(401)
+
+      expect(deleteCommentsForProject).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 when projectKey does not match the configured smoke project', async () => {
+      process.env.SMOKE_CLEANUP_TOKEN = 'expected'
+      process.env.SMOKE_PROJECT_KEY = 'smoke'
+
+      const res = mockRes()
+      await call(mockReq({
+        method: 'DELETE',
+        query: { projectKey: 'demo-project' },
+        headers: { 'x-smoke-cleanup-token': 'expected' },
+      }), res)
+
+      expect(res.statusCode).toBe(403)
+      expect(deleteCommentsForProject).not.toHaveBeenCalled()
+    })
+
+    it('deletes comments for the smoke project when token and key match', async () => {
+      process.env.SMOKE_CLEANUP_TOKEN = 'expected'
+      process.env.SMOKE_PROJECT_KEY = 'smoke'
+      vi.mocked(deleteCommentsForProject).mockResolvedValue(undefined)
+
+      const res = mockRes()
+      await call(mockReq({
+        method: 'DELETE',
+        query: { projectKey: 'smoke' },
+        headers: { 'x-smoke-cleanup-token': 'expected' },
+      }), res)
+
+      expect(res.statusCode).toBe(204)
+      expect(deleteCommentsForProject).toHaveBeenCalledWith('smoke')
     })
   })
 

--- a/api/v1/public/comments.ts
+++ b/api/v1/public/comments.ts
@@ -1,10 +1,10 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createPublicComment, getProject, listComments, updateReviewStatus } from '../../_lib/store.js'
+import { createPublicComment, deleteCommentsForProject, getProject, listComments, updateReviewStatus } from '../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
 import type { ReviewStatus } from '../../_lib/status.js'
 import { getSupabase } from '../../_lib/supabase.js'
 
-const METHODS = ['GET', 'POST', 'PATCH', 'OPTIONS']
+const METHODS = ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS']
 const VALID_STATUSES = new Set(['open', 'accepted', 'approved', 'rejected', 'pending'])
 
 function normalizePatchStatus(value: unknown): ReviewStatus | null {
@@ -19,7 +19,44 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'GET') return handleGet(req, res)
   if (req.method === 'POST') return handlePost(req, res)
   if (req.method === 'PATCH') return handlePatch(req, res)
+  if (req.method === 'DELETE') return handleDelete(req, res)
   return methodNotAllowed(req, res, METHODS)
+}
+
+function timingSafeEqual(a: string, b: string) {
+  if (a.length !== b.length) return false
+  let mismatch = 0
+  for (let i = 0; i < a.length; i++) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  return mismatch === 0
+}
+
+// Smoke-only cleanup. Gated by SMOKE_CLEANUP_TOKEN and locked to the
+// SMOKE_PROJECT_KEY env var so a leaked token cannot wipe a real project.
+async function handleDelete(req: VercelRequest, res: VercelResponse) {
+  try {
+    const expectedToken = process.env.SMOKE_CLEANUP_TOKEN
+    const expectedProjectKey = process.env.SMOKE_PROJECT_KEY
+    if (!expectedToken || !expectedProjectKey) {
+      return jsonError(req, res, 405, 'Cleanup not configured')
+    }
+
+    const presented = req.headers['x-smoke-cleanup-token']
+    const token = typeof presented === 'string' ? presented : ''
+    if (!token || !timingSafeEqual(token, expectedToken)) {
+      return jsonError(req, res, 401, 'Invalid cleanup token')
+    }
+
+    const projectKey = getStringQuery(req.query.projectKey) ?? getStringQuery(req.query.projectId)
+    if (!projectKey || projectKey !== expectedProjectKey) {
+      return jsonError(req, res, 403, 'Cleanup scoped to smoke project only')
+    }
+
+    await deleteCommentsForProject(projectKey)
+    setCors(req, res, METHODS)
+    return res.status(204).end()
+  } catch (error) {
+    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+  }
 }
 
 async function handleGet(req: VercelRequest, res: VercelResponse) {


### PR DESCRIPTION
## Summary
The Smoke workflow has been failing on every production deploy since 2026-04-24 (PR #43), but nobody was paged because failed `deployment_status` workflows don't notify anyone. This PR fixes the workflow; the alerting gap is a separate fast-follow.

**Root cause:** PR #43 added project-existence validation to `POST /api/comments`. The smoke job was still posting with a synthetic `projectId="smoke-<ts>-<sha>"` that has no row in the `projects` table → 404. Cleanup was also silently broken — there is no DELETE handler on `/api/comments`, so cleanup got 405 on every run (rows have been piling up since the workflow was added).

## Changes
- **`api/v1/public/comments.ts`** — add a `DELETE` handler. It requires:
  - `x-smoke-cleanup-token` header equal to `SMOKE_CLEANUP_TOKEN` env (constant-time compare)
  - `?projectKey=` matching `SMOKE_PROJECT_KEY` env exactly

  Both must be set, or the handler returns 405 ("not configured"). This means a leaked token can never wipe a real project's comments — only the smoke project's.
- **`api/_lib/store.ts`** — add `deleteCommentsForProject(projectKey)`.
- **`api/comments.ts`** — legacy `projectId → projectKey` query mapping now also covers DELETE.
- **`.github/workflows/smoke.yml`** — read a `SMOKE_PROJECT_KEY` secret, hard-fail with a clear message if it or `SMOKE_CLEANUP_TOKEN` is unset, assert 201 on POST (the API has always returned 201; old check expected 200 — would have been a bug too if the 404 weren't masking it), use a per-run `MARKER` in the comment body so cleanup can purge the whole smoke project without losing the unique-per-run check.
- **`api/v1/public/comments.test.ts`** — coverage for the four DELETE branches (not configured / bad token / wrong project / success).

## One-time setup before merging
1. Insert a row in the `projects` table for the smoke project (e.g. `public_key='ci-smoke-<random>'`, `slug='ci-smoke'`, `name='CI Smoke'`, `allowed_origins='{}'`).
2. Set GitHub secret `SMOKE_PROJECT_KEY` to that `public_key`.
3. Set Vercel env vars `SMOKE_PROJECT_KEY` (same value) and `SMOKE_CLEANUP_TOKEN` (must match the existing GH secret of the same name).

Until those are set, Smoke will hard-fail with a clear setup message instead of a confusing 404 — that's the intended behavior.

## Test plan
- [x] `bun run test` — 28/28 pass (4 new DELETE tests)
- [x] `bun run typecheck` — clean
- [ ] After merge + secret/env setup, verify Smoke goes green on the next prod deploy
- [ ] Confirm the smoke project has no leftover rows after one successful run

🤖 Generated with [Claude Code](https://claude.com/claude-code)