### PR TITLE
feat: implement auto-creation of project for unknown projectid

### DIFF
--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -105,6 +105,20 @@ describe('ensurePublicProject', () => {
     expect(result.publicKey).toBe('pk')
   })
 
+  it('throws when a 23505 hits but the refetch still finds nothing', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        maybeSingleResults: [
+          { data: null, error: null },
+          { data: null, error: null },
+        ],
+        insertSingleResult: { data: null, error: { code: '23505', message: 'dup' } },
+      }) as never,
+    )
+
+    await expect(ensurePublicProject('pk')).rejects.toThrow('dup')
+  })
+
   it('throws when the project insert fails with a non-conflict error', async () => {
     vi.mocked(getSupabase).mockReturnValue(
       buildSupabase({

--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./supabase.js', () => ({ getSupabase: vi.fn() }))
+
+import { getSupabase } from './supabase.js'
+import { ensurePublicProject } from './store.js'
+
+type ProjectRow = {
+  public_key: string
+  slug: string
+  name: string
+  created_at: string
+  updated_at: string
+}
+
+type Result<T> = { data: T | null; error: { code?: string; message: string } | null }
+
+interface BuildOpts {
+  maybeSingleResults?: Array<Result<ProjectRow>>
+  insertSingleResult?: Result<ProjectRow>
+  repoInsertResult?: { error: { code?: string; message: string } | null }
+}
+
+function buildSupabase(opts: BuildOpts) {
+  const maybeSingleQueue = [...(opts.maybeSingleResults ?? [])]
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'projects') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(() =>
+                Promise.resolve(maybeSingleQueue.shift() ?? { data: null, error: null }),
+              ),
+            })),
+          })),
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() =>
+                Promise.resolve(opts.insertSingleResult ?? { data: null, error: null }),
+              ),
+            })),
+          })),
+        }
+      }
+      if (table === 'project_repo_configs') {
+        return {
+          insert: vi.fn(() => Promise.resolve(opts.repoInsertResult ?? { error: null })),
+        }
+      }
+      throw new Error(`Unmocked table ${table}`)
+    }),
+  }
+}
+
+const PROJECT_ROW: ProjectRow = {
+  public_key: 'pk',
+  slug: 'pk',
+  name: 'pk',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+beforeEach(() => {
+  vi.mocked(getSupabase).mockReset()
+})
+
+describe('ensurePublicProject', () => {
+  it('returns the existing project without inserting', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ maybeSingleResults: [{ data: PROJECT_ROW, error: null }] }) as never,
+    )
+
+    const result = await ensurePublicProject('pk')
+    expect(result.publicKey).toBe('pk')
+  })
+
+  it('inserts the project and seeds the repo config when missing', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        maybeSingleResults: [{ data: null, error: null }],
+        insertSingleResult: { data: PROJECT_ROW, error: null },
+        repoInsertResult: { error: null },
+      }) as never,
+    )
+
+    const result = await ensurePublicProject('pk')
+    expect(result.publicKey).toBe('pk')
+    expect(result.slug).toBe('pk')
+    expect(result.name).toBe('pk')
+  })
+
+  it('refetches and returns the project when a concurrent insert wins (23505)', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        maybeSingleResults: [
+          { data: null, error: null },
+          { data: PROJECT_ROW, error: null },
+        ],
+        insertSingleResult: { data: null, error: { code: '23505', message: 'dup' } },
+      }) as never,
+    )
+
+    const result = await ensurePublicProject('pk')
+    expect(result.publicKey).toBe('pk')
+  })
+
+  it('throws when the project insert fails with a non-conflict error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        maybeSingleResults: [{ data: null, error: null }],
+        insertSingleResult: { data: null, error: { code: '50000', message: 'boom' } },
+      }) as never,
+    )
+
+    await expect(ensurePublicProject('pk')).rejects.toThrow('boom')
+  })
+
+  it('throws when seeding the repo config fails with a non-conflict error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        maybeSingleResults: [{ data: null, error: null }],
+        insertSingleResult: { data: PROJECT_ROW, error: null },
+        repoInsertResult: { error: { code: '50000', message: 'repo boom' } },
+      }) as never,
+    )
+
+    await expect(ensurePublicProject('pk')).rejects.toThrow('repo boom')
+  })
+
+  it('ignores a 23505 on the repo config insert (already exists)', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        maybeSingleResults: [{ data: null, error: null }],
+        insertSingleResult: { data: PROJECT_ROW, error: null },
+        repoInsertResult: { error: { code: '23505', message: 'dup' } },
+      }) as never,
+    )
+
+    const result = await ensurePublicProject('pk')
+    expect(result.publicKey).toBe('pk')
+  })
+})

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -243,6 +243,45 @@ export async function getProject(projectKey: string) {
   return data ? mapProject(data as ProjectRow) : null
 }
 
+export async function ensurePublicProject(publicKey: string) {
+  const existing = await getProject(publicKey)
+  if (existing) return existing
+
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('projects')
+    .insert([{
+      public_key: publicKey,
+      slug: publicKey,
+      name: publicKey,
+      allowed_origins: [],
+    }] as never)
+    .select('public_key, slug, name, created_at, updated_at')
+    .single()
+
+  if (error) {
+    // 23505 = unique_violation. Concurrent insert won the race; refetch.
+    if (error.code === '23505') {
+      const refetched = await getProject(publicKey)
+      if (refetched) return refetched
+    }
+    throw new Error(error.message)
+  }
+
+  const { error: repoError } = await supabase
+    .from('project_repo_configs')
+    .insert([{
+      project_key: publicKey,
+      default_branch: 'main',
+    }] as never)
+
+  if (repoError && repoError.code !== '23505') {
+    throw new Error(repoError.message)
+  }
+
+  return mapProject(data as ProjectRow)
+}
+
 export async function getRepoConfig(projectKey: string) {
   const supabase = getSupabase()
   const { data, error } = await supabase

--- a/api/v1/public/comments.test.ts
+++ b/api/v1/public/comments.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../_lib/store.js', () => ({
-  getProject: vi.fn(),
+  ensurePublicProject: vi.fn(),
   createPublicComment: vi.fn(),
   listComments: vi.fn(),
   updateReviewStatus: vi.fn(),
 }))
 
-import { createPublicComment, getProject, listComments, updateReviewStatus } from '../../_lib/store.js'
+import { createPublicComment, ensurePublicProject, listComments, updateReviewStatus } from '../../_lib/store.js'
 import handler from './comments.js'
 
 interface MockRes {
@@ -50,7 +50,7 @@ const call = (req: unknown, res: unknown) =>
   (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
 
 beforeEach(() => {
-  vi.mocked(getProject).mockReset()
+  vi.mocked(ensurePublicProject).mockReset()
   vi.mocked(createPublicComment).mockReset()
   vi.mocked(listComments).mockReset()
   vi.mocked(updateReviewStatus).mockReset()
@@ -81,10 +81,32 @@ describe('api/v1/public/comments', () => {
     expect(res.headers['Access-Control-Allow-Origin']).toBe('*')
   })
 
-  it('returns 404 when the project key is unknown', async () => {
-    vi.mocked(getProject).mockResolvedValue(null)
-    const res = mockRes()
+  it('auto-creates the project when the key is unknown', async () => {
+    vi.mocked(ensurePublicProject).mockResolvedValue({
+      publicKey: 'missing',
+      slug: 'missing',
+      name: 'missing',
+      createdAt: '',
+      updatedAt: '',
+    })
+    vi.mocked(createPublicComment).mockResolvedValue({
+      id: 'comment-1',
+      projectId: 'missing',
+      pageUrl: 'https://example.com',
+      selector: 'body',
+      x: 10,
+      y: 20,
+      body: 'Hi',
+      reviewStatus: 'open',
+      implementationStatus: 'unassigned',
+      claimedByAgentId: null,
+      imageUrl: null,
+      authorName: null,
+      createdAt: '',
+      updatedAt: '',
+    })
 
+    const res = mockRes()
     await call(mockReq({
       body: {
         projectKey: 'missing',
@@ -96,11 +118,12 @@ describe('api/v1/public/comments', () => {
       },
     }), res)
 
-    expect(res.statusCode).toBe(404)
+    expect(ensurePublicProject).toHaveBeenCalledWith('missing')
+    expect(res.statusCode).toBe(201)
   })
 
   it('creates a public comment', async () => {
-    vi.mocked(getProject).mockResolvedValue({
+    vi.mocked(ensurePublicProject).mockResolvedValue({
       publicKey: 'demo-project',
       slug: 'demo-project',
       name: 'Demo',

--- a/api/v1/public/comments.ts
+++ b/api/v1/public/comments.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { createPublicComment, getProject, listComments, updateReviewStatus } from '../../_lib/store.js'
+import { createPublicComment, ensurePublicProject, listComments, updateReviewStatus } from '../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
 import type { ReviewStatus } from '../../_lib/status.js'
 import { getSupabase } from '../../_lib/supabase.js'
@@ -110,10 +110,7 @@ async function handlePost(req: VercelRequest, res: VercelResponse) {
       }
     }
 
-    const project = await getProject(resolvedProjectKey)
-    if (!project) {
-      return jsonError(req, res, 404, 'Project not found')
-    }
+    await ensurePublicProject(resolvedProjectKey)
 
     let imageUrl: string | null = null
     if (imageBase64 && imageMimeType) {


### PR DESCRIPTION
# Auto-create projects on first public comment

- Stop returning 404 when an embedded widget posts a comment under a project key the backend has never seen, the project is now created on the fly.
- Seed the matching repo config row at the same time, so a freshly auto-created project behaves like any project made through the dashboard.
- Cover the new path with unit tests for the store helper and the public comments endpoint, including the conflict and refetch branches.
