### PR TITLE
Lift the name modal and selecting bar out of the widget core

### DIFF
--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -686,4 +686,54 @@ describe('<FeedbackWidget />', () => {
       })
     })
   })
+
+  describe('name modal cancel', () => {
+    it('avatar click reopens modal and Close button cancels without saving', async () => {
+      try { localStorage.setItem('fw-author-name', 'Tomas') } catch {}
+      mockFetch()
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+
+      // Drop a pin to enter the commenting popover (author already saved, so
+      // the modal does NOT pop on first click).
+      document.querySelectorAll('[data-test-target]').forEach((n) => n.remove())
+      const targetNode = document.createElement('article')
+      targetNode.setAttribute('data-test-target', '')
+      document.body.appendChild(targetNode)
+      await waitFor(() => {
+        if (document.querySelectorAll('[data-fw]').length === 0) {
+          throw new Error('widget not mounted')
+        }
+      })
+      await act(async () => { fireEvent.keyDown(window, { key: 'c' }) })
+      await act(async () => {
+        targetNode.dispatchEvent(new MouseEvent('click', {
+          bubbles: true, cancelable: true, clientX: 100, clientY: 100,
+        }))
+      })
+
+      // Avatar in the popover → click to reopen the name modal.
+      const avatar = await waitFor(() => {
+        const el = document.querySelector<HTMLButtonElement>(
+          'button[title^="Signed in as Tomas"]',
+        )
+        if (!el) throw new Error('avatar button not mounted yet')
+        return el
+      })
+      await act(async () => { fireEvent.click(avatar) })
+
+      // Close button visible (existingName=Tomas branch).
+      const closeBtn = await waitFor(() => {
+        const el = document.querySelector<HTMLButtonElement>('button[aria-label="Close"]')
+        if (!el) throw new Error('close button not mounted yet')
+        return el
+      })
+      await act(async () => { fireEvent.click(closeBtn) })
+
+      await waitFor(() => {
+        expect(document.querySelector('button[aria-label="Close"]')).toBeNull()
+      })
+      // localStorage author name unchanged — cancel does not save.
+      expect(localStorage.getItem('fw-author-name')).toBe('Tomas')
+    })
+  })
 })

--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -688,6 +688,98 @@ describe('<FeedbackWidget />', () => {
   })
 
   describe('name modal cancel', () => {
+    it('form submit with empty value early-returns and leaves modal open', async () => {
+      mockFetch()
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+
+      document.querySelectorAll('[data-test-target]').forEach((n) => n.remove())
+      const targetNode = document.createElement('article')
+      targetNode.setAttribute('data-test-target', '')
+      document.body.appendChild(targetNode)
+      await waitFor(() => {
+        if (document.querySelectorAll('[data-fw]').length === 0) {
+          throw new Error('widget not mounted')
+        }
+      })
+      await act(async () => { fireEvent.keyDown(window, { key: 'c' }) })
+      await act(async () => {
+        targetNode.dispatchEvent(new MouseEvent('click', {
+          bubbles: true, cancelable: true, clientX: 80, clientY: 80,
+        }))
+      })
+
+      const nameInput = await waitFor(() => {
+        const el = document.querySelector<HTMLInputElement>('input[placeholder^="e.g."]')
+        if (!el) throw new Error('name input not mounted')
+        return el
+      })
+
+      // Fire form submit while value is still empty — handleNameSubmit must
+      // hit the trim-guard early return, leaving the modal mounted.
+      await act(async () => {
+        fireEvent.submit(nameInput.closest('form')!)
+      })
+      expect(document.querySelector('input[placeholder^="e.g."]')).not.toBeNull()
+      expect(localStorage.getItem('fw-author-name')).toBeNull()
+    })
+
+    it('re-edit name while in commenting mode does not re-flip mode', async () => {
+      try { localStorage.setItem('fw-author-name', 'Tomas') } catch {}
+      mockFetch()
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+
+      document.querySelectorAll('[data-test-target]').forEach((n) => n.remove())
+      const targetNode = document.createElement('article')
+      targetNode.setAttribute('data-test-target', '')
+      document.body.appendChild(targetNode)
+      await waitFor(() => {
+        if (document.querySelectorAll('[data-fw]').length === 0) {
+          throw new Error('widget not mounted')
+        }
+      })
+      await act(async () => { fireEvent.keyDown(window, { key: 'c' }) })
+      await act(async () => {
+        targetNode.dispatchEvent(new MouseEvent('click', {
+          bubbles: true, cancelable: true, clientX: 80, clientY: 80,
+        }))
+      })
+
+      // Wait for the commenting popover textarea — confirms mode='commenting'.
+      await waitFor(() => {
+        const el = document.querySelector<HTMLTextAreaElement>('textarea')
+        if (!el) throw new Error('commenting textarea not mounted')
+        return el
+      })
+
+      const avatar = await waitFor(() => {
+        const el = document.querySelector<HTMLButtonElement>(
+          'button[title^="Signed in as Tomas"]',
+        )
+        if (!el) throw new Error('avatar button not mounted')
+        return el
+      })
+      await act(async () => { fireEvent.click(avatar) })
+
+      const nameInput = await waitFor(() => {
+        const el = document.querySelector<HTMLInputElement>('input[placeholder^="e.g."]')
+        if (!el) throw new Error('name input not mounted')
+        return el
+      })
+      await act(async () => {
+        fireEvent.change(nameInput, { target: { value: 'Alex' } })
+      })
+      await act(async () => {
+        fireEvent.submit(nameInput.closest('form')!)
+      })
+
+      // Name saved, modal closed, textarea still mounted (mode stayed 'commenting').
+      await waitFor(() => {
+        expect(document.querySelector('input[placeholder^="e.g."]')).toBeNull()
+      })
+      expect(localStorage.getItem('fw-author-name')).toBe('Alex')
+      expect(document.querySelector('textarea')).not.toBeNull()
+    })
+
     it('avatar click reopens modal and Close button cancels without saving', async () => {
       try { localStorage.setItem('fw-author-name', 'Tomas') } catch {}
       mockFetch()

--- a/src/__tests__/NameModal.test.tsx
+++ b/src/__tests__/NameModal.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render } from '@testing-library/react'
+import { NameModal } from '../components/FeedbackWidget/modal/NameModal'
+
+function makeProps(overrides: Partial<Parameters<typeof NameModal>[0]> = {}) {
+  return {
+    value: '',
+    onChange: vi.fn(),
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+    existingName: null as string | null,
+    ...overrides,
+  }
+}
+
+describe('NameModal', () => {
+  it('renders first-time copy when existingName is null', () => {
+    const { getByText, queryByLabelText } = render(<NameModal {...makeProps()} />)
+    expect(getByText("What's your name?")).not.toBeNull()
+    expect(getByText('Continue')).not.toBeNull()
+    expect(queryByLabelText('Close')).toBeNull()
+  })
+
+  it('renders change-name copy when existingName provided', () => {
+    const { getByText, getByLabelText } = render(
+      <NameModal {...makeProps({ existingName: 'Tomas' })} />
+    )
+    expect(getByText('Change your name')).not.toBeNull()
+    expect(getByText('Save')).not.toBeNull()
+    expect(getByLabelText('Close')).not.toBeNull()
+  })
+
+  it('submit button disabled when value is empty', () => {
+    const { getByText } = render(<NameModal {...makeProps({ value: '' })} />)
+    expect((getByText('Continue') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('submit button disabled when value is only whitespace', () => {
+    const { getByText } = render(<NameModal {...makeProps({ value: '   ' })} />)
+    expect((getByText('Continue') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('submit button enabled when value has non-whitespace', () => {
+    const { getByText } = render(<NameModal {...makeProps({ value: 'Alex' })} />)
+    const btn = getByText('Continue') as HTMLButtonElement
+    expect(btn.disabled).toBe(false)
+    expect(btn.style.background).toBe('#111')
+    expect(btn.style.cursor).toBe('pointer')
+  })
+
+  it('disabled submit uses ccc background + not-allowed cursor', () => {
+    const { getByText } = render(<NameModal {...makeProps({ value: '' })} />)
+    const btn = getByText('Continue') as HTMLButtonElement
+    expect(btn.style.background).toBe('#ccc')
+    expect(btn.style.cursor).toBe('not-allowed')
+  })
+
+  it('form submit fires onSubmit', () => {
+    const props = makeProps({ value: 'Alex' })
+    const { container } = render(<NameModal {...props} />)
+    const form = container.querySelector('form') as HTMLFormElement
+    fireEvent.submit(form)
+    expect(props.onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('input onChange fires onChange with new value', () => {
+    const props = makeProps()
+    const { container } = render(<NameModal {...props} />)
+    const input = container.querySelector('input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Bob' } })
+    expect(props.onChange).toHaveBeenCalledWith('Bob')
+  })
+
+  it('close button fires onCancel', () => {
+    const props = makeProps({ existingName: 'Tomas' })
+    const { getByLabelText } = render(<NameModal {...props} />)
+    fireEvent.click(getByLabelText('Close'))
+    expect(props.onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('close button hover paints background + color', () => {
+    const { getByLabelText } = render(
+      <NameModal {...makeProps({ existingName: 'Tomas' })} />
+    )
+    const close = getByLabelText('Close') as HTMLButtonElement
+    fireEvent.mouseEnter(close)
+    expect(close.style.background).toBe('#f5f5f5')
+    expect(close.style.color).toBe('#111')
+    fireEvent.mouseLeave(close)
+    expect(close.style.background).toBe('transparent')
+    expect(close.style.color).toBe('#888')
+  })
+
+  it('input focus + blur swap border + background', () => {
+    const { container } = render(<NameModal {...makeProps()} />)
+    const input = container.querySelector('input') as HTMLInputElement
+    fireEvent.focus(input)
+    expect(input.style.borderColor).toBe('#2563eb')
+    expect(input.style.background).toBe('#fff')
+    fireEvent.blur(input)
+    expect(input.style.borderColor).toBe('#e5e5e5')
+    expect(input.style.background).toBe('#fafafa')
+  })
+
+  it('overlay click stops propagation', () => {
+    const { container } = render(<NameModal {...makeProps()} />)
+    const overlay = container.firstChild as HTMLElement
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    overlay.dispatchEvent(event)
+  })
+})

--- a/src/__tests__/SelectingInstructionBar.test.tsx
+++ b/src/__tests__/SelectingInstructionBar.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render } from '@testing-library/react'
+import { SelectingInstructionBar } from '../components/FeedbackWidget/selecting/SelectingInstructionBar'
+
+describe('SelectingInstructionBar', () => {
+  it('renders instruction text and Esc badge', () => {
+    const { getByText } = render(<SelectingInstructionBar onCancel={vi.fn()} />)
+    expect(getByText('Click any element to leave feedback')).not.toBeNull()
+    expect(getByText('Esc')).not.toBeNull()
+    expect(getByText('exit')).not.toBeNull()
+  })
+
+  it('clicking exit fires onCancel', () => {
+    const onCancel = vi.fn()
+    const { getByText } = render(<SelectingInstructionBar onCancel={onCancel} />)
+    fireEvent.click(getByText('exit'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('exit hover swaps color back and forth', () => {
+    const { getByText } = render(<SelectingInstructionBar onCancel={vi.fn()} />)
+    const exit = getByText('exit') as HTMLElement
+    fireEvent.mouseEnter(exit)
+    expect(exit.style.color).toBe('#111')
+    fireEvent.mouseLeave(exit)
+    expect(exit.style.color).toBe('#999')
+  })
+})

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -11,6 +11,8 @@ import { avatarColor, getInitials, normalizeReviewStatus, timeAgo } from './form
 import { fetchProjectComments, patchReviewStatus as apiPatchReviewStatus, postComment } from './api'
 import { FeedbackWidgetStyles } from './styles'
 import { PinActionCluster, PinMarker } from './pin'
+import { NameModal } from './modal'
+import { SelectingInstructionBar } from './selecting'
 
 export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
   const [mode, setMode] = useState<Mode>('idle')
@@ -44,6 +46,20 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
   function openNameEditor() {
     setNameInput(authorNameRef.current ?? '')
     setShowNameModal(true)
+  }
+
+  function handleNameSubmit() {
+    if (!nameInput.trim()) return
+    const wasCommenting = mode === 'commenting'
+    saveAuthorName(nameInput)
+    setShowNameModal(false)
+    setNameInput('')
+    if (!wasCommenting && target) setMode('commenting')
+  }
+
+  function handleNameCancel() {
+    setShowNameModal(false)
+    setNameInput('')
   }
 
   // Draggable pill state
@@ -524,57 +540,7 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
       )}
 
       {/* Instruction tooltip */}
-      {mode === 'selecting' && (
-        <div
-          {...{ [WIDGET_ATTR]: '' }}
-          style={{
-            position: 'fixed',
-            top: 16,
-            left: '50%',
-            transform: 'translateX(-50%)',
-            zIndex: 2147483647,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            padding: '8px 14px',
-            borderRadius: 9999,
-            background: '#fff',
-            border: '1px solid #e5e7eb',
-            boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
-            fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-            fontSize: 13,
-            color: '#111',
-            whiteSpace: 'nowrap',
-            animation: 'fw-instruction-in 0.3s ease both',
-          }}
-        >
-          <span className="fw-rec-dot" style={{ width: 8, height: 8, borderRadius: '50%', background: '#E5502A', flexShrink: 0 }} />
-          <span style={{ fontWeight: 500 }}>Click any element to leave feedback</span>
-          <span style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: '1px 6px',
-            borderRadius: 4,
-            border: '1px solid #d1d5db',
-            fontSize: 12,
-            fontWeight: 600,
-            color: '#888',
-            lineHeight: 1.4,
-          }}>Esc</span>
-          <span
-            onClick={exitFeedbackMode}
-            style={{
-              color: '#999',
-              fontSize: 12,
-              cursor: 'pointer',
-              marginLeft: 2,
-            }}
-            onMouseEnter={(e) => (e.currentTarget.style.color = '#111')}
-            onMouseLeave={(e) => (e.currentTarget.style.color = '#999')}
-          >exit</span>
-        </div>
-      )}
+      {mode === 'selecting' && <SelectingInstructionBar onCancel={exitFeedbackMode} />}
 
       {/* Popover */}
       {mode === 'commenting' && target && (
@@ -1486,108 +1452,13 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
       <FeedbackWidgetStyles />
 
       {showNameModal && (
-        <div
-          {...{ [WIDGET_ATTR]: '' }}
-          style={{
-            position: 'fixed', inset: 0, zIndex: 2147483647,
-            background: 'rgba(10, 10, 15, 0.55)',
-            backdropFilter: 'blur(6px)',
-            WebkitBackdropFilter: 'blur(6px)',
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            animation: 'fw-modal-overlay-in 0.18s ease both',
-            fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-          }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <form
-            onSubmit={(e) => {
-              e.preventDefault()
-              if (!nameInput.trim()) return
-              const wasCommenting = mode === 'commenting'
-              saveAuthorName(nameInput)
-              setShowNameModal(false)
-              setNameInput('')
-              if (!wasCommenting && target) setMode('commenting')
-            }}
-            style={{
-              width: 360, maxWidth: 'calc(100vw - 32px)',
-              background: '#fff', borderRadius: 16, padding: 24,
-              boxShadow: '0 24px 64px rgba(0, 0, 0, 0.25), 0 4px 12px rgba(0, 0, 0, 0.12)',
-              animation: 'fw-modal-card-in 0.22s cubic-bezier(0.16, 1, 0.3, 1) both',
-              display: 'flex', flexDirection: 'column', gap: 16,
-              position: 'relative',
-            }}
-          >
-            {authorNameRef.current && (
-              <button
-                type="button"
-                onClick={() => { setShowNameModal(false); setNameInput('') }}
-                aria-label="Close"
-                style={{
-                  position: 'absolute', top: 12, right: 12,
-                  width: 28, height: 28, borderRadius: '50%',
-                  border: 'none', background: 'transparent',
-                  cursor: 'pointer', color: '#888',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                }}
-                onMouseEnter={(e) => { e.currentTarget.style.background = '#f5f5f5'; e.currentTarget.style.color = '#111' }}
-                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = '#888' }}
-              >
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                  <line x1="4" y1="4" x2="12" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                  <line x1="12" y1="4" x2="4" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                </svg>
-              </button>
-            )}
-            <div style={{
-              width: 44, height: 44, borderRadius: '50% 50% 50% 0',
-              background: PIN_GRADIENT,
-              alignSelf: 'flex-start',
-            }} />
-            <div>
-              <h2 style={{ fontSize: 18, fontWeight: 700, color: '#111', margin: 0, marginBottom: 6 }}>
-                {authorNameRef.current ? 'Change your name' : "What's your name?"}
-              </h2>
-              <p style={{ fontSize: 13, color: '#666', margin: 0, lineHeight: 1.4 }}>
-                Your name will appear on the comments you leave.
-              </p>
-            </div>
-            <input
-              autoFocus
-              type="text"
-              value={nameInput}
-              onChange={(e) => setNameInput(e.target.value)}
-              placeholder="e.g. Tomas"
-              required
-              maxLength={40}
-              style={{
-                width: '100%', boxSizing: 'border-box',
-                padding: '10px 12px', fontSize: 14, color: '#111',
-                background: '#fafafa',
-                border: '1px solid #e5e5e5', borderRadius: 8,
-                outline: 'none', fontFamily: 'inherit',
-                transition: 'border-color 0.15s, background 0.15s',
-              }}
-              onFocus={(e) => { e.currentTarget.style.borderColor = '#2563eb'; e.currentTarget.style.background = '#fff' }}
-              onBlur={(e) => { e.currentTarget.style.borderColor = '#e5e5e5'; e.currentTarget.style.background = '#fafafa' }}
-            />
-            <button
-              type="submit"
-              disabled={!nameInput.trim()}
-              style={{
-                width: '100%', padding: '11px 0', fontSize: 14, fontWeight: 600,
-                color: '#fff',
-                background: nameInput.trim() ? '#111' : '#ccc',
-                border: 'none', borderRadius: 8,
-                cursor: nameInput.trim() ? 'pointer' : 'not-allowed',
-                transition: 'background 0.15s',
-                fontFamily: 'inherit',
-              }}
-            >
-              {authorNameRef.current ? 'Save' : 'Continue'}
-            </button>
-          </form>
-        </div>
+        <NameModal
+          value={nameInput}
+          onChange={setNameInput}
+          onSubmit={handleNameSubmit}
+          onCancel={handleNameCancel}
+          existingName={authorNameRef.current}
+        />
       )}
     </div>
   )

--- a/src/components/FeedbackWidget/modal/NameModal.tsx
+++ b/src/components/FeedbackWidget/modal/NameModal.tsx
@@ -1,0 +1,109 @@
+import { PIN_GRADIENT, WIDGET_ATTR } from '../constants'
+
+export interface NameModalProps {
+  value: string
+  onChange: (v: string) => void
+  onSubmit: () => void
+  onCancel: () => void
+  existingName: string | null
+}
+
+export function NameModal({ value, onChange, onSubmit, onCancel, existingName }: NameModalProps) {
+  const trimmed = value.trim()
+  return (
+    <div
+      {...{ [WIDGET_ATTR]: '' }}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 2147483647,
+        background: 'rgba(10, 10, 15, 0.55)',
+        backdropFilter: 'blur(6px)',
+        WebkitBackdropFilter: 'blur(6px)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        animation: 'fw-modal-overlay-in 0.18s ease both',
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <form
+        onSubmit={(e) => { e.preventDefault(); onSubmit() }}
+        style={{
+          width: 360, maxWidth: 'calc(100vw - 32px)',
+          background: '#fff', borderRadius: 16, padding: 24,
+          boxShadow: '0 24px 64px rgba(0, 0, 0, 0.25), 0 4px 12px rgba(0, 0, 0, 0.12)',
+          animation: 'fw-modal-card-in 0.22s cubic-bezier(0.16, 1, 0.3, 1) both',
+          display: 'flex', flexDirection: 'column', gap: 16,
+          position: 'relative',
+        }}
+      >
+        {existingName && (
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Close"
+            style={{
+              position: 'absolute', top: 12, right: 12,
+              width: 28, height: 28, borderRadius: '50%',
+              border: 'none', background: 'transparent',
+              cursor: 'pointer', color: '#888',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.background = '#f5f5f5'; e.currentTarget.style.color = '#111' }}
+            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = '#888' }}
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <line x1="4" y1="4" x2="12" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              <line x1="12" y1="4" x2="4" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        )}
+        <div style={{
+          width: 44, height: 44, borderRadius: '50% 50% 50% 0',
+          background: PIN_GRADIENT,
+          alignSelf: 'flex-start',
+        }} />
+        <div>
+          <h2 style={{ fontSize: 18, fontWeight: 700, color: '#111', margin: 0, marginBottom: 6 }}>
+            {existingName ? 'Change your name' : "What's your name?"}
+          </h2>
+          <p style={{ fontSize: 13, color: '#666', margin: 0, lineHeight: 1.4 }}>
+            Your name will appear on the comments you leave.
+          </p>
+        </div>
+        <input
+          autoFocus
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="e.g. Tomas"
+          required
+          maxLength={40}
+          style={{
+            width: '100%', boxSizing: 'border-box',
+            padding: '10px 12px', fontSize: 14, color: '#111',
+            background: '#fafafa',
+            border: '1px solid #e5e5e5', borderRadius: 8,
+            outline: 'none', fontFamily: 'inherit',
+            transition: 'border-color 0.15s, background 0.15s',
+          }}
+          onFocus={(e) => { e.currentTarget.style.borderColor = '#2563eb'; e.currentTarget.style.background = '#fff' }}
+          onBlur={(e) => { e.currentTarget.style.borderColor = '#e5e5e5'; e.currentTarget.style.background = '#fafafa' }}
+        />
+        <button
+          type="submit"
+          disabled={!trimmed}
+          style={{
+            width: '100%', padding: '11px 0', fontSize: 14, fontWeight: 600,
+            color: '#fff',
+            background: trimmed ? '#111' : '#ccc',
+            border: 'none', borderRadius: 8,
+            cursor: trimmed ? 'pointer' : 'not-allowed',
+            transition: 'background 0.15s',
+            fontFamily: 'inherit',
+          }}
+        >
+          {existingName ? 'Save' : 'Continue'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/components/FeedbackWidget/modal/index.ts
+++ b/src/components/FeedbackWidget/modal/index.ts
@@ -1,0 +1,1 @@
+export { NameModal } from './NameModal'

--- a/src/components/FeedbackWidget/selecting/SelectingInstructionBar.tsx
+++ b/src/components/FeedbackWidget/selecting/SelectingInstructionBar.tsx
@@ -1,0 +1,59 @@
+import { WIDGET_ATTR } from '../constants'
+
+export interface SelectingInstructionBarProps {
+  onCancel: () => void
+}
+
+export function SelectingInstructionBar({ onCancel }: SelectingInstructionBarProps) {
+  return (
+    <div
+      {...{ [WIDGET_ATTR]: '' }}
+      style={{
+        position: 'fixed',
+        top: 16,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 2147483647,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '8px 14px',
+        borderRadius: 9999,
+        background: '#fff',
+        border: '1px solid #e5e7eb',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        fontSize: 13,
+        color: '#111',
+        whiteSpace: 'nowrap',
+        animation: 'fw-instruction-in 0.3s ease both',
+      }}
+    >
+      <span className="fw-rec-dot" style={{ width: 8, height: 8, borderRadius: '50%', background: '#E5502A', flexShrink: 0 }} />
+      <span style={{ fontWeight: 500 }}>Click any element to leave feedback</span>
+      <span style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '1px 6px',
+        borderRadius: 4,
+        border: '1px solid #d1d5db',
+        fontSize: 12,
+        fontWeight: 600,
+        color: '#888',
+        lineHeight: 1.4,
+      }}>Esc</span>
+      <span
+        onClick={onCancel}
+        style={{
+          color: '#999',
+          fontSize: 12,
+          cursor: 'pointer',
+          marginLeft: 2,
+        }}
+        onMouseEnter={(e) => (e.currentTarget.style.color = '#111')}
+        onMouseLeave={(e) => (e.currentTarget.style.color = '#999')}
+      >exit</span>
+    </div>
+  )
+}

--- a/src/components/FeedbackWidget/selecting/index.ts
+++ b/src/components/FeedbackWidget/selecting/index.ts
@@ -1,0 +1,1 @@
+export { SelectingInstructionBar } from './SelectingInstructionBar'


### PR DESCRIPTION
# Summary

- Move the "What's your name?" prompt and the floating "click any element to leave feedback" bar into their own files so the widget's main file gets shorter and easier to reason about.
- Keep behavior identical — both pieces receive callbacks from the orchestrator, so the state machine, save logic, and mode transitions stay in one place.
- Tighten the boundary between the orchestrator and these overlays: the modal only knows about an input value, a submit, and a cancel; the instruction bar only knows how to ask the user to exit.
- Shrink the widget's main file by another ~130 lines.