### PR TITLE
chore(npm): rename package to crrt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
       - run: bun run build
       - name: Enforce bundle size ceiling
         run: |
-          SIZE=$(wc -c < dist/feedback-widget.es.js | tr -d ' ')
+          SIZE=$(wc -c < dist/crrt.es.js | tr -d ' ')
           # Screenshot capture currently bundles html2canvas; keep a modest
           # headroom over the current screenshot-enabled baseline.
           MAX=524288
-          echo "dist/feedback-widget.es.js: $SIZE bytes (max $MAX)"
+          echo "dist/crrt.es.js: $SIZE bytes (max $MAX)"
           if [ "$SIZE" -gt "$MAX" ]; then
             echo "::error::Bundle exceeds size ceiling"
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           }
           JSON
           cat > index.tsx <<'TSX'
-          import { FeedbackWidget } from '@thedesignproject/feedback-widget'
+          import { FeedbackWidget } from '@thedesignproject/crrt'
           export default function App() {
             return <FeedbackWidget projectId="smoke" apiBase="https://x" />
           }

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ The old `/api/comments` route still exists as a compatibility path and for the s
 Install:
 
 ```bash
-bun add @thedesignproject/feedback-widget
+bun add @thedesignproject/crrt
 ```
 
 Usage:
 
 ```tsx
-import { FeedbackWidget } from '@thedesignproject/feedback-widget'
+import { FeedbackWidget } from '@thedesignproject/crrt'
 
 export default function App() {
   return (

--- a/apps/dashboard/lib/format.ts
+++ b/apps/dashboard/lib/format.ts
@@ -61,11 +61,11 @@ export function buildIntegrationPrompt(projectId: string, apiBase: string) {
 
 1. Install the package:
 
-   npm install @thedesignproject/feedback-widget
+   npm install @thedesignproject/crrt
 
 2. Mount <FeedbackWidget /> in the root React component (e.g. App.tsx or a top-level layout) so it appears on every page:
 
-   import { FeedbackWidget } from '@thedesignproject/feedback-widget'
+   import { FeedbackWidget } from '@thedesignproject/crrt'
 
    export default function App() {
      return (

--- a/apps/landing/sections/Closing.tsx
+++ b/apps/landing/sections/Closing.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react'
 import { PillButton } from '../components/PillButton'
 import { activateCRRT } from '../lib/crrt'
 
-const npmSnippet = `pnpm add @thedesignproject/feedback-widget`
-const reactSnippet = `import { FeedbackWidget } from '@thedesignproject/feedback-widget'
+const npmSnippet = `pnpm add @thedesignproject/crrt`
+const reactSnippet = `import { FeedbackWidget } from '@thedesignproject/crrt'
 
 export default function App() {
   return (
@@ -181,4 +181,3 @@ function Snippet({ number, title, description, code }: { number: string; title: 
     </div>
   )
 }
-

--- a/apps/landing/sections/Footer.tsx
+++ b/apps/landing/sections/Footer.tsx
@@ -25,9 +25,9 @@ export function Footer() {
           }}
         >
           {[
-            { label: 'GitHub', href: 'https://github.com/thedesignproject/feedback-widget', external: true },
+            { label: 'GitHub', href: 'https://github.com/thedesignproject/CRRT', external: true },
             { label: 'Docs', href: '#install' },
-            { label: 'Status', href: 'https://github.com/thedesignproject/feedback-widget/issues', external: true },
+            { label: 'Status', href: 'https://github.com/thedesignproject/CRRT/issues', external: true },
           ].map((link) => (
             <a
               key={link.label}

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@thedesignproject/feedback-widget",
+      "name": "@thedesignproject/crrt",
       "dependencies": {
         "@supabase/supabase-js": "^2.49.4",
         "framer-motion": "^12.38.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `npm run typecheck` script that type-checks `src/`, `api/`, and app surfaces together.
 - `npm run test:coverage` script + v8 coverage reporter.
 - GitHub Actions CI workflow:
-  - `check (react 18)` / `check (react 19)` — matrix job running typecheck, tests-with-coverage, build, and a hard 50 KB ceiling on `dist/feedback-widget.es.js`.
+  - `check (react 18)` / `check (react 19)` — matrix job running typecheck, tests-with-coverage, build, and a hard 50 KB ceiling on `dist/crrt.es.js`.
   - `audit` — `npm audit --omit=dev --audit-level=high` fails on high/critical advisories in **shipped runtime** deps. Dev-tool advisories are tracked via Dependabot rather than blocking merges on upstream churn the maintainers cannot fix.
   - `secrets` — gitleaks (pinned by `sha256`) scans the full history for committed credentials.
   - Concurrency cancellation on repeat pushes to the same ref.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@thedesignproject/feedback-widget",
-  "version": "0.3.11",
+  "name": "@thedesignproject/crrt",
+  "version": "0.3.12",
   "description": "CRRT 🥕 visual feedback capture for React apps",
   "license": "Apache-2.0",
   "repository": {
@@ -12,14 +12,14 @@
     "url": "https://github.com/thedesignproject/CRRT/issues"
   },
   "type": "module",
-  "main": "dist/feedback-widget.umd.js",
-  "module": "dist/feedback-widget.es.js",
+  "main": "dist/crrt.umd.js",
+  "module": "dist/crrt.es.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/feedback-widget.es.js",
-      "require": "./dist/feedback-widget.umd.js"
+      "import": "./dist/crrt.es.js",
+      "require": "./dist/crrt.umd.js"
     }
   },
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      name: 'FeedbackWidget',
-      fileName: (format) => `feedback-widget.${format}.js`,
+      name: 'CRRT',
+      fileName: (format) => `crrt.${format}.js`,
       formats: ['es', 'umd'],
     },
     rollupOptions: {


### PR DESCRIPTION
## Summary
- rename the npm package to `@thedesignproject/crrt` and bump to `0.3.12`
- update install/import snippets and publish consumer smoke import
- rename library build artifacts to `dist/crrt.*.js` and update CI bundle-size check

## Verification
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- bundle size check for `dist/crrt.es.js`
- `npm pack --dry-run --json`
- local consumer smoke against generated tarball for React 18 and React 19
- `npx -y react-doctor@latest . --verbose --diff`