### PR TITLE
chore: fix npm deprecation workflow

### DIFF
--- a/.github/workflows/deprecate-old-npm-package.yml
+++ b/.github/workflows/deprecate-old-npm-package.yml
@@ -7,6 +7,7 @@ jobs:
   deprecate:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
Adds checkout before setup-node so the one-off deprecation workflow can read .nvmrc.