### PR TITLE
Add user auth helpers, project claim, invite bootstrap

### DIFF
--- a/api/_lib/auth.test.ts
+++ b/api/_lib/auth.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./supabase.js', () => ({ getSupabase: vi.fn() }))
+vi.mock('./store.js', () => ({ getProjectMembership: vi.fn() }))
+
+import { getSupabase } from './supabase.js'
+import { getProjectMembership } from './store.js'
+import {
+  requireProjectAdmin,
+  requireProjectMembership,
+  requireReviewer,
+  requireUser,
+} from './auth.js'
+
+interface MockRes {
+  statusCode: number
+  body: unknown
+  headers: Record<string, string>
+  status(code: number): MockRes
+  json(data: unknown): MockRes
+  end(): MockRes
+  setHeader(key: string, value: string): void
+}
+
+function mockReq(headers: Record<string, string> = {}) {
+  return { method: 'GET', query: {}, body: {}, headers } as never
+}
+
+function mockRes(): MockRes {
+  return {
+    statusCode: 200,
+    body: null,
+    headers: {},
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(data) {
+      this.body = data
+      return this
+    },
+    end() {
+      return this
+    },
+    setHeader(key, value) {
+      this.headers[key] = value
+    },
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(getSupabase).mockReset()
+  vi.mocked(getProjectMembership).mockReset()
+  delete process.env.REVIEWER_API_TOKEN
+})
+
+describe('requireReviewer', () => {
+  it('returns 500 when REVIEWER_API_TOKEN is not configured', () => {
+    const res = mockRes()
+    const ok = requireReviewer(mockReq(), res as never)
+    expect(ok).toBe(false)
+    expect(res.statusCode).toBe(500)
+  })
+
+  it('returns 401 when no token is presented', () => {
+    process.env.REVIEWER_API_TOKEN = 'expected'
+    const res = mockRes()
+    const ok = requireReviewer(mockReq(), res as never)
+    expect(ok).toBe(false)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('returns 401 when token does not match', () => {
+    process.env.REVIEWER_API_TOKEN = 'expected'
+    const res = mockRes()
+    const ok = requireReviewer(mockReq({ authorization: 'Bearer wrong' }), res as never)
+    expect(ok).toBe(false)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('returns true when token matches', () => {
+    process.env.REVIEWER_API_TOKEN = 'expected'
+    const res = mockRes()
+    const ok = requireReviewer(mockReq({ authorization: 'Bearer expected' }), res as never)
+    expect(ok).toBe(true)
+  })
+})
+
+describe('requireUser', () => {
+  it('returns 401 when no Bearer token is present', async () => {
+    const res = mockRes()
+    const user = await requireUser(mockReq(), res as never)
+    expect(user).toBeNull()
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('returns 401 when Supabase rejects the token', async () => {
+    vi.mocked(getSupabase).mockReturnValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: null, error: { message: 'bad' } }) },
+    } as never)
+
+    const res = mockRes()
+    const user = await requireUser(mockReq({ authorization: 'Bearer tok' }), res as never)
+    expect(user).toBeNull()
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('returns 401 when Supabase returns a user without email', async () => {
+    vi.mocked(getSupabase).mockReturnValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u', email: null } }, error: null }) },
+    } as never)
+
+    const res = mockRes()
+    const user = await requireUser(mockReq({ authorization: 'Bearer tok' }), res as never)
+    expect(user).toBeNull()
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('returns 401 when Supabase throws', async () => {
+    vi.mocked(getSupabase).mockReturnValue({
+      auth: { getUser: vi.fn().mockRejectedValue(new Error('network')) },
+    } as never)
+
+    const res = mockRes()
+    const user = await requireUser(mockReq({ authorization: 'Bearer tok' }), res as never)
+    expect(user).toBeNull()
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('returns the authenticated user when token is valid', async () => {
+    vi.mocked(getSupabase).mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'u-1', email: 'a@example.com' } },
+          error: null,
+        }),
+      },
+    } as never)
+
+    const res = mockRes()
+    const user = await requireUser(mockReq({ authorization: 'Bearer tok' }), res as never)
+    expect(user).toEqual({ userId: 'u-1', email: 'a@example.com' })
+  })
+})
+
+describe('requireProjectMembership', () => {
+  it('returns 403 when the user is not a member', async () => {
+    vi.mocked(getProjectMembership).mockResolvedValue(null)
+    const res = mockRes()
+    const role = await requireProjectMembership(mockReq(), res as never, 'u', 'p')
+    expect(role).toBeNull()
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('returns the role when the user is a member', async () => {
+    vi.mocked(getProjectMembership).mockResolvedValue('member')
+    const res = mockRes()
+    const role = await requireProjectMembership(mockReq(), res as never, 'u', 'p')
+    expect(role).toBe('member')
+  })
+})
+
+describe('requireProjectAdmin', () => {
+  it('returns false when the user is not a member', async () => {
+    vi.mocked(getProjectMembership).mockResolvedValue(null)
+    const res = mockRes()
+    const ok = await requireProjectAdmin(mockReq(), res as never, 'u', 'p')
+    expect(ok).toBe(false)
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('returns false when the user is a member but not admin', async () => {
+    vi.mocked(getProjectMembership).mockResolvedValue('member')
+    const res = mockRes()
+    const ok = await requireProjectAdmin(mockReq(), res as never, 'u', 'p')
+    expect(ok).toBe(false)
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('returns true for an admin', async () => {
+    vi.mocked(getProjectMembership).mockResolvedValue('admin')
+    const res = mockRes()
+    const ok = await requireProjectAdmin(mockReq(), res as never, 'u', 'p')
+    expect(ok).toBe(true)
+  })
+})

--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -1,5 +1,9 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { getReviewerToken, jsonError } from './http.js'
+import { getBearerToken, getReviewerToken, jsonError } from './http.js'
+import { getProjectMembership, type ProjectRole } from './store.js'
+import { getSupabase } from './supabase.js'
+
+export type AuthenticatedUser = { userId: string; email: string }
 
 export function requireReviewer(req: VercelRequest, res: VercelResponse) {
   const configured = process.env.REVIEWER_API_TOKEN
@@ -17,3 +21,54 @@ export function requireReviewer(req: VercelRequest, res: VercelResponse) {
   return true
 }
 
+export async function requireUser(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<AuthenticatedUser | null> {
+  const token = getBearerToken(req)
+  if (!token) {
+    jsonError(req, res, 401, 'Unauthorized')
+    return null
+  }
+
+  try {
+    const { data, error } = await getSupabase().auth.getUser(token)
+    if (error || !data?.user || !data.user.email) {
+      jsonError(req, res, 401, 'Unauthorized')
+      return null
+    }
+    return { userId: data.user.id, email: data.user.email }
+  } catch {
+    jsonError(req, res, 401, 'Unauthorized')
+    return null
+  }
+}
+
+export async function requireProjectMembership(
+  req: VercelRequest,
+  res: VercelResponse,
+  userId: string,
+  projectKey: string,
+): Promise<ProjectRole | null> {
+  const role = await getProjectMembership(userId, projectKey)
+  if (!role) {
+    jsonError(req, res, 403, 'Forbidden')
+    return null
+  }
+  return role
+}
+
+export async function requireProjectAdmin(
+  req: VercelRequest,
+  res: VercelResponse,
+  userId: string,
+  projectKey: string,
+): Promise<boolean> {
+  const role = await requireProjectMembership(req, res, userId, projectKey)
+  if (!role) return false
+  if (role !== 'admin') {
+    jsonError(req, res, 403, 'Admin required')
+    return false
+  }
+  return true
+}

--- a/api/_lib/store-membership.test.ts
+++ b/api/_lib/store-membership.test.ts
@@ -1,0 +1,350 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./supabase.js', () => ({ getSupabase: vi.fn() }))
+
+import { getSupabase } from './supabase.js'
+import {
+  countProjectAdmins,
+  createProject,
+  deleteInvite,
+  findInvite,
+  findInvitesForEmail,
+  getProjectMembership,
+  insertProjectMembership,
+} from './store.js'
+
+type SupabaseError = { code?: string; message: string }
+type Result<T> = { data?: T | null; error: SupabaseError | null; count?: number | null }
+
+interface StoreOpts {
+  projectsInsert?: Array<Result<Record<string, unknown>>>
+  projectsDelete?: Result<unknown>
+  membersInsert?: Result<unknown>
+  membersSelectMaybe?: Result<{ role: 'admin' | 'member' }>
+  membersCount?: Result<unknown>
+  repoInsert?: Result<unknown>
+  invitesSelectMaybe?: Result<Record<string, unknown>>
+  invitesSelectList?: Result<Record<string, unknown>[]>
+  invitesDelete?: Result<unknown>
+}
+
+function buildSupabase(opts: StoreOpts) {
+  const projectsInsertQueue = [...(opts.projectsInsert ?? [])]
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'projects') {
+        return {
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve(projectsInsertQueue.shift() ?? { data: null, error: null })),
+            })),
+          })),
+          delete: vi.fn(() => ({
+            eq: vi.fn(() => Promise.resolve(opts.projectsDelete ?? { data: null, error: null })),
+          })),
+        }
+      }
+      if (table === 'project_repo_configs') {
+        return {
+          insert: vi.fn(() => Promise.resolve(opts.repoInsert ?? { error: null })),
+        }
+      }
+      if (table === 'project_members') {
+        return {
+          insert: vi.fn(() => Promise.resolve(opts.membersInsert ?? { error: null })),
+          select: vi.fn((_cols: string, options?: { count?: string; head?: boolean }) => {
+            if (options?.count === 'exact') {
+              return {
+                eq: vi.fn(() => ({
+                  eq: vi.fn(() => Promise.resolve(opts.membersCount ?? { count: 0, error: null })),
+                })),
+              }
+            }
+            return {
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  maybeSingle: vi.fn(() => Promise.resolve(opts.membersSelectMaybe ?? { data: null, error: null })),
+                })),
+              })),
+            }
+          }),
+        }
+      }
+      if (table === 'project_invites') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn(() =>
+                  Promise.resolve(opts.invitesSelectMaybe ?? { data: null, error: null }),
+                ),
+              })),
+            })),
+          })),
+          delete: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => Promise.resolve(opts.invitesDelete ?? { error: null })),
+            })),
+          })),
+        }
+      }
+      throw new Error(`Unmocked table ${table}`)
+    }),
+  }
+}
+
+function buildInvitesListSupabase(result: Result<Record<string, unknown>[]>) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => Promise.resolve(result)),
+      })),
+    })),
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(getSupabase).mockReset()
+})
+
+const PROJECT_ROW = {
+  public_key: 'demo',
+  slug: 'demo',
+  name: 'demo',
+  claimable: true,
+  created_at: '',
+  updated_at: '',
+}
+
+describe('createProject (new branches)', () => {
+  it('uses an explicit publicKey without retry on collision', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        projectsInsert: [{ data: null, error: { code: '23505', message: 'dup' } }],
+      }) as never,
+    )
+
+    await expect(
+      createProject({ name: 'demo', publicKey: 'demo' }),
+    ).rejects.toThrow('dup')
+  })
+
+  it('rolls back the project when repo config insert fails', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        projectsInsert: [{ data: PROJECT_ROW, error: null }],
+        repoInsert: { error: { code: '50000', message: 'repo boom' } },
+        projectsDelete: { data: null, error: null },
+      }) as never,
+    )
+
+    await expect(createProject({ name: 'demo', publicKey: 'demo' })).rejects.toThrow('repo boom')
+  })
+
+  it('inserts an admin membership when userId is provided', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        projectsInsert: [{ data: PROJECT_ROW, error: null }],
+        repoInsert: { error: null },
+        membersInsert: { error: null },
+      }) as never,
+    )
+
+    const result = await createProject({ name: 'demo', publicKey: 'demo', userId: 'u-1' })
+    expect(result.publicKey).toBe('demo')
+    expect(result.claimable).toBe(true)
+  })
+
+  it('rolls back the project when membership insert fails', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        projectsInsert: [{ data: PROJECT_ROW, error: null }],
+        repoInsert: { error: null },
+        membersInsert: { error: { code: '50000', message: 'member boom' } },
+        projectsDelete: { data: null, error: null },
+      }) as never,
+    )
+
+    await expect(
+      createProject({ name: 'demo', publicKey: 'demo', userId: 'u-1' }),
+    ).rejects.toThrow('member boom')
+  })
+
+  it('throws "Project name required" when name is empty', async () => {
+    await expect(createProject({ name: '   ' })).rejects.toThrow('Project name required')
+  })
+})
+
+describe('getProjectMembership', () => {
+  it('returns the role for an existing member', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ membersSelectMaybe: { data: { role: 'admin' }, error: null } }) as never,
+    )
+
+    const role = await getProjectMembership('u-1', 'demo')
+    expect(role).toBe('admin')
+  })
+
+  it('returns null when there is no membership', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ membersSelectMaybe: { data: null, error: null } }) as never,
+    )
+
+    const role = await getProjectMembership('u-1', 'demo')
+    expect(role).toBeNull()
+  })
+
+  it('throws when Supabase errors', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ membersSelectMaybe: { data: null, error: { message: 'boom' } } }) as never,
+    )
+
+    await expect(getProjectMembership('u-1', 'demo')).rejects.toThrow('boom')
+  })
+})
+
+describe('countProjectAdmins', () => {
+  it('returns the admin count from Supabase', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ membersCount: { count: 3, error: null, data: null } }) as never,
+    )
+
+    expect(await countProjectAdmins('demo')).toBe(3)
+  })
+
+  it('returns 0 when the count is null', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ membersCount: { count: null, error: null, data: null } }) as never,
+    )
+
+    expect(await countProjectAdmins('demo')).toBe(0)
+  })
+
+  it('throws on Supabase error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ membersCount: { data: null, count: null, error: { message: 'boom' } } }) as never,
+    )
+
+    await expect(countProjectAdmins('demo')).rejects.toThrow('boom')
+  })
+})
+
+describe('insertProjectMembership', () => {
+  it('inserts a new membership', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ membersInsert: { error: null, data: null } }) as never,
+    )
+
+    await expect(
+      insertProjectMembership({ projectKey: 'demo', userId: 'u-1', role: 'member' }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('swallows 23505 (already a member)', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ membersInsert: { error: { code: '23505', message: 'dup' }, data: null } }) as never,
+    )
+
+    await expect(
+      insertProjectMembership({ projectKey: 'demo', userId: 'u-1', role: 'member' }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws on other Supabase errors', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ membersInsert: { error: { code: '50000', message: 'boom' }, data: null } }) as never,
+    )
+
+    await expect(
+      insertProjectMembership({ projectKey: 'demo', userId: 'u-1', role: 'member' }),
+    ).rejects.toThrow('boom')
+  })
+})
+
+describe('findInvite', () => {
+  it('lowercases the email and returns the invite row', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({
+        invitesSelectMaybe: {
+          data: {
+            project_key: 'demo',
+            email: 'a@example.com',
+            role: 'member',
+            invited_by: 'admin-1',
+            created_at: '',
+          },
+          error: null,
+        },
+      }) as never,
+    )
+
+    const invite = await findInvite('demo', 'A@Example.com')
+    expect(invite?.email).toBe('a@example.com')
+    expect(invite?.role).toBe('member')
+  })
+
+  it('returns null when no invite matches', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ invitesSelectMaybe: { data: null, error: null } }) as never,
+    )
+
+    expect(await findInvite('demo', 'a@example.com')).toBeNull()
+  })
+
+  it('throws on Supabase error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ invitesSelectMaybe: { data: null, error: { message: 'boom' } } }) as never,
+    )
+
+    await expect(findInvite('demo', 'a@example.com')).rejects.toThrow('boom')
+  })
+})
+
+describe('findInvitesForEmail', () => {
+  it('lowercases the email and returns mapped invites', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildInvitesListSupabase({
+        data: [
+          { project_key: 'p1', email: 'a@example.com', role: 'member', invited_by: 'admin-1', created_at: '' },
+          { project_key: 'p2', email: 'a@example.com', role: 'admin', invited_by: 'admin-2', created_at: '' },
+        ],
+        error: null,
+      }) as never,
+    )
+
+    const invites = await findInvitesForEmail('A@Example.com')
+    expect(invites.map((i) => i.projectKey)).toEqual(['p1', 'p2'])
+  })
+
+  it('returns an empty array when none match', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildInvitesListSupabase({ data: null, error: null }) as never,
+    )
+    expect(await findInvitesForEmail('a@example.com')).toEqual([])
+  })
+
+  it('throws on Supabase error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildInvitesListSupabase({ data: null, error: { message: 'boom' } }) as never,
+    )
+    await expect(findInvitesForEmail('a@example.com')).rejects.toThrow('boom')
+  })
+})
+
+describe('deleteInvite', () => {
+  it('lowercases the email when deleting', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ invitesDelete: { error: null, data: null } }) as never,
+    )
+
+    await expect(deleteInvite('demo', 'A@Example.com')).resolves.toBeUndefined()
+  })
+
+  it('throws on Supabase error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(
+      buildSupabase({ invitesDelete: { error: { message: 'boom' }, data: null } }) as never,
+    )
+
+    await expect(deleteInvite('demo', 'a@example.com')).rejects.toThrow('boom')
+  })
+})

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -22,8 +22,19 @@ type ProjectRow = {
   public_key: string
   slug: string
   name: string
+  claimable: boolean
   created_at: string
   updated_at: string
+}
+
+export type ProjectRole = 'admin' | 'member'
+
+type InviteRow = {
+  project_key: string
+  email: string
+  role: ProjectRole
+  invited_by: string
+  created_at: string
 }
 
 type RepoConfigRow = {
@@ -95,8 +106,21 @@ function mapProject(row: ProjectRow) {
     publicKey: row.public_key,
     slug: row.slug,
     name: row.name,
+    claimable: row.claimable,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+  }
+}
+
+const PROJECT_COLS = 'public_key, slug, name, claimable, created_at, updated_at'
+
+function mapInvite(row: InviteRow) {
+  return {
+    projectKey: row.project_key,
+    email: row.email,
+    role: row.role,
+    invitedBy: row.invited_by,
+    createdAt: row.created_at,
   }
 }
 
@@ -158,7 +182,7 @@ export async function listProjects() {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('projects')
-    .select('public_key, slug, name, created_at, updated_at')
+    .select(PROJECT_COLS)
     .order('created_at', { ascending: true })
 
   if (error) throw new Error(error.message)
@@ -178,18 +202,24 @@ function randomSuffix() {
   return Math.random().toString(36).slice(2, 8)
 }
 
-export async function createProject(input: { name: string }) {
+export async function createProject(input: {
+  name: string
+  publicKey?: string
+  userId?: string
+}) {
   const trimmed = input.name.trim()
   if (!trimmed) throw new Error('Project name required')
 
   const supabase = getSupabase()
-  const baseSlug = slugify(trimmed) || `project-${randomSuffix()}`
+  const explicitKey = input.publicKey?.trim()
+  const baseSlug = explicitKey || slugify(trimmed) || `project-${randomSuffix()}`
+  const maxAttempts = explicitKey ? 1 : 5
 
   let slug = baseSlug
   let projectData: ProjectRow | null = null
   let lastError: { code?: string; message: string } | null = null
 
-  for (let attempt = 0; attempt < 5; attempt++) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const { data, error } = await supabase
       .from('projects')
       .insert([{
@@ -198,7 +228,7 @@ export async function createProject(input: { name: string }) {
         name: trimmed,
         allowed_origins: [],
       }] as never)
-      .select('public_key, slug, name, created_at, updated_at')
+      .select(PROJECT_COLS)
       .single()
 
     if (!error) {
@@ -206,9 +236,9 @@ export async function createProject(input: { name: string }) {
       break
     }
 
-    // 23505 = unique_violation. Retry with new suffix; bail on anything else.
     if (error.code !== '23505') throw new Error(error.message)
     lastError = error
+    if (explicitKey) break
     slug = `${baseSlug}-${randomSuffix()}`
   }
 
@@ -223,19 +253,114 @@ export async function createProject(input: { name: string }) {
       default_branch: 'main',
     }] as never)
 
+  // Supabase REST has no transactions — on child-insert failure, drop the
+  // parent so the FKs cascade-clean repo + membership rows (see db/schema.ts).
   if (repoError) {
     await supabase.from('projects').delete().eq('public_key', slug)
     throw new Error(repoError.message)
   }
 
+  if (input.userId) {
+    const { error: memberError } = await supabase
+      .from('project_members')
+      .insert([{
+        project_key: slug,
+        user_id: input.userId,
+        role: 'admin',
+      }] as never)
+
+    if (memberError) {
+      await supabase.from('projects').delete().eq('public_key', slug)
+      throw new Error(memberError.message)
+    }
+  }
+
   return mapProject(projectData)
+}
+
+export async function getProjectMembership(userId: string, projectKey: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_members')
+    .select('role')
+    .eq('project_key', projectKey)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error) throw new Error(error.message)
+  return data ? (data as { role: ProjectRole }).role : null
+}
+
+export async function countProjectAdmins(projectKey: string) {
+  const supabase = getSupabase()
+  const { count, error } = await supabase
+    .from('project_members')
+    .select('user_id', { count: 'exact', head: true })
+    .eq('project_key', projectKey)
+    .eq('role', 'admin')
+
+  if (error) throw new Error(error.message)
+  return count ?? 0
+}
+
+export async function insertProjectMembership(input: {
+  projectKey: string
+  userId: string
+  role: ProjectRole
+}) {
+  const supabase = getSupabase()
+  const { error } = await supabase
+    .from('project_members')
+    .insert([{
+      project_key: input.projectKey,
+      user_id: input.userId,
+      role: input.role,
+    }] as never)
+
+  // 23505 = duplicate (already a member). Idempotent — swallow.
+  if (error && error.code !== '23505') throw new Error(error.message)
+}
+
+export async function findInvite(projectKey: string, email: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .select('project_key, email, role, invited_by, created_at')
+    .eq('project_key', projectKey)
+    .eq('email', email.toLowerCase())
+    .maybeSingle()
+
+  if (error) throw new Error(error.message)
+  return data ? mapInvite(data as InviteRow) : null
+}
+
+export async function findInvitesForEmail(email: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .select('project_key, email, role, invited_by, created_at')
+    .eq('email', email.toLowerCase())
+
+  if (error) throw new Error(error.message)
+  return (data || []).map((row) => mapInvite(row as InviteRow))
+}
+
+export async function deleteInvite(projectKey: string, email: string) {
+  const supabase = getSupabase()
+  const { error } = await supabase
+    .from('project_invites')
+    .delete()
+    .eq('project_key', projectKey)
+    .eq('email', email.toLowerCase())
+
+  if (error) throw new Error(error.message)
 }
 
 export async function getProject(projectKey: string) {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('projects')
-    .select('public_key, slug, name, created_at, updated_at')
+    .select(PROJECT_COLS)
     .eq('public_key', projectKey)
     .maybeSingle()
 
@@ -256,7 +381,7 @@ export async function ensurePublicProject(publicKey: string) {
       name: publicKey,
       allowed_origins: [],
     }] as never)
-    .select('public_key, slug, name, created_at, updated_at')
+    .select(PROJECT_COLS)
     .single()
 
   if (error) {

--- a/api/v1/me/bootstrap.test.ts
+++ b/api/v1/me/bootstrap.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({
+  requireUser: vi.fn(),
+}))
+
+vi.mock('../../_lib/store.js', () => ({
+  deleteInvite: vi.fn(),
+  findInvitesForEmail: vi.fn(),
+  insertProjectMembership: vi.fn(),
+}))
+
+import handler from './bootstrap.js'
+import { requireUser } from '../../_lib/auth.js'
+import { deleteInvite, findInvitesForEmail, insertProjectMembership } from '../../_lib/store.js'
+
+interface MockRes {
+  statusCode: number
+  body: unknown
+  headers: Record<string, string>
+  status(code: number): MockRes
+  json(data: unknown): MockRes
+  end(): MockRes
+  setHeader(key: string, value: string): void
+}
+
+function mockReq(overrides: Record<string, unknown> = {}) {
+  return { method: 'POST', query: {}, body: {}, headers: {}, ...overrides }
+}
+
+function mockRes(): MockRes {
+  return {
+    statusCode: 200,
+    body: null,
+    headers: {},
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(data) {
+      this.body = data
+      return this
+    },
+    end() {
+      return this
+    },
+    setHeader(key, value) {
+      this.headers[key] = value
+    },
+  }
+}
+
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+const USER = { userId: 'user-1', email: 'a@example.com' }
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(findInvitesForEmail).mockReset()
+  vi.mocked(insertProjectMembership).mockReset()
+  vi.mocked(deleteInvite).mockReset()
+})
+
+describe('POST /api/v1/me/bootstrap', () => {
+  it('returns 405 on non-POST', async () => {
+    const res = mockRes()
+    await call(mockReq({ method: 'GET' }), res)
+    expect(res.statusCode).toBe(405)
+  })
+
+  it('handles OPTIONS preflight', async () => {
+    const res = mockRes()
+    await call(mockReq({ method: 'OPTIONS' }), res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('aborts when unauthenticated', async () => {
+    vi.mocked(requireUser).mockResolvedValue(null)
+    const res = mockRes()
+    await call(mockReq(), res)
+    expect(findInvitesForEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns 0 when there are no pending invites', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    vi.mocked(findInvitesForEmail).mockResolvedValue([])
+
+    const res = mockRes()
+    await call(mockReq(), res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ redeemed: 0 })
+    expect(insertProjectMembership).not.toHaveBeenCalled()
+  })
+
+  it('redeems each pending invite into a membership and deletes the invite', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    vi.mocked(findInvitesForEmail).mockResolvedValue([
+      { projectKey: 'p1', email: 'a@example.com', role: 'member', invitedBy: 'admin-1', createdAt: '' },
+      { projectKey: 'p2', email: 'a@example.com', role: 'admin', invitedBy: 'admin-2', createdAt: '' },
+    ])
+
+    const res = mockRes()
+    await call(mockReq(), res)
+
+    expect(insertProjectMembership).toHaveBeenCalledTimes(2)
+    expect(insertProjectMembership).toHaveBeenNthCalledWith(1, {
+      projectKey: 'p1',
+      userId: 'user-1',
+      role: 'member',
+    })
+    expect(insertProjectMembership).toHaveBeenNthCalledWith(2, {
+      projectKey: 'p2',
+      userId: 'user-1',
+      role: 'admin',
+    })
+    expect(deleteInvite).toHaveBeenCalledTimes(2)
+    expect(res.body).toEqual({ redeemed: 2 })
+  })
+
+  it('returns 500 when the store throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    vi.mocked(findInvitesForEmail).mockRejectedValue(new Error('boom'))
+
+    const res = mockRes()
+    await call(mockReq(), res)
+
+    expect(res.statusCode).toBe(500)
+    expect((res.body as { error: string }).error).toBe('boom')
+  })
+})

--- a/api/v1/me/bootstrap.ts
+++ b/api/v1/me/bootstrap.ts
@@ -1,0 +1,30 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+import { deleteInvite, findInvitesForEmail, insertProjectMembership } from '../../_lib/store.js'
+
+const METHODS = ['POST', 'OPTIONS']
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, METHODS)) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, METHODS)
+
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  try {
+    const invites = await findInvitesForEmail(user.email)
+    for (const invite of invites) {
+      await insertProjectMembership({
+        projectKey: invite.projectKey,
+        userId: user.userId,
+        role: invite.role,
+      })
+      await deleteInvite(invite.projectKey, invite.email)
+    }
+    setCors(req, res, METHODS)
+    return res.status(200).json({ redeemed: invites.length })
+  } catch (error) {
+    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+  }
+}

--- a/api/v1/projects/claim.test.ts
+++ b/api/v1/projects/claim.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({
+  requireUser: vi.fn(),
+}))
+
+vi.mock('../../_lib/store.js', () => ({
+  countProjectAdmins: vi.fn(),
+  createProject: vi.fn(),
+  deleteInvite: vi.fn(),
+  findInvite: vi.fn(),
+  getProject: vi.fn(),
+  insertProjectMembership: vi.fn(),
+}))
+
+import handler from './claim.js'
+import { requireUser } from '../../_lib/auth.js'
+import {
+  countProjectAdmins,
+  createProject,
+  deleteInvite,
+  findInvite,
+  getProject,
+  insertProjectMembership,
+} from '../../_lib/store.js'
+
+interface MockRes {
+  statusCode: number
+  body: unknown
+  headers: Record<string, string>
+  status(code: number): MockRes
+  json(data: unknown): MockRes
+  end(): MockRes
+  setHeader(key: string, value: string): void
+}
+
+function mockReq(overrides: Record<string, unknown> = {}) {
+  return { method: 'POST', query: {}, body: {}, headers: {}, ...overrides }
+}
+
+function mockRes(): MockRes {
+  return {
+    statusCode: 200,
+    body: null,
+    headers: {},
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(data) {
+      this.body = data
+      return this
+    },
+    end() {
+      return this
+    },
+    setHeader(key, value) {
+      this.headers[key] = value
+    },
+  }
+}
+
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+const USER = { userId: 'user-1', email: 'a@example.com' }
+const PROJECT = {
+  publicKey: 'demo',
+  slug: 'demo',
+  name: 'demo',
+  claimable: true,
+  createdAt: '',
+  updatedAt: '',
+}
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(getProject).mockReset()
+  vi.mocked(createProject).mockReset()
+  vi.mocked(countProjectAdmins).mockReset()
+  vi.mocked(insertProjectMembership).mockReset()
+  vi.mocked(findInvite).mockReset()
+  vi.mocked(deleteInvite).mockReset()
+})
+
+describe('POST /api/v1/projects/claim', () => {
+  it('returns 405 on non-POST', async () => {
+    const res = mockRes()
+    await call(mockReq({ method: 'GET' }), res)
+    expect(res.statusCode).toBe(405)
+  })
+
+  it('handles OPTIONS preflight', async () => {
+    const res = mockRes()
+    await call(mockReq({ method: 'OPTIONS' }), res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(requireUser).mockResolvedValue(null)
+    const res = mockRes()
+    await call(mockReq({ body: { projectKey: 'demo' } }), res)
+    expect(requireUser).toHaveBeenCalled()
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('rejects missing projectKey', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    const res = mockRes()
+    await call(mockReq({ body: {} }), res)
+    expect(res.statusCode).toBe(400)
+    expect((res.body as { error: string }).error).toMatch(/Missing projectKey/)
+  })
+
+  it('rejects invalid projectKey format', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    const res = mockRes()
+    await call(mockReq({ body: { projectKey: 'BAD KEY!' } }), res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('creates a new project and assigns the user as admin when the key is unknown', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    vi.mocked(getProject).mockResolvedValue(null)
+    vi.mocked(createProject).mockResolvedValue(PROJECT)
+
+    const res = mockRes()
+    await call(mockReq({ body: { projectKey: 'demo' } }), res)
+
+    expect(createProject).toHaveBeenCalledWith({
+      name: 'demo',
+      publicKey: 'demo',
+      userId: 'user-1',
+    })
+    expect(res.statusCode).toBe(201)
+    expect(res.body).toEqual({ project: PROJECT, role: 'admin', created: true })
+  })
+
+  it('joins an existing claimable project as admin when no admins yet', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    vi.mocked(getProject).mockResolvedValue(PROJECT)
+    vi.mocked(countProjectAdmins).mockResolvedValue(0)
+
+    const res = mockRes()
+    await call(mockReq({ body: { projectKey: 'demo' } }), res)
+
+    expect(insertProjectMembership).toHaveBeenCalledWith({
+      projectKey: 'demo',
+      userId: 'user-1',
+      role: 'admin',
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ project: PROJECT, role: 'admin', created: false })
+  })
+
+  it('joins an existing claimable project as member when an admin already exists', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    vi.mocked(getProject).mockResolvedValue(PROJECT)
+    vi.mocked(countProjectAdmins).mockResolvedValue(1)
+
+    const res = mockRes()
+    await call(mockReq({ body: { projectKey: 'demo' } }), res)
+
+    expect(insertProjectMembership).toHaveBeenCalledWith({
+      projectKey: 'demo',
+      userId: 'user-1',
+      role: 'member',
+    })
+    expect(res.body).toEqual({ project: PROJECT, role: 'member', created: false })
+  })
+
+  it('redeems an invite on an invite-only project', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    vi.mocked(getProject).mockResolvedValue({ ...PROJECT, claimable: false })
+    vi.mocked(findInvite).mockResolvedValue({
+      projectKey: 'demo',
+      email: 'a@example.com',
+      role: 'member',
+      invitedBy: 'admin-1',
+      createdAt: '',
+    })
+
+    const res = mockRes()
+    await call(mockReq({ body: { projectKey: 'demo' } }), res)
+
+    expect(findInvite).toHaveBeenCalledWith('demo', 'a@example.com')
+    expect(insertProjectMembership).toHaveBeenCalledWith({
+      projectKey: 'demo',
+      userId: 'user-1',
+      role: 'member',
+    })
+    expect(deleteInvite).toHaveBeenCalledWith('demo', 'a@example.com')
+    expect(res.body).toEqual({ project: { ...PROJECT, claimable: false }, role: 'member', created: false })
+  })
+
+  it('rejects with 403 when project is invite-only and no invite matches', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    vi.mocked(getProject).mockResolvedValue({ ...PROJECT, claimable: false })
+    vi.mocked(findInvite).mockResolvedValue(null)
+
+    const res = mockRes()
+    await call(mockReq({ body: { projectKey: 'demo' } }), res)
+
+    expect(res.statusCode).toBe(403)
+    expect(insertProjectMembership).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when the store throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue(USER)
+    vi.mocked(getProject).mockRejectedValue(new Error('db down'))
+
+    const res = mockRes()
+    await call(mockReq({ body: { projectKey: 'demo' } }), res)
+
+    expect(res.statusCode).toBe(500)
+    expect((res.body as { error: string }).error).toBe('db down')
+  })
+})

--- a/api/v1/projects/claim.ts
+++ b/api/v1/projects/claim.ts
@@ -1,0 +1,59 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+import {
+  countProjectAdmins,
+  createProject,
+  deleteInvite,
+  findInvite,
+  getProject,
+  insertProjectMembership,
+  type ProjectRole,
+} from '../../_lib/store.js'
+
+const METHODS = ['POST', 'OPTIONS']
+
+const KEY_PATTERN = /^[a-z0-9][a-z0-9-]{0,59}$/
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, METHODS)) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, METHODS)
+
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const body = (req.body ?? {}) as { projectKey?: unknown }
+  const rawKey = typeof body.projectKey === 'string' ? body.projectKey.trim().toLowerCase() : ''
+  if (!rawKey) return jsonError(req, res, 400, 'Missing projectKey')
+  if (!KEY_PATTERN.test(rawKey)) {
+    return jsonError(req, res, 400, 'projectKey must be lowercase alphanumeric + hyphens (max 60 chars)')
+  }
+
+  try {
+    const existing = await getProject(rawKey)
+
+    if (!existing) {
+      const project = await createProject({ name: rawKey, publicKey: rawKey, userId: user.userId })
+      setCors(req, res, METHODS)
+      return res.status(201).json({ project, role: 'admin', created: true })
+    }
+
+    if (existing.claimable) {
+      const adminCount = await countProjectAdmins(rawKey)
+      const role: ProjectRole = adminCount === 0 ? 'admin' : 'member'
+      await insertProjectMembership({ projectKey: rawKey, userId: user.userId, role })
+      setCors(req, res, METHODS)
+      return res.status(200).json({ project: existing, role, created: false })
+    }
+
+    const invite = await findInvite(rawKey, user.email)
+    if (!invite) return jsonError(req, res, 403, 'Project is invite-only')
+
+    await insertProjectMembership({ projectKey: rawKey, userId: user.userId, role: invite.role })
+    await deleteInvite(rawKey, user.email)
+    setCors(req, res, METHODS)
+    return res.status(200).json({ project: existing, role: invite.role, created: false })
+  } catch (error) {
+    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+  }
+}

--- a/api/v1/public/comments.test.ts
+++ b/api/v1/public/comments.test.ts
@@ -90,6 +90,7 @@ describe('api/v1/public/comments', () => {
       publicKey: 'missing',
       slug: 'missing',
       name: 'missing',
+      claimable: true,
       createdAt: '',
       updatedAt: '',
     })
@@ -131,6 +132,7 @@ describe('api/v1/public/comments', () => {
       publicKey: 'demo-project',
       slug: 'demo-project',
       name: 'Demo',
+      claimable: true,
       createdAt: '',
       updatedAt: '',
     })


### PR DESCRIPTION
- ~885 of the changed lines are vitest specs covering every new code path — production code is ~280 lines. Diff coverage is 100% line + branch vs trunk.
- New `requireUser` helper turns a Bearer JWT into a verified `{ userId, email }` by calling `supabase.auth.getUser`, with 401s for missing / rejected / no-email tokens. Companion `requireProjectMembership` + `requireProjectAdmin` enforce per-project authorization in handlers.
- New `POST /api/v1/projects/claim` covers all four outcomes in one endpoint — unknown key → create the project and assign the user as admin; existing claimable + no admins → admin; existing claimable + has admins → member; invite-only → redeem the matching invite or 403.
- New `POST /api/v1/me/bootstrap` redeems every pending invite for the signed-in user's email on login, so admins can pre-authorize teammates by email before signup.
- `createProject` now accepts an explicit `publicKey` (skips the slug-retry loop) and optional `userId` (auto-inserts the admin membership), with cascade-rollback on child-insert failures since Supabase REST has no transactions.
- Stacks on top of #100 (schema foundation). `requireReviewer` is intentionally left in place — it's removed in the final PR of the stack.