### PR TITLE
chore(npm): publish CRRT update under feedback-widget

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           }
           JSON
           cat > index.tsx <<'TSX'
-          import { FeedbackWidget } from '@thedesignproject/crrt'
+          import { FeedbackWidget } from '@thedesignproject/feedback-widget'
           export default function App() {
             return <FeedbackWidget projectId="smoke" apiBase="https://x" />
           }

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ The old `/api/comments` route still exists as a compatibility path and for the s
 Install:
 
 ```bash
-bun add @thedesignproject/crrt
+bun add @thedesignproject/feedback-widget
 ```
 
 Usage:
 
 ```tsx
-import { FeedbackWidget } from '@thedesignproject/crrt'
+import { FeedbackWidget } from '@thedesignproject/feedback-widget'
 
 export default function App() {
   return (

--- a/apps/dashboard/lib/format.ts
+++ b/apps/dashboard/lib/format.ts
@@ -61,11 +61,11 @@ export function buildIntegrationPrompt(projectId: string, apiBase: string) {
 
 1. Install the package:
 
-   npm install @thedesignproject/crrt
+   npm install @thedesignproject/feedback-widget
 
 2. Mount <FeedbackWidget /> in the root React component (e.g. App.tsx or a top-level layout) so it appears on every page:
 
-   import { FeedbackWidget } from '@thedesignproject/crrt'
+   import { FeedbackWidget } from '@thedesignproject/feedback-widget'
 
    export default function App() {
      return (

--- a/apps/landing/sections/Closing.tsx
+++ b/apps/landing/sections/Closing.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react'
 import { PillButton } from '../components/PillButton'
 import { activateCRRT } from '../lib/crrt'
 
-const npmSnippet = `pnpm add @thedesignproject/crrt`
-const reactSnippet = `import { FeedbackWidget } from '@thedesignproject/crrt'
+const npmSnippet = `pnpm add @thedesignproject/feedback-widget`
+const reactSnippet = `import { FeedbackWidget } from '@thedesignproject/feedback-widget'
 
 export default function App() {
   return (

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@thedesignproject/crrt",
+      "name": "@thedesignproject/feedback-widget",
       "dependencies": {
         "@supabase/supabase-js": "^2.49.4",
         "framer-motion": "^12.38.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@thedesignproject/crrt",
-  "version": "0.3.12",
+  "name": "@thedesignproject/feedback-widget",
+  "version": "0.3.13",
   "description": "CRRT 🥕 visual feedback capture for React apps",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- publish the CRRT code/metadata update under the existing npm package `@thedesignproject/feedback-widget`
- bump package version to `0.3.13` because `v0.3.12` was used for the failed new-package-name publish attempt
- keep CRRT repo/homepage metadata and `dist/crrt.*.js` build artifacts
- keep install/import snippets on the package name that exists on npm today

## Verification
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `npm pack`
- local consumer smoke against generated tarball for React 18 and React 19