### PR TITLE
Rename feedback widget to CRRT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# @thedesignproject/feedback-widget
+# CRRT 🥕
 
-[![codecov](https://codecov.io/gh/thedesignproject/feedback-widget/branch/trunk/graph/badge.svg)](https://codecov.io/gh/thedesignproject/feedback-widget/tree/trunk)
+[![codecov](https://codecov.io/gh/thedesignproject/CRRT/branch/trunk/graph/badge.svg)](https://codecov.io/gh/thedesignproject/CRRT/tree/trunk)
 
-Visual feedback capture for React sites, plus a private reviewer console and a Proof-style agent bridge.
+CRRT 🥕 is visual feedback capture for React sites, plus a private reviewer console and a Proof-style agent bridge.
 
 ## What changed
 

--- a/api/_lib/prompts.ts
+++ b/api/_lib/prompts.ts
@@ -46,7 +46,7 @@ function buildBody(input: PromptInput) {
   }
 
   return [
-    'Feedback Widget is a visual feedback system: humans drop comments pinned to real pixels on live pages, and you implement the accepted ones.',
+    'CRRT 🥕 is a visual feedback system: humans drop comments pinned to real pixels on live pages, and you implement the accepted ones.',
     '',
     'Join this session immediately so the human can see your presence:',
     docUrl,
@@ -60,7 +60,7 @@ function buildBody(input: PromptInput) {
     '2. Read state.',
     `   GET ${bridge}/state`,
     '',
-    '3. Flip presence to idle so the reviewer sees you finished connecting, then reply: Connected to Feedback Widget and ready.',
+    '3. Flip presence to idle so the reviewer sees you finished connecting, then reply: Connected to CRRT and ready.',
     `   POST ${bridge}/presence`,
     '   Body: {"status":"idle","summary":"Connected — ready to start"}',
     '',
@@ -88,12 +88,12 @@ export function buildPrompt(target: string, input: PromptInput) {
   const body = buildBody(input)
 
   if (target === 'claude-code') {
-    return `You are Claude Code working on a Feedback Widget session.\n\n${body}`
+    return `You are Claude Code working on a CRRT session.\n\n${body}`
   }
 
   if (target === 'codex') {
-    return `You are Codex working on a Feedback Widget session.\n\n${body}`
+    return `You are Codex working on a CRRT session.\n\n${body}`
   }
 
-  return `You are a coding agent working on a Feedback Widget session.\n\n${body}`
+  return `You are a coding agent working on a CRRT session.\n\n${body}`
 }

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Feedback — Dashboard</title>
+    <title>CRRT 🥕 Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Feedback Widget Demo</title>
+    <title>CRRT 🥕 Demo</title>
   </head>
   <body>
     <div id="root"></div>

--- a/demo/public/skill.md
+++ b/demo/public/skill.md
@@ -1,6 +1,6 @@
-# Feedback Widget Agent Skill
+# CRRT 🥕 Agent Skill
 
-Feedback Widget is a visual feedback system. Humans leave comments pinned to real pixels on live pages. Agents implement the accepted ones.
+CRRT 🥕 is a visual feedback system. Humans leave comments pinned to real pixels on live pages. Agents implement the accepted ones.
 
 This file is the machine-readable contract for the agent bridge. Fetch it when you need setup details the prompt doesn't cover.
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@thedesignproject/feedback-widget",
   "version": "0.3.11",
-  "description": "Visual feedback widget for React apps",
+  "description": "CRRT 🥕 visual feedback capture for React apps",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/thedesignproject/feedback-widget.git"
+    "url": "git+https://github.com/thedesignproject/CRRT.git"
   },
-  "homepage": "https://github.com/thedesignproject/feedback-widget#readme",
+  "homepage": "https://crrt.ai",
   "bugs": {
-    "url": "https://github.com/thedesignproject/feedback-widget/issues"
+    "url": "https://github.com/thedesignproject/CRRT/issues"
   },
   "type": "module",
   "main": "dist/feedback-widget.umd.js",

--- a/plan.md
+++ b/plan.md
@@ -1,4 +1,4 @@
-# Feedback Widget — Product Plan
+# CRRT 🥕 — Product Plan
 
 Visual feedback tool for React projects. The client visits their deployed URL, clicks any element, and leaves a comment. The developer sees everything in a dashboard.
 


### PR DESCRIPTION
Renames the repo-facing product title to CRRT 🥕 and updates the documented URL to https://crrt.ai.\n\nThis also updates the demo/dashboard page titles, agent-facing docs/prompts, and package metadata links while preserving the published npm package name.\n\nVerification: bun run typecheck was attempted but fails on the existing screenshotCapture/html2canvas type issues in this checkout.