### PR TITLE
Refactor/widget folder scaffold

### DIFF
--- a/.claude/skills/diff-coverage/SKILL.md
+++ b/.claude/skills/diff-coverage/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: diff-coverage
+description: Verify 100% diff line AND branch coverage vs trunk after code changes. Runs vitest coverage, then diff-cover (line) + diff-branch-cov.py (branch). Both required. Use after any src/**/*.{ts,tsx} or api/**/*.ts edit before handing work back.
+---
+
+# Diff coverage workflow
+
+**Hard rule:** after every code change on a branch, both line-diff and branch-diff coverage vs `trunk` must be 100%. Add or extend tests until clean before handing work back.
+
+## Steps
+
+1. `bun run test:coverage` — runs vitest with v8 coverage, writes `coverage/lcov.info` (configured in `vitest.config.ts`).
+2. `/tmp/dc-venv/bin/diff-cover coverage/lcov.info --compare-branch=trunk` — % changed lines covered + missing line numbers per file.
+   - `diff-cover` lives in local venv at `/tmp/dc-venv`. If gone, recreate: `python3 -m venv /tmp/dc-venv && /tmp/dc-venv/bin/pip install diff-cover`.
+3. `python3 scripts/diff-branch-cov.py trunk` — partial/untaken branches on changed lines (e.g. `L16: 1/2 taken`). Exits non-zero if any found. Reproduces Codecov's branch view locally; lcov marks a line "hit" even if only one branch arm ran, so this catches what `diff-cover` misses.
+4. For each file under `Missing lines` (step 2) or partial branches (step 3): read those lines, add a test exercising them, re-run all three commands. Repeat until step 2 reads `Coverage: 100%` AND step 3 exits 0.
+
+## Notes
+
+- Coverage scope set in `vitest.config.ts` (`include: src/**/*.{ts,tsx}`, `api/**/*.ts`). Files outside scope don't count even if changed.
+- Heavy browser-only deps (e.g. `html2canvas`) should be mocked with `vi.mock(...)` not skipped — see `src/__tests__/screenshotCapture.test.ts` for the pattern.
+- Step 3 base branch is configurable (`trunk`, `staging`, etc.) — match whatever the PR will target.

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 *.log
 .vercel
 *.tgz
+pr/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,36 +14,4 @@ Supabase client (`@supabase/supabase-js`) stays the runtime query layer. Do **no
 
 ## Diff coverage
 
-**After every code change on a branch, diff coverage vs `trunk` must be 100%.** Add or extend tests until every changed/added line is covered before handing the work back.
-
-Workflow:
-
-1. `bun run test:coverage` — runs vitest with v8 coverage, writes `coverage/lcov.info` (configured in `vitest.config.ts`).
-2. `/tmp/dc-venv/bin/diff-cover coverage/lcov.info --compare-branch=trunk` — reports % of changed lines covered, plus the exact missing line numbers per file.
-   - `diff-cover` is installed in a local venv at `/tmp/dc-venv` (Python `diff-cover` package). If the venv is gone, recreate: `python3 -m venv /tmp/dc-venv && /tmp/dc-venv/bin/pip install diff-cover`.
-3. For each file listed under `Missing lines`, read those lines, add a test that exercises them, re-run both commands. Repeat until output reads `Coverage: 100%`.
-
-Notes:
-
-- Coverage scope is set in `vitest.config.ts` (`include: src/**/*.{ts,tsx}`, `api/**/*.ts`). Files outside that scope don't count, even if changed.
-- Heavy browser-only deps (e.g. `html2canvas`) should be mocked with `vi.mock(...)` rather than skipped — see `src/__tests__/screenshotCapture.test.ts` for the pattern.
-
-### Branch coverage on diff (optional, opt-in)
-
-`diff-cover` only checks line coverage; lcov marks a line "hit" if executed once, even when only one arm of a branch ran. Codecov reads `BRDA:` records from the same lcov and flags partial branches — so a PR can be 100% diff-line-covered locally and still fail Codecov on branch coverage.
-
-To reproduce Codecov's branch view locally on changed lines vs a base branch:
-
-```
-bun run test:coverage
-python3 scripts/diff-branch-cov.py trunk    # or staging, etc.
-```
-
-Output lists each changed line with a partial branch (e.g. `L16: 1/2 taken`) or fully-untaken branch. Exits non-zero if any are found.
-
-**Do not run this on every change.** Only run when:
-
-- the user asks for it explicitly, or
-- a major chunk of work is done and you want to confirm Codecov will pass — in that case, ask the user first ("want me to run the branch-coverage check before you push?") instead of running it unprompted.
-
-Line-coverage 100% is still the hard requirement from the section above; branch coverage is a stricter gate that's only worth paying for at milestones.
+After any code change, MUST invoke `diff-coverage` skill before handing work back. Both line and branch diff coverage vs `trunk` required at 100%.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,19 @@ Supabase client (`@supabase/supabase-js`) stays the runtime query layer. Do **no
 ## Legacy schema files
 
 `supabase/legacy/` is frozen historical record from before Drizzle. Do not add new files there. Do not run those SQLs against any environment.
+
+## Diff coverage
+
+**After every code change on a branch, diff coverage vs `trunk` must be 100%.** Add or extend tests until every changed/added line is covered before handing the work back.
+
+Workflow:
+
+1. `bun run test:coverage` — runs vitest with v8 coverage, writes `coverage/lcov.info` (configured in `vitest.config.ts`).
+2. `/tmp/dc-venv/bin/diff-cover coverage/lcov.info --compare-branch=trunk` — reports % of changed lines covered, plus the exact missing line numbers per file.
+   - `diff-cover` is installed in a local venv at `/tmp/dc-venv` (Python `diff-cover` package). If the venv is gone, recreate: `python3 -m venv /tmp/dc-venv && /tmp/dc-venv/bin/pip install diff-cover`.
+3. For each file listed under `Missing lines`, read those lines, add a test that exercises them, re-run both commands. Repeat until output reads `Coverage: 100%`.
+
+Notes:
+
+- Coverage scope is set in `vitest.config.ts` (`include: src/**/*.{ts,tsx}`, `api/**/*.ts`). Files outside that scope don't count, even if changed.
+- Heavy browser-only deps (e.g. `html2canvas`) should be mocked with `vi.mock(...)` rather than skipped — see `src/__tests__/screenshotCapture.test.ts` for the pattern.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,23 @@ Notes:
 
 - Coverage scope is set in `vitest.config.ts` (`include: src/**/*.{ts,tsx}`, `api/**/*.ts`). Files outside that scope don't count, even if changed.
 - Heavy browser-only deps (e.g. `html2canvas`) should be mocked with `vi.mock(...)` rather than skipped — see `src/__tests__/screenshotCapture.test.ts` for the pattern.
+
+### Branch coverage on diff (optional, opt-in)
+
+`diff-cover` only checks line coverage; lcov marks a line "hit" if executed once, even when only one arm of a branch ran. Codecov reads `BRDA:` records from the same lcov and flags partial branches — so a PR can be 100% diff-line-covered locally and still fail Codecov on branch coverage.
+
+To reproduce Codecov's branch view locally on changed lines vs a base branch:
+
+```
+bun run test:coverage
+python3 scripts/diff-branch-cov.py trunk    # or staging, etc.
+```
+
+Output lists each changed line with a partial branch (e.g. `L16: 1/2 taken`) or fully-untaken branch. Exits non-zero if any are found.
+
+**Do not run this on every change.** Only run when:
+
+- the user asks for it explicitly, or
+- a major chunk of work is done and you want to confirm Codecov will pass — in that case, ask the user first ("want me to run the branch-coverage check before you push?") instead of running it unprompted.
+
+Line-coverage 100% is still the hard requirement from the section above; branch coverage is a stricter gate that's only worth paying for at milestones.

--- a/scripts/diff-branch-cov.py
+++ b/scripts/diff-branch-cov.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Branch coverage on changed lines vs a base branch.
+
+diff-cover only reports line coverage. lcov BRDA records also encode branch
+coverage; Codecov uses them to flag partial branches that line coverage hides.
+This script reproduces that locally: parse `git diff --unified=0 BASE...HEAD`,
+intersect changed lines with BRDA records in coverage/lcov.info, print partial
+or fully-untaken branches per file. Exits non-zero if any are found.
+
+Usage: python3 scripts/diff-branch-cov.py [base-branch]   # default: trunk
+Run `bun run test:coverage` first to refresh coverage/lcov.info.
+"""
+import re
+import os
+import sys
+import subprocess
+from collections import defaultdict
+
+base = sys.argv[1] if len(sys.argv) > 1 else "trunk"
+
+diff = subprocess.check_output(
+    [
+        "git", "diff", "--unified=0", f"{base}...HEAD", "--",
+        "src/**/*.ts", "src/**/*.tsx", "api/**/*.ts",
+    ],
+    text=True,
+)
+
+changed = defaultdict(set)
+cur = None
+for line in diff.split("\n"):
+    if line.startswith("+++ b/"):
+        cur = line[6:]
+    elif line.startswith("@@") and cur:
+        m = re.search(r"\+(\d+)(?:,(\d+))?", line)
+        if m:
+            s = int(m.group(1))
+            n = int(m.group(2) or 1)
+            for i in range(s, s + n):
+                changed[cur].add(i)
+
+with open("coverage/lcov.info") as f:
+    lcov = f.read()
+
+fail = False
+for rec in lcov.split("end_of_record"):
+    sf = re.search(r"SF:(.+)", rec)
+    if not sf:
+        continue
+    path = os.path.relpath(sf.group(1).strip())
+    if path not in changed:
+        continue
+    by_line = defaultdict(list)
+    for m in re.finditer(r"BRDA:(\d+),\d+,\d+,(-|\d+)", rec):
+        ln = int(m.group(1))
+        if ln in changed[path]:
+            by_line[ln].append(m.group(2))
+    partial, untaken = [], []
+    for ln, takens in by_line.items():
+        hit = sum(1 for t in takens if t != "-" and int(t) > 0)
+        miss = sum(1 for t in takens if t == "-" or int(t) == 0)
+        if hit and miss:
+            partial.append((ln, hit, hit + miss))
+        elif not hit:
+            untaken.append((ln, len(takens)))
+    if partial or untaken:
+        fail = True
+        print(f"\n{path}")
+        for ln, h, t in sorted(partial):
+            print(f"  L{ln}: {h}/{t} taken")
+        for ln, n in sorted(untaken):
+            print(f"  L{ln}: 0/{n} taken")
+
+sys.exit(1 if fail else 0)

--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -552,6 +552,21 @@ describe('<FeedbackWidget />', () => {
       expect(cards[1].textContent).toContain('#2')
       expect(cards[2].textContent).toContain('#1')
     })
+
+    it('hides comments created before COMMENT_CUTOFF and shows ones after', async () => {
+      mockFetch(undefined, commentsResponse([
+        seedComment({ id: 'pre', body: 'legacy comment', createdAt: '2026-04-18T00:00:00Z' }),
+        seedComment({ id: 'post', body: 'fresh comment', createdAt: '2026-04-22T00:00:00Z' }),
+      ]))
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+
+      await waitFor(() => {
+        if (!document.body.textContent?.includes('fresh comment')) {
+          throw new Error('post-cutoff comment not loaded yet')
+        }
+      })
+      expect(document.body.textContent).not.toContain('legacy comment')
+    })
   })
 
   describe('keyboard shortcuts', () => {

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { fetchProjectComments, patchReviewStatus, postComment } from '../components/FeedbackWidget/api'
+
+const API = 'https://api.example.com'
+
+function mockFetch(impl: (url: string, init?: RequestInit) => Promise<Response> | Response) {
+  const spy = vi.fn(impl)
+  vi.stubGlobal('fetch', spy)
+  return spy
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+}
+
+describe('fetchProjectComments', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('GETs the comments endpoint with URL-encoded projectId', async () => {
+    const spy = mockFetch(() => jsonResponse([]))
+    await fetchProjectComments(API, 'acme/internal')
+    expect(spy).toHaveBeenCalledWith(`${API}/v1/public/comments?projectKey=acme%2Finternal`)
+  })
+
+  it('normalizes reviewStatus on each comment', async () => {
+    mockFetch(() => jsonResponse([
+      { id: 'a', reviewStatus: 'accepted' },
+      { id: 'b', reviewStatus: 'banana' },
+      { id: 'c' },
+    ]))
+    const out = await fetchProjectComments(API, 'p')
+    expect(out.map((c) => c.reviewStatus)).toEqual(['accepted', 'open', 'open'])
+  })
+
+  it('returns [] for non-OK responses', async () => {
+    mockFetch(() => new Response('boom', { status: 500 }))
+    expect(await fetchProjectComments(API, 'p')).toEqual([])
+  })
+
+  it('returns [] when body is not an array', async () => {
+    mockFetch(() => jsonResponse({ items: [] }))
+    expect(await fetchProjectComments(API, 'p')).toEqual([])
+  })
+
+  it('returns [] when fetch throws', async () => {
+    mockFetch(() => { throw new Error('offline') })
+    expect(await fetchProjectComments(API, 'p')).toEqual([])
+  })
+})
+
+describe('postComment', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('POSTs JSON and returns the parsed body on success', async () => {
+    const spy = mockFetch(() => jsonResponse({ id: '1', body: 'hi' }))
+    const result = await postComment(API, { body: 'hi' })
+    expect(result).toEqual({ id: '1', body: 'hi' })
+    const init = spy.mock.calls[0]![1]!
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ body: 'hi' })
+  })
+
+  it('returns null and warns on non-OK response', async () => {
+    mockFetch(() => new Response('nope', { status: 422 }))
+    const result = await postComment(API, { body: 'hi' })
+    expect(result).toBeNull()
+    expect(console.warn).toHaveBeenCalled()
+  })
+})
+
+describe('patchReviewStatus', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('PATCHes id + reviewStatus as JSON', async () => {
+    const spy = mockFetch(() => jsonResponse({}))
+    await patchReviewStatus(API, 'abc', 'accepted')
+    const [, init] = spy.mock.calls[0]!
+    expect(init!.method).toBe('PATCH')
+    expect(JSON.parse(init!.body as string)).toEqual({ id: 'abc', reviewStatus: 'accepted' })
+  })
+
+  it('swallows fetch errors and warns', async () => {
+    mockFetch(() => { throw new Error('boom') })
+    await expect(patchReviewStatus(API, 'abc', 'accepted')).resolves.toBeUndefined()
+    expect(console.warn).toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/coords.test.ts
+++ b/src/__tests__/coords.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { fromPagePercent, fromPagePercentFixed, toPagePercent } from '../components/FeedbackWidget/coords'
+
+describe('coords', () => {
+  let originalScrollWidth: PropertyDescriptor | undefined
+  let originalScrollHeight: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    originalScrollWidth = Object.getOwnPropertyDescriptor(document.documentElement, 'scrollWidth')
+    originalScrollHeight = Object.getOwnPropertyDescriptor(document.documentElement, 'scrollHeight')
+    Object.defineProperty(document.documentElement, 'scrollWidth', { configurable: true, value: 1000 })
+    Object.defineProperty(document.documentElement, 'scrollHeight', { configurable: true, value: 2000 })
+    window.scrollX = 0
+    window.scrollY = 0
+  })
+
+  afterEach(() => {
+    if (originalScrollWidth) Object.defineProperty(document.documentElement, 'scrollWidth', originalScrollWidth)
+    if (originalScrollHeight) Object.defineProperty(document.documentElement, 'scrollHeight', originalScrollHeight)
+  })
+
+  it('toPagePercent converts pixels to percent of document', () => {
+    expect(toPagePercent(250, 500)).toEqual({ x: 25, y: 25 })
+  })
+
+  it('fromPagePercent converts percent back to pixels', () => {
+    expect(fromPagePercent(25, 25)).toEqual({ pageX: 250, pageY: 500 })
+  })
+
+  it('fromPagePercent falls back to pixel coords for legacy rows (>100)', () => {
+    expect(fromPagePercent(800, 1500)).toEqual({ pageX: 800, pageY: 1500 })
+    expect(fromPagePercent(150, 50)).toEqual({ pageX: 150, pageY: 50 })
+    expect(fromPagePercent(50, 150)).toEqual({ pageX: 50, pageY: 150 })
+  })
+
+  it('fromPagePercentFixed subtracts current scroll offsets', () => {
+    window.scrollX = 100
+    window.scrollY = 200
+    expect(fromPagePercentFixed(50, 50)).toEqual({ fixedX: 400, fixedY: 800 })
+  })
+})

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { avatarColor, getInitials, normalizeReviewStatus, timeAgo } from '../components/FeedbackWidget/format'
+import { AVATAR_COLORS } from '../components/FeedbackWidget/constants'
+
+describe('avatarColor', () => {
+  it('returns a color from AVATAR_COLORS', () => {
+    expect(AVATAR_COLORS).toContain(avatarColor('abc'))
+  })
+
+  it('is deterministic for the same id', () => {
+    expect(avatarColor('user-1')).toBe(avatarColor('user-1'))
+  })
+
+  it('handles empty string', () => {
+    expect(AVATAR_COLORS).toContain(avatarColor(''))
+  })
+})
+
+describe('getInitials', () => {
+  it('returns null for null/undefined/empty', () => {
+    expect(getInitials(null)).toBeNull()
+    expect(getInitials(undefined)).toBeNull()
+    expect(getInitials('')).toBeNull()
+    expect(getInitials('   ')).toBeNull()
+  })
+
+  it('returns single uppercase letter for one-word names', () => {
+    expect(getInitials('alice')).toBe('A')
+    expect(getInitials('  bob  ')).toBe('B')
+  })
+
+  it('returns first + last initials for multi-word names', () => {
+    expect(getInitials('Ada Lovelace')).toBe('AL')
+    expect(getInitials('grace b hopper')).toBe('GH')
+    expect(getInitials('  john   doe  ')).toBe('JD')
+  })
+})
+
+describe('timeAgo', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const at = (offsetMs: number) => new Date(Date.now() - offsetMs).toISOString()
+
+  it('reports just now under 5 seconds', () => {
+    expect(timeAgo(at(2000))).toBe('just now')
+  })
+
+  it('reports seconds under a minute', () => {
+    expect(timeAgo(at(30_000))).toBe('30s ago')
+  })
+
+  it('reports minutes under an hour', () => {
+    expect(timeAgo(at(15 * 60_000))).toBe('15 min ago')
+  })
+
+  it('reports hours under a day', () => {
+    expect(timeAgo(at(5 * 3_600_000))).toBe('5h ago')
+  })
+
+  it('reports days otherwise', () => {
+    expect(timeAgo(at(3 * 86_400_000))).toBe('3d ago')
+  })
+})
+
+describe('normalizeReviewStatus', () => {
+  it('passes through accepted and rejected', () => {
+    expect(normalizeReviewStatus('accepted')).toBe('accepted')
+    expect(normalizeReviewStatus('rejected')).toBe('rejected')
+  })
+
+  it('falls back to open for everything else', () => {
+    expect(normalizeReviewStatus('open')).toBe('open')
+    expect(normalizeReviewStatus(undefined)).toBe('open')
+    expect(normalizeReviewStatus(null)).toBe('open')
+    expect(normalizeReviewStatus('')).toBe('open')
+    expect(normalizeReviewStatus(42)).toBe('open')
+  })
+})

--- a/src/components/FeedbackWidget/api.ts
+++ b/src/components/FeedbackWidget/api.ts
@@ -1,0 +1,50 @@
+import { normalizeReviewStatus } from './format'
+import type { Comment } from './types'
+
+export async function fetchProjectComments(apiBase: string, projectId: string): Promise<Comment[]> {
+  try {
+    const res = await fetch(`${apiBase}/v1/public/comments?projectKey=${encodeURIComponent(projectId)}`)
+    if (!res.ok) return []
+
+    const data: unknown = await res.json()
+    if (!Array.isArray(data)) return []
+
+    return data.map((comment) => {
+      const c = comment as Comment
+      return {
+        ...c,
+        reviewStatus: normalizeReviewStatus((comment as { reviewStatus?: unknown }).reviewStatus),
+      }
+    })
+  } catch {
+    return []
+  }
+}
+
+export async function postComment(
+  apiBase: string,
+  payload: Record<string, unknown>,
+): Promise<Partial<Comment> | null> {
+  const res = await fetch(`${apiBase}/v1/public/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    console.warn('[FeedbackWidget] API returned', res.status)
+    return null
+  }
+  return (await res.json()) as Partial<Comment>
+}
+
+export async function patchReviewStatus(apiBase: string, id: string, reviewStatus: string): Promise<void> {
+  try {
+    await fetch(`${apiBase}/v1/public/comments`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, reviewStatus }),
+    })
+  } catch (err) {
+    console.warn('[FeedbackWidget] PATCH failed:', err)
+  }
+}

--- a/src/components/FeedbackWidget/constants.ts
+++ b/src/components/FeedbackWidget/constants.ts
@@ -1,0 +1,22 @@
+export const WIDGET_ATTR = 'data-fw'
+
+export const PIN_GRADIENT =
+  'radial-gradient(circle at 50% 40%, #ffffff 0%, #ffffff 6%, #c4d6ff 25%, #5b87e8 65%, #2563eb 100%)'
+
+export const NOISE_OVERLAY_BG =
+  "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.55'/></svg>\")"
+
+export const AVATAR_COLORS = [
+  '#8b5cf6',
+  '#f97316',
+  '#3b82f6',
+  '#ec4899',
+  '#14b8a6',
+  '#f43f5e',
+  '#6366f1',
+  '#84cc16',
+]
+
+export const AUTHOR_NAME_KEY = 'fw-author-name'
+
+export const COMMENT_CUTOFF = new Date('2026-04-19T00:00:00Z')

--- a/src/components/FeedbackWidget/coords.ts
+++ b/src/components/FeedbackWidget/coords.ts
@@ -1,0 +1,23 @@
+export function toPagePercent(pageX: number, pageY: number) {
+  const { scrollWidth, scrollHeight } = document.documentElement
+  return {
+    x: (pageX / scrollWidth) * 100,
+    y: (pageY / scrollHeight) * 100,
+  }
+}
+
+export function fromPagePercent(x: number, y: number) {
+  const { scrollWidth, scrollHeight } = document.documentElement
+  if (x > 100 || y > 100) {
+    return { pageX: x, pageY: y }
+  }
+  return {
+    pageX: (x / 100) * scrollWidth,
+    pageY: (y / 100) * scrollHeight,
+  }
+}
+
+export function fromPagePercentFixed(x: number, y: number) {
+  const { pageX, pageY } = fromPagePercent(x, y)
+  return { fixedX: pageX - window.scrollX, fixedY: pageY - window.scrollY }
+}

--- a/src/components/FeedbackWidget/format.ts
+++ b/src/components/FeedbackWidget/format.ts
@@ -1,0 +1,33 @@
+import { AVATAR_COLORS } from './constants'
+import type { ReviewStatus } from './types'
+
+export function avatarColor(id: string) {
+  let hash = 0
+  for (let i = 0; i < id.length; i++) hash = ((hash << 5) - hash + id.charCodeAt(i)) | 0
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length]
+}
+
+export function getInitials(name: string | null | undefined): string | null {
+  if (!name) return null
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return null
+  if (parts.length === 1) return parts[0]!.slice(0, 1).toUpperCase()
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase()
+}
+
+export function timeAgo(date: string): string {
+  const seconds = Math.floor((Date.now() - new Date(date).getTime()) / 1000)
+  if (seconds < 5) return 'just now'
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes} min ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+export function normalizeReviewStatus(value: unknown): ReviewStatus {
+  if (value === 'accepted' || value === 'rejected') return value
+  return 'open'
+}

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { MessageCircle, Menu, X, Bot, SlidersHorizontal, Eye, EyeOff, Check } from 'lucide-react'
-import { VtooltipRoot, VtooltipItem, VtooltipTrigger, VtooltipContent } from './VTooltipMenu'
-import { getSelector } from '../lib/getSelector'
-import { useScreenshotCapture } from '../lib/screenshotCapture'
-import { AgentBridgeModal } from './AgentBridgeModal'
+import { VtooltipRoot, VtooltipItem, VtooltipTrigger, VtooltipContent } from '../VTooltipMenu'
+import { getSelector } from '../../lib/getSelector'
+import { useScreenshotCapture } from '../../lib/screenshotCapture'
+import { AgentBridgeModal } from '../AgentBridgeModal'
 
 interface FeedbackWidgetProps {
   projectId: string

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -4,67 +4,11 @@ import { VtooltipRoot, VtooltipItem, VtooltipTrigger, VtooltipContent } from '..
 import { getSelector } from '../../lib/getSelector'
 import { useScreenshotCapture } from '../../lib/screenshotCapture'
 import { AgentBridgeModal } from '../AgentBridgeModal'
-
-interface FeedbackWidgetProps {
-  projectId: string
-  apiBase: string
-}
-
-type Mode = 'idle' | 'selecting' | 'commenting'
-type ReviewStatus = 'open' | 'accepted' | 'rejected'
-
-interface ClickTarget {
-  selector: string
-  x: number  // page-relative px
-  y: number  // page-relative px
-  url: string
-}
-
-interface Comment {
-  id: string
-  projectId: string
-  pageUrl: string
-  x: number
-  y: number
-  selector: string
-  body: string
-  reviewStatus: ReviewStatus
-  imageUrl?: string | null
-  createdAt: string
-  authorName?: string
-}
-
-
-function toPagePercent(pageX: number, pageY: number) {
-  const { scrollWidth, scrollHeight } = document.documentElement
-  return {
-    x: (pageX / scrollWidth) * 100,
-    y: (pageY / scrollHeight) * 100,
-  }
-}
-
-function fromPagePercent(x: number, y: number) {
-  const { scrollWidth, scrollHeight } = document.documentElement
-  // Legacy rows stored absolute pixels (often > 100). Fall back to pixel coords.
-  if (x > 100 || y > 100) {
-    return { pageX: x, pageY: y }
-  }
-  return {
-    pageX: (x / 100) * scrollWidth,
-    pageY: (y / 100) * scrollHeight,
-  }
-}
-
-function fromPagePercentFixed(x: number, y: number) {
-  const { pageX, pageY } = fromPagePercent(x, y)
-  return { fixedX: pageX - window.scrollX, fixedY: pageY - window.scrollY }
-}
-
-const WIDGET_ATTR = 'data-fw'
-
-const PIN_GRADIENT = 'radial-gradient(circle at 50% 40%, #ffffff 0%, #ffffff 6%, #c4d6ff 25%, #5b87e8 65%, #2563eb 100%)'
-
-const NOISE_OVERLAY_BG = "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.55'/></svg>\")"
+import type { ClickTarget, Comment, FeedbackWidgetProps, Mode, ReviewStatus } from './types'
+import { AUTHOR_NAME_KEY, AVATAR_COLORS, COMMENT_CUTOFF, NOISE_OVERLAY_BG, PIN_GRADIENT, WIDGET_ATTR } from './constants'
+import { fromPagePercent, fromPagePercentFixed, toPagePercent } from './coords'
+import { avatarColor, getInitials, normalizeReviewStatus, timeAgo } from './format'
+import { fetchProjectComments, patchReviewStatus as apiPatchReviewStatus, postComment } from './api'
 
 function PinMarker({ outline = false }: { outline?: boolean }) {
   return (
@@ -98,61 +42,6 @@ function PinMarker({ outline = false }: { outline?: boolean }) {
       }} />
     </div>
   )
-}
-
-const AVATAR_COLORS = ['#8b5cf6', '#f97316', '#3b82f6', '#ec4899', '#14b8a6', '#f43f5e', '#6366f1', '#84cc16']
-function avatarColor(id: string) {
-  let hash = 0
-  for (let i = 0; i < id.length; i++) hash = ((hash << 5) - hash + id.charCodeAt(i)) | 0
-  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length]
-}
-
-const AUTHOR_NAME_KEY = 'fw-author-name'
-
-function getInitials(name: string | null | undefined): string | null {
-  if (!name) return null
-  const parts = name.trim().split(/\s+/).filter(Boolean)
-  if (parts.length === 0) return null
-  if (parts.length === 1) return parts[0]!.slice(0, 1).toUpperCase()
-  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase()
-}
-
-function timeAgo(date: string): string {
-  const seconds = Math.floor((Date.now() - new Date(date).getTime()) / 1000)
-  if (seconds < 5) return 'just now'
-  if (seconds < 60) return `${seconds}s ago`
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes} min ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
-}
-
-function normalizeReviewStatus(value: unknown): ReviewStatus {
-  if (value === 'accepted' || value === 'rejected') return value
-  return 'open'
-}
-
-async function fetchProjectComments(apiBase: string, projectId: string): Promise<Comment[]> {
-  try {
-    const res = await fetch(`${apiBase}/v1/public/comments?projectKey=${encodeURIComponent(projectId)}`)
-    if (!res.ok) return []
-
-    const data: unknown = await res.json()
-    if (!Array.isArray(data)) return []
-
-    return data.map((comment) => {
-      const c = comment as Comment
-      return {
-        ...c,
-        reviewStatus: normalizeReviewStatus((comment as { reviewStatus?: unknown }).reviewStatus),
-      }
-    })
-  } catch {
-    // Endpoint not ready yet; keep the widget usable with an empty sidebar.
-    return []
-  }
 }
 
 interface PinActionClusterProps {
@@ -501,18 +390,8 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
         payload.imageMimeType = encoded.mimeType
       }
 
-      const res = await fetch(`${apiBase}/v1/public/comments`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
-
-      if (!res.ok) {
-        console.warn('[FeedbackWidget] API returned', res.status)
-        return
-      }
-
-      const data = await res.json() as Partial<Comment>
+      const data = await postComment(apiBase, payload)
+      if (!data) return
 
       const newComment: Comment = {
         id: data.id ?? crypto.randomUUID(),
@@ -642,21 +521,9 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
     }
   }, [])
 
-  async function patchReviewStatus(id: string, reviewStatus: string) {
-    try {
-      await fetch(`${apiBase}/v1/public/comments`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id, reviewStatus }),
-      })
-    } catch (err) {
-      console.warn('[FeedbackWidget] PATCH failed:', err)
-    }
-  }
-
   function updateStatus(commentId: string, reviewStatus: ReviewStatus) {
     setComments((prev) => prev.map((c) => c.id === commentId ? { ...c, reviewStatus } : c))
-    patchReviewStatus(commentId, reviewStatus)
+    apiPatchReviewStatus(apiBase, commentId, reviewStatus)
   }
 
   function deleteComment(commentId: string) {
@@ -722,9 +589,8 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
     }
   }
 
-  const cutoff = new Date('2026-04-19T00:00:00Z')
   const visibleComments = useMemo(() => comments.filter((c) => {
-    if (new Date(c.createdAt) < cutoff) return false
+    if (new Date(c.createdAt) < COMMENT_CUTOFF) return false
     const commentUrl = c.pageUrl.split('#')[0]
     return commentUrl === currentUrl
   }), [comments, currentUrl])

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -9,6 +9,7 @@ import { AUTHOR_NAME_KEY, AVATAR_COLORS, COMMENT_CUTOFF, NOISE_OVERLAY_BG, PIN_G
 import { fromPagePercent, fromPagePercentFixed, toPagePercent } from './coords'
 import { avatarColor, getInitials, normalizeReviewStatus, timeAgo } from './format'
 import { fetchProjectComments, patchReviewStatus as apiPatchReviewStatus, postComment } from './api'
+import { FeedbackWidgetStyles } from './styles'
 
 function PinMarker({ outline = false }: { outline?: boolean }) {
   return (
@@ -1616,101 +1617,7 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
       {/* Agent bridge modal */}
       {agentOpen && <AgentBridgeModal apiBase={apiBase} projectId={projectId} onClose={() => setAgentOpen(false)} />}
 
-      {/* Keyframes */}
-      <style>{`
-        @keyframes fw-badge-pop {
-          0% { transform: scale(1); }
-          30% { transform: scale(1.3); }
-          100% { transform: scale(1); }
-        }
-        @keyframes fw-slide-in {
-          0% { opacity: 0; transform: translateY(8px); }
-          100% { opacity: 1; transform: translateY(0); }
-        }
-        @keyframes fw-agent-reveal {
-          0% { opacity: 0; transform: scale(0.4); }
-          100% { opacity: 1; transform: scale(1); }
-        }
-        @keyframes fw-slide-in-new {
-          0% { opacity: 0; transform: translateY(-12px); }
-          50% { background: #1e3a1e; }
-          100% { opacity: 1; transform: translateY(0); }
-        }
-        [data-fw] button:focus,
-        [data-fw] button:focus-visible {
-          outline: none;
-          box-shadow: none;
-        }
-        @keyframes fw-instruction-in {
-          0% { opacity: 0; transform: translateX(-50%) translateY(-10px); }
-          100% { opacity: 1; transform: translateX(-50%) translateY(0); }
-        }
-        .fw-rec-dot {
-          animation: fw-rec-pulse 1.5s ease-in-out infinite;
-        }
-        @keyframes fw-rec-pulse {
-          0%, 100% { opacity: 1; }
-          50% { opacity: 0.3; }
-        }
-        @keyframes fw-tooltip-in {
-          0% { opacity: 0; transform: translateY(4px); }
-          100% { opacity: 1; transform: translateY(0); }
-        }
-        @keyframes fw-pin-drop {
-          0% { transform: translateY(-20px); opacity: 0; }
-          60% { transform: translateY(4px); opacity: 1; }
-          100% { transform: translateY(0); opacity: 1; }
-        }
-        @keyframes fw-pin-glow-pulse {
-          0%, 100% {
-            filter:
-              drop-shadow(0 0 8px rgba(91, 135, 232, 0.5))
-              drop-shadow(0 0 16px rgba(91, 135, 232, 0.25))
-              drop-shadow(0 2px 4px rgba(0, 0, 0, 0.18));
-          }
-          50% {
-            filter:
-              drop-shadow(0 0 12px rgba(91, 135, 232, 0.65))
-              drop-shadow(0 0 26px rgba(91, 135, 232, 0.35))
-              drop-shadow(0 2px 4px rgba(0, 0, 0, 0.18));
-          }
-        }
-        @keyframes fw-pin-inner-pulse {
-          0%, 100% { opacity: 0.5; transform: translate(-50%, -50%) scale(0.8); }
-          50% { opacity: 1; transform: translate(-50%, -50%) scale(1.2); }
-        }
-        @keyframes fw-tooltip-liquid {
-          0% { opacity: 0; transform: scale(0.08); filter: blur(10px); }
-          35% { opacity: 1; }
-          100% { opacity: 1; transform: scale(1); filter: blur(0); }
-        }
-        .fw-sidebar-card:hover .fw-card-actions {
-          display: flex !important;
-        }
-        .fw-pill-icon:hover {
-          background: rgba(255, 255, 255, 0.15);
-        }
-        .fw-highlight {
-          outline: 2px solid #3b82f6 !important;
-          outline-offset: 2px !important;
-          background-color: rgba(59, 130, 246, 0.15) !important;
-          animation: fw-highlight-pulse 1.4s ease both !important;
-        }
-        @keyframes fw-highlight-pulse {
-          0% { outline-color: transparent; background-color: transparent; }
-          14% { outline-color: #3b82f6; background-color: rgba(59, 130, 246, 0.15); }
-          71% { outline-color: #3b82f6; background-color: rgba(59, 130, 246, 0.15); }
-          100% { outline-color: transparent; background-color: transparent; }
-        }
-        @keyframes fw-modal-overlay-in {
-          0% { opacity: 0; }
-          100% { opacity: 1; }
-        }
-        @keyframes fw-modal-card-in {
-          0% { opacity: 0; transform: scale(0.94) translateY(8px); }
-          100% { opacity: 1; transform: scale(1) translateY(0); }
-        }
-      `}</style>
+      <FeedbackWidgetStyles />
 
       {showNameModal && (
         <div

--- a/src/components/FeedbackWidget/styles.tsx
+++ b/src/components/FeedbackWidget/styles.tsx
@@ -1,0 +1,98 @@
+export function FeedbackWidgetStyles() {
+  return (
+    <style>{`
+        @keyframes fw-badge-pop {
+          0% { transform: scale(1); }
+          30% { transform: scale(1.3); }
+          100% { transform: scale(1); }
+        }
+        @keyframes fw-slide-in {
+          0% { opacity: 0; transform: translateY(8px); }
+          100% { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes fw-agent-reveal {
+          0% { opacity: 0; transform: scale(0.4); }
+          100% { opacity: 1; transform: scale(1); }
+        }
+        @keyframes fw-slide-in-new {
+          0% { opacity: 0; transform: translateY(-12px); }
+          50% { background: #1e3a1e; }
+          100% { opacity: 1; transform: translateY(0); }
+        }
+        [data-fw] button:focus,
+        [data-fw] button:focus-visible {
+          outline: none;
+          box-shadow: none;
+        }
+        @keyframes fw-instruction-in {
+          0% { opacity: 0; transform: translateX(-50%) translateY(-10px); }
+          100% { opacity: 1; transform: translateX(-50%) translateY(0); }
+        }
+        .fw-rec-dot {
+          animation: fw-rec-pulse 1.5s ease-in-out infinite;
+        }
+        @keyframes fw-rec-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.3; }
+        }
+        @keyframes fw-tooltip-in {
+          0% { opacity: 0; transform: translateY(4px); }
+          100% { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes fw-pin-drop {
+          0% { transform: translateY(-20px); opacity: 0; }
+          60% { transform: translateY(4px); opacity: 1; }
+          100% { transform: translateY(0); opacity: 1; }
+        }
+        @keyframes fw-pin-glow-pulse {
+          0%, 100% {
+            filter:
+              drop-shadow(0 0 8px rgba(91, 135, 232, 0.5))
+              drop-shadow(0 0 16px rgba(91, 135, 232, 0.25))
+              drop-shadow(0 2px 4px rgba(0, 0, 0, 0.18));
+          }
+          50% {
+            filter:
+              drop-shadow(0 0 12px rgba(91, 135, 232, 0.65))
+              drop-shadow(0 0 26px rgba(91, 135, 232, 0.35))
+              drop-shadow(0 2px 4px rgba(0, 0, 0, 0.18));
+          }
+        }
+        @keyframes fw-pin-inner-pulse {
+          0%, 100% { opacity: 0.5; transform: translate(-50%, -50%) scale(0.8); }
+          50% { opacity: 1; transform: translate(-50%, -50%) scale(1.2); }
+        }
+        @keyframes fw-tooltip-liquid {
+          0% { opacity: 0; transform: scale(0.08); filter: blur(10px); }
+          35% { opacity: 1; }
+          100% { opacity: 1; transform: scale(1); filter: blur(0); }
+        }
+        .fw-sidebar-card:hover .fw-card-actions {
+          display: flex !important;
+        }
+        .fw-pill-icon:hover {
+          background: rgba(255, 255, 255, 0.15);
+        }
+        .fw-highlight {
+          outline: 2px solid #3b82f6 !important;
+          outline-offset: 2px !important;
+          background-color: rgba(59, 130, 246, 0.15) !important;
+          animation: fw-highlight-pulse 1.4s ease both !important;
+        }
+        @keyframes fw-highlight-pulse {
+          0% { outline-color: transparent; background-color: transparent; }
+          14% { outline-color: #3b82f6; background-color: rgba(59, 130, 246, 0.15); }
+          71% { outline-color: #3b82f6; background-color: rgba(59, 130, 246, 0.15); }
+          100% { outline-color: transparent; background-color: transparent; }
+        }
+        @keyframes fw-modal-overlay-in {
+          0% { opacity: 0; }
+          100% { opacity: 1; }
+        }
+        @keyframes fw-modal-card-in {
+          0% { opacity: 0; transform: scale(0.94) translateY(8px); }
+          100% { opacity: 1; transform: scale(1) translateY(0); }
+        }
+    `}</style>
+  )
+}

--- a/src/components/FeedbackWidget/types.ts
+++ b/src/components/FeedbackWidget/types.ts
@@ -1,0 +1,28 @@
+export interface FeedbackWidgetProps {
+  projectId: string
+  apiBase: string
+}
+
+export type Mode = 'idle' | 'selecting' | 'commenting'
+export type ReviewStatus = 'open' | 'accepted' | 'rejected'
+
+export interface ClickTarget {
+  selector: string
+  x: number
+  y: number
+  url: string
+}
+
+export interface Comment {
+  id: string
+  projectId: string
+  pageUrl: string
+  x: number
+  y: number
+  selector: string
+  body: string
+  reviewStatus: ReviewStatus
+  imageUrl?: string | null
+  createdAt: string
+  authorName?: string
+}


### PR DESCRIPTION
# Split FeedbackWidget into focused modules

- Break the monolithic widget file into a folder of single-purpose modules — types, constants, coordinate math, formatting helpers, API calls, and CSS keyframes — so the main component reads as composition instead of a 1.7k-line wall.
- Add unit tests for the newly extracted helpers (coordinate conversion, string/date formatting, fetch wrappers) that were previously unreachable as standalone units.
- Ship a Python helper that reports branch coverage on changed lines vs a base branch, mirroring what Codecov enforces — line coverage alone hides partial-branch gaps.
- Document the diff-coverage workflow and the optional branch-coverage gate in `CLAUDE.md` so contributors know when to run each and what the 100% bar actually means.
