### PR TITLE
Fix launcher pill hover oscillation

### DIFF
--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -2951,23 +2951,26 @@ describe('<FeedbackWidget />', () => {
       // Notification dot is the only absolute-positioned <span> inside the pill.
       const dot = pill.querySelector<HTMLSpanElement>('span[style*="position: absolute"]')
       expect(dot).not.toBeNull()
-      // Rest: collapsed (width 56) — dot sits at top:6 / right:6.
-      expect(pill.style.width).toBe('64px')
+      // Icon box width = the pillHover signal (46 collapsed → 28 hovered).
+      // The icon container is the first <span> child of the pill button.
+      const iconBox = pill.firstElementChild as HTMLSpanElement
+      expect(pill.style.minWidth).toBe('64px')
+      expect(iconBox.style.width).toBe('46px')
       expect(dot!.style.top).toBe('6px')
       expect(dot!.style.right).toBe('6px')
 
       const wrapper = pill.parentElement!.parentElement!
       await act(async () => { fireEvent.mouseEnter(wrapper) })
       await waitFor(() => {
-        expect(pill.style.width).toBe('auto')
+        expect(iconBox.style.width).toBe('28px')
       })
-      // Hover: pill expands, dot snaps to top:-2 / right:-2.
+      // Hover: dot snaps to top:-2 / right:-2.
       expect(dot!.style.top).toBe('-2px')
       expect(dot!.style.right).toBe('-2px')
 
       await act(async () => { fireEvent.mouseLeave(wrapper) })
       await waitFor(() => {
-        expect(pill.style.width).toBe('64px')
+        expect(iconBox.style.width).toBe('46px')
       })
       expect(dot!.style.top).toBe('6px')
       expect(dot!.style.right).toBe('6px')

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -31,7 +31,7 @@ function getElementFixedPos(
   }
 }
 
-function CarrotPixelIcon({ size = 20 }: { size?: number }) {
+function CarrotPixelIcon({ size = 20 }: { size?: number | string }) {
   return (
     <img
       src={CRRT_CARROT_LOGO_URL}
@@ -1631,7 +1631,9 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
               justifyContent: 'center',
               gap: pillHover ? 12 : 0,
               height: 64,
-              width: pillHover ? 'auto' : 64,
+              // minWidth (not width) so hover-expanded width interpolates with
+              // the children instead of snapping between 64 and `auto`.
+              minWidth: 64,
               padding: pillHover ? '0 22px 0 12px' : 0,
               borderRadius: 32,
               background: pillHover ? '#0A0A0A' : '#141414',
@@ -1650,7 +1652,21 @@ export function FeedbackWidget({ projectId, apiBase }: FeedbackWidgetProps) {
               overflow: 'hidden',
             }}
           >
-            <CarrotPixelIcon size={pillHover ? 28 : 46} />
+            {/* Size on wrapper (CSS transition), not icon prop — prop change
+             * would snap one frame and re-trigger hover under the cursor. */}
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: pillHover ? 28 : 46,
+                height: pillHover ? 28 : 46,
+                flexShrink: 0,
+                transition: 'width 360ms cubic-bezier(0.32, 0.72, 0, 1), height 360ms cubic-bezier(0.32, 0.72, 0, 1)',
+              }}
+            >
+              <CarrotPixelIcon size="100%" />
+            </span>
             <span
               style={{
                 maxWidth: pillHover ? 160 : 0,


### PR DESCRIPTION
- Stop the launcher pill from snapping between a fixed and `auto` width by switching to a `minWidth` base so the layout interpolates with its children.
- Move the carrot icon size animation onto a CSS-transitioned wrapper so the icon prop no longer changes mid-hover and re-triggers the hover state under the cursor.
- Update the pill hover test to assert against the new icon-box width signal and the pill's `minWidth`.