### PR TITLE
chore: add one-off npm deprecation workflow

### DIFF
--- a/.github/workflows/deprecate-old-npm-package.yml
+++ b/.github/workflows/deprecate-old-npm-package.yml
@@ -1,0 +1,17 @@
+name: Deprecate old npm package
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deprecate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
+      - name: Deprecate old package name
+        run: npm deprecate '@thedesignproject/feedback-widget@*' 'Package renamed to @thedesignproject/crrt. Please install @thedesignproject/crrt instead.'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds a one-off workflow to deprecate the old @thedesignproject/feedback-widget package now that @thedesignproject/crrt is published. This will be removed after the package is deprecated.