### PR TITLE
Default apiBase to https://crrt.ai/api

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,7 @@ import { FeedbackWidget } from '@thedesignproject/crrt'
 
 export default function App() {
   return (
-    <FeedbackWidget
-      apiBase="https://your-deployment.example.com/api"
-      projectId="demo-project"
-    />
+    <FeedbackWidget projectId="demo-project" />
   )
 }
 ```
@@ -69,8 +66,8 @@ Props:
 
 | Prop | Type | Required | Description |
 | --- | --- | --- | --- |
-| `apiBase` | `string` | yes | Base URL of the backend that serves the widget API. For this repo's Vercel functions, use `https://<your-deployment>/api`. |
 | `projectId` | `string` | yes | Project public key used for comment capture. |
+| `apiBase` | `string` | no | Base URL of the backend that serves the widget API. Defaults to `https://crrt.ai/api`. Override to point at a self-hosted deployment. |
 
 ## API surfaces
 

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -52,7 +52,7 @@ function CarrotPixelIcon({ size = 20 }: { size?: number }) {
   )
 }
 
-export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
+export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: FeedbackWidgetProps) {
   const [mode, setMode] = useState<Mode>('idle')
   const [target, setTarget] = useState<ClickTarget | null>(null)
   const [comment, setComment] = useState('')

--- a/src/components/FeedbackWidget/types.ts
+++ b/src/components/FeedbackWidget/types.ts
@@ -1,6 +1,6 @@
 export interface FeedbackWidgetProps {
   projectId: string
-  apiBase: string
+  apiBase?: string
 }
 
 export type Mode = 'idle' | 'selecting' | 'commenting'


### PR DESCRIPTION
- Make `apiBase` an optional prop on `FeedbackWidget` so the common hosted-backend case is zero-config.
- Default the value to `https://crrt.ai/api` when the prop is omitted.
- Simplify the README usage snippet to drop `apiBase` and mark the prop as optional in the props table.