### PR TITLE
Switch dashboard routes to Supabase user sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,11 @@ VITE_API_BASE=https://your-deployment.vercel.app/api
 # Demo app — project namespace for comments
 VITE_PROJECT_ID=demo-project
 
-# Optional dashboard token seed for local reviewer UI
-VITE_REVIEWER_TOKEN=replace-me
-
-# Server — Supabase credentials used by the API routes
+# Supabase — URL + anon (publishable) key.
+# SUPABASE_KEY is the anon key: baked into the dashboard bundle at build time
+# (see apps/dashboard/vite.config.ts) and also used server-side by api/_lib/supabase.ts.
 SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_KEY=your-supabase-service-role-key # use service_role key (not anon) — found in Supabase dashboard → Settings → API
+SUPABASE_KEY=your-supabase-anon-key
 
 # Server — Postgres connection string for Drizzle migrations (schema management only).
 # Use Direct connection (port 5432) from Supabase dashboard → Project Settings → Database.

--- a/api/v1/comments/[commentId]/implementation-status.test.ts
+++ b/api/v1/comments/[commentId]/implementation-status.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({
+  createFeedbackEvent: vi.fn(),
+  findActiveSharesForComment: vi.fn(),
+  updateImplementationStatus: vi.fn(),
+}))
+
+import handler from './implementation-status.js'
+import { requireUser } from '../../../_lib/auth.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+})
+
+describe('api/v1/comments/[commentId]/implementation-status', () => {
+  it('returns 401 when requireUser rejects', async () => {
+    vi.mocked(requireUser).mockImplementation(async (_req, res) => {
+      res.status(401).json({ error: 'Unauthorized' })
+      return null
+    })
+
+    const res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('proceeds past the guard when requireUser returns a user', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    const res = mockRes()
+    await call({ method: 'PATCH', query: {}, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/api/v1/comments/[commentId]/implementation-status.ts
+++ b/api/v1/comments/[commentId]/implementation-status.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireReviewer } from '../../../_lib/auth.js'
+import { requireUser } from '../../../_lib/auth.js'
 import { createFeedbackEvent, findActiveSharesForComment, updateImplementationStatus } from '../../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
 import { IMPLEMENTATION_STATUSES, type ImplementationStatus } from '../../../_lib/status.js'
@@ -9,7 +9,8 @@ const VALID_STATUSES = new Set<ImplementationStatus>(IMPLEMENTATION_STATUSES)
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['PATCH', 'OPTIONS'])) return
   if (req.method !== 'PATCH') return methodNotAllowed(req, res, ['PATCH', 'OPTIONS'])
-  if (!requireReviewer(req, res)) return
+  // TODO(membership): fetch comment → require membership on comment.projectId.
+  if (!(await requireUser(req, res))) return
 
   try {
     const commentId = getStringQuery(req.query.commentId)

--- a/api/v1/comments/[commentId]/review-status.test.ts
+++ b/api/v1/comments/[commentId]/review-status.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({
+  createFeedbackEvent: vi.fn(),
+  findActiveSharesForComment: vi.fn(),
+  updateReviewStatus: vi.fn(),
+}))
+
+import handler from './review-status.js'
+import { requireUser } from '../../../_lib/auth.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+})
+
+describe('api/v1/comments/[commentId]/review-status', () => {
+  it('returns 401 when requireUser rejects', async () => {
+    vi.mocked(requireUser).mockImplementation(async (_req, res) => {
+      res.status(401).json({ error: 'Unauthorized' })
+      return null
+    })
+
+    const res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('proceeds past the guard when requireUser returns a user', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    const res = mockRes()
+    await call({ method: 'PATCH', query: {}, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/api/v1/comments/[commentId]/review-status.ts
+++ b/api/v1/comments/[commentId]/review-status.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireReviewer } from '../../../_lib/auth.js'
+import { requireUser } from '../../../_lib/auth.js'
 import { createFeedbackEvent, findActiveSharesForComment, updateReviewStatus } from '../../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
 import type { ReviewStatus } from '../../../_lib/status.js'
@@ -9,7 +9,8 @@ const VALID_STATUSES = new Set<ReviewStatus>(['open', 'accepted', 'rejected'])
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['PATCH', 'OPTIONS'])) return
   if (req.method !== 'PATCH') return methodNotAllowed(req, res, ['PATCH', 'OPTIONS'])
-  if (!requireReviewer(req, res)) return
+  // TODO(membership): fetch comment → require membership on comment.projectId.
+  if (!(await requireUser(req, res))) return
 
   try {
     const commentId = getStringQuery(req.query.commentId)

--- a/api/v1/feedback-shares/[shareId]/prompt.test.ts
+++ b/api/v1/feedback-shares/[shareId]/prompt.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({
+  getProject: vi.fn(),
+  getRepoConfig: vi.fn(),
+  getShareById: vi.fn(),
+}))
+vi.mock('../../../_lib/prompts.js', () => ({ buildPrompt: vi.fn() }))
+vi.mock('../../../_lib/tokens.js', () => ({ decryptToken: vi.fn() }))
+
+import handler from './prompt.js'
+import { requireUser } from '../../../_lib/auth.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+})
+
+describe('api/v1/feedback-shares/[shareId]/prompt', () => {
+  it('returns 401 when requireUser rejects', async () => {
+    vi.mocked(requireUser).mockImplementation(async (_req, res) => {
+      res.status(401).json({ error: 'Unauthorized' })
+      return null
+    })
+
+    const res = mockRes()
+    await call({ method: 'GET', query: { shareId: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('proceeds past the guard when requireUser returns a user', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/api/v1/feedback-shares/[shareId]/prompt.ts
+++ b/api/v1/feedback-shares/[shareId]/prompt.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireReviewer } from '../../../_lib/auth.js'
+import { requireUser } from '../../../_lib/auth.js'
 import { getAppUrl, handleOptions, jsonError, methodNotAllowed, setCors, getStringQuery } from '../../../_lib/http.js'
 import { getProject, getRepoConfig, getShareById } from '../../../_lib/store.js'
 import { buildPrompt } from '../../../_lib/prompts.js'
@@ -8,7 +8,8 @@ import { decryptToken } from '../../../_lib/tokens.js'
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
   if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
-  if (!requireReviewer(req, res)) return
+  // TODO(membership): fetch share → require membership on share.projectId.
+  if (!(await requireUser(req, res))) return
 
   try {
     const shareId = getStringQuery(req.query.shareId)

--- a/api/v1/feedback-shares/index.test.ts
+++ b/api/v1/feedback-shares/index.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../_lib/auth.js', () => ({
-  requireReviewer: vi.fn(() => true),
+  requireUser: vi.fn(),
 }))
 
 vi.mock('../../_lib/store.js', () => ({
@@ -20,6 +20,7 @@ vi.mock('../../_lib/tokens.js', () => ({
 }))
 
 import handler from './index.js'
+import { requireUser } from '../../_lib/auth.js'
 import {
   addShareItems,
   createFeedbackEvent,
@@ -69,6 +70,8 @@ const call = (req: unknown, res: unknown) =>
 
 beforeEach(() => {
   process.env.APP_URL = 'https://app.example'
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(requireUser).mockResolvedValue({ userId: 'u-test', email: 'test@example.com' })
   vi.mocked(listAcceptedCommentsForPage).mockReset()
   vi.mocked(listAcceptedCommentsByIds).mockReset()
   vi.mocked(createShare).mockReset()
@@ -77,6 +80,17 @@ beforeEach(() => {
 })
 
 describe('api/v1/feedback-shares', () => {
+  it('returns 401 when requireUser rejects', async () => {
+    vi.mocked(requireUser).mockImplementation(async (_req, res) => {
+      res.status(401).json({ error: 'Unauthorized' })
+      return null
+    })
+
+    const res = mockRes()
+    await call(mockReq({ body: {} }), res)
+    expect(res.statusCode).toBe(401)
+  })
+
   it('creates a page-scoped share from accepted comments', async () => {
     vi.mocked(listAcceptedCommentsForPage).mockResolvedValue([
       { id: 'comment-1' },

--- a/api/v1/feedback-shares/index.ts
+++ b/api/v1/feedback-shares/index.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireReviewer } from '../../_lib/auth.js'
+import { requireUser } from '../../_lib/auth.js'
 import { createFeedbackEvent, createShare, addShareItems, listAcceptedCommentsByIds, listAcceptedCommentsForPage } from '../../_lib/store.js'
 import { generateAccessToken, generateSlug, hashToken, encryptToken } from '../../_lib/tokens.js'
 import { getAppUrl, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
@@ -7,7 +7,8 @@ import { getAppUrl, handleOptions, jsonError, methodNotAllowed, setCors } from '
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
   if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
-  if (!requireReviewer(req, res)) return
+  // TODO(membership): require membership on body.projectId.
+  if (!(await requireUser(req, res))) return
 
   try {
     const { projectId, scopeType, pageUrl, commentIds } = req.body ?? {}

--- a/api/v1/projects/[projectId]/comments.test.ts
+++ b/api/v1/projects/[projectId]/comments.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({ listComments: vi.fn() }))
+
+import handler from './comments.js'
+import { requireUser } from '../../../_lib/auth.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+})
+
+describe('api/v1/projects/[projectId]/comments', () => {
+  it('returns 401 when requireUser rejects', async () => {
+    vi.mocked(requireUser).mockImplementation(async (_req, res) => {
+      res.status(401).json({ error: 'Unauthorized' })
+      return null
+    })
+
+    const res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('proceeds past the guard when requireUser returns a user', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/api/v1/projects/[projectId]/comments.ts
+++ b/api/v1/projects/[projectId]/comments.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireReviewer } from '../../../_lib/auth.js'
+import { requireUser } from '../../../_lib/auth.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
 import { listComments } from '../../../_lib/store.js'
 import type { ImplementationStatus, ReviewStatus } from '../../../_lib/status.js'
@@ -10,7 +10,8 @@ const IMPLEMENTATION_STATUSES = new Set<ImplementationStatus>(['unassigned', 'cl
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
   if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
-  if (!requireReviewer(req, res)) return
+  // TODO(membership): require requireProjectMembership(user, projectId).
+  if (!(await requireUser(req, res))) return
 
   try {
     const projectId = getStringQuery(req.query.projectId)

--- a/api/v1/projects/index.test.ts
+++ b/api/v1/projects/index.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({
+  createProject: vi.fn(),
+  listProjects: vi.fn(),
+}))
+
+import handler from './index.js'
+import { requireUser } from '../../_lib/auth.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+})
+
+describe('api/v1/projects', () => {
+  it('returns 401 when requireUser rejects', async () => {
+    vi.mocked(requireUser).mockImplementation(async (_req, res) => {
+      res.status(401).json({ error: 'Unauthorized' })
+      return null
+    })
+
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('proceeds past the guard when requireUser returns a user', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/api/v1/projects/index.ts
+++ b/api/v1/projects/index.ts
@@ -1,12 +1,13 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireReviewer } from '../../_lib/auth.js'
+import { requireUser } from '../../_lib/auth.js'
 import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
 import { createProject, listProjects } from '../../_lib/store.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['GET', 'POST', 'OPTIONS'])) return
   if (req.method !== 'GET' && req.method !== 'POST') return methodNotAllowed(req, res, ['GET', 'POST', 'OPTIONS'])
-  if (!requireReviewer(req, res)) return
+  // TODO(membership): filter listProjects by membership + drop POST in favor of claim endpoint.
+  if (!(await requireUser(req, res))) return
 
   try {
     if (req.method === 'GET') {

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -3,6 +3,7 @@ import { updateImplementationStatus as apiUpdateImpl, updateReviewStatus as apiU
 import { useProjects } from './hooks/useProjects'
 import { useComments } from './hooks/useComments'
 import { useAgentSession } from './hooks/useAgentSession'
+import { useAuth } from './hooks/useAuth'
 import { getDisplayStatus, isInactive, mapServerComment } from './lib/comment'
 import { AGENTS, type Comment, type ImplStatus, type ReviewStatus, type StatusFilter } from './lib/types'
 import { Header } from './components/Header'
@@ -11,16 +12,33 @@ import { CommentDetail } from './components/CommentDetail'
 import { AgentSidebar } from './components/AgentSidebar'
 import { StatusBar } from './components/StatusBar'
 import { CommandPalette } from './components/CommandPalette'
+import { LoginPage } from './components/LoginPage'
+import { Spinner } from './components/primitives'
 
 const API_BASE = import.meta.env.VITE_API_BASE || '/api'
-const REVIEWER_TOKEN = import.meta.env.VITE_REVIEWER_TOKEN || ''
 
 export function App() {
-  const { projects, loading: projectsLoading, error: projectsError, createProject } = useProjects(API_BASE, REVIEWER_TOKEN)
+  const { session, user, loading: authLoading, signOut } = useAuth()
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <Spinner size={20} />
+      </div>
+    )
+  }
+
+  if (!session || !user) return <LoginPage />
+
+  return <AuthenticatedApp accessToken={session.access_token} user={user} onSignOut={signOut} />
+}
+
+function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: string; user: import('@supabase/supabase-js').User; onSignOut: () => void }) {
+  const { projects, loading: projectsLoading, error: projectsError, createProject } = useProjects(API_BASE, accessToken)
   const [selectedProject, setSelectedProject] = useState<string>('')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const [selectedCommentId, setSelectedCommentId] = useState<string>('')
-  const { comments: serverComments, loading: commentsLoading, error: commentsError, refresh: refreshComments } = useComments(API_BASE, REVIEWER_TOKEN, selectedProject || null)
+  const { comments: serverComments, loading: commentsLoading, error: commentsError, refresh: refreshComments } = useComments(API_BASE, accessToken, selectedProject || null)
   const [comments, setComments] = useState<Comment[]>([])
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [cmdOpen, setCmdOpen] = useState(false)
@@ -90,7 +108,7 @@ export function App() {
   const handleReviewStatus = useCallback(async (id: string, status: ReviewStatus) => {
     setComments((prev) => prev.map((c) => c.id === id ? { ...c, reviewStatus: status, updatedAt: new Date().toISOString() } : c))
     try {
-      await apiUpdateReview(API_BASE, REVIEWER_TOKEN, id, status)
+      await apiUpdateReview(API_BASE, accessToken, id, status)
     } catch (err) {
       console.error('Failed to update review status:', err)
       refreshComments()
@@ -105,7 +123,7 @@ export function App() {
       ? { ...c, implementationStatus: nextStatus, updatedAt: new Date().toISOString() }
       : c))
     try {
-      await apiUpdateImpl(API_BASE, REVIEWER_TOKEN, id, nextStatus)
+      await apiUpdateImpl(API_BASE, accessToken, id, nextStatus)
     } catch (err) {
       console.error('Failed to update implementation status:', err)
       refreshComments()
@@ -145,11 +163,11 @@ export function App() {
     exitBulkMode()
 
     const calls: Promise<unknown>[] = ids.flatMap((id) => {
-      if (action === 'ready') return [apiUpdateReview(API_BASE, REVIEWER_TOKEN, id, 'accepted')]
-      if (action === 'reject') return [apiUpdateReview(API_BASE, REVIEWER_TOKEN, id, 'rejected')]
+      if (action === 'ready') return [apiUpdateReview(API_BASE, accessToken, id, 'accepted')]
+      if (action === 'reject') return [apiUpdateReview(API_BASE, accessToken, id, 'rejected')]
       return [
-        apiUpdateReview(API_BASE, REVIEWER_TOKEN, id, 'accepted'),
-        apiUpdateImpl(API_BASE, REVIEWER_TOKEN, id, 'done'),
+        apiUpdateReview(API_BASE, accessToken, id, 'accepted'),
+        apiUpdateImpl(API_BASE, accessToken, id, 'done'),
       ]
     })
 
@@ -293,6 +311,8 @@ export function App() {
         onOpenCmd={() => setCmdOpen(true)}
         theme={theme}
         toggleTheme={() => setTheme((t) => t === 'light' ? 'dark' : 'light')}
+        user={user}
+        onSignOut={onSignOut}
       />
 
       <div className="flex flex-1 overflow-hidden">

--- a/apps/dashboard/api.ts
+++ b/apps/dashboard/api.ts
@@ -94,10 +94,10 @@ export interface ShareEventsResponse {
   nextCursor: number
 }
 
-function authHeaders(reviewerToken?: string) {
+function authHeaders(accessToken?: string) {
   const headers: Record<string, string> = {}
-  if (reviewerToken) {
-    headers.Authorization = `Bearer ${reviewerToken}`
+  if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`
   }
   return headers
 }
@@ -118,75 +118,75 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   }
 }
 
-export function listProjects(apiBase: string, reviewerToken: string) {
+export function listProjects(apiBase: string, accessToken: string) {
   return requestJson<Project[]>(`${apiBase}/v1/projects`, {
     headers: {
-      ...authHeaders(reviewerToken),
+      ...authHeaders(accessToken),
     },
   })
 }
 
-export function createProject(apiBase: string, reviewerToken: string, name: string) {
+export function createProject(apiBase: string, accessToken: string, name: string) {
   return requestJson<Project>(`${apiBase}/v1/projects`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...authHeaders(reviewerToken),
+      ...authHeaders(accessToken),
     },
     body: JSON.stringify({ name }),
   })
 }
 
-export function listComments(apiBase: string, reviewerToken: string, projectId: string, pageUrl?: string) {
+export function listComments(apiBase: string, accessToken: string, projectId: string, pageUrl?: string) {
   const query = new URLSearchParams()
   if (pageUrl) query.set('pageUrl', pageUrl)
   const suffix = query.toString() ? `?${query.toString()}` : ''
   return requestJson<CommentRecord[]>(`${apiBase}/v1/projects/${encodeURIComponent(projectId)}/comments${suffix}`, {
     headers: {
-      ...authHeaders(reviewerToken),
+      ...authHeaders(accessToken),
     },
   })
 }
 
-export function updateReviewStatus(apiBase: string, reviewerToken: string, commentId: string, reviewStatus: CommentRecord['reviewStatus']) {
+export function updateReviewStatus(apiBase: string, accessToken: string, commentId: string, reviewStatus: CommentRecord['reviewStatus']) {
   return requestJson<CommentRecord>(`${apiBase}/v1/comments/${encodeURIComponent(commentId)}/review-status`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
-      ...authHeaders(reviewerToken),
+      ...authHeaders(accessToken),
     },
     body: JSON.stringify({ reviewStatus }),
   })
 }
 
-export function updateImplementationStatus(apiBase: string, reviewerToken: string, commentId: string, implementationStatus: CommentRecord['implementationStatus']) {
+export function updateImplementationStatus(apiBase: string, accessToken: string, commentId: string, implementationStatus: CommentRecord['implementationStatus']) {
   return requestJson<CommentRecord>(`${apiBase}/v1/comments/${encodeURIComponent(commentId)}/implementation-status`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
-      ...authHeaders(reviewerToken),
+      ...authHeaders(accessToken),
     },
     body: JSON.stringify({ implementationStatus }),
   })
 }
 
-export function createShare(apiBase: string, reviewerToken: string, body: Record<string, unknown>) {
+export function createShare(apiBase: string, accessToken: string, body: Record<string, unknown>) {
   return requestJson<ShareCreationResponse>(`${apiBase}/v1/feedback-shares`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...authHeaders(reviewerToken),
+      ...authHeaders(accessToken),
     },
     body: JSON.stringify(body),
   })
 }
 
-export function getPrompt(apiBase: string, reviewerToken: string, shareId: string, target: 'codex' | 'claude-code' | 'generic') {
+export function getPrompt(apiBase: string, accessToken: string, shareId: string, target: 'codex' | 'claude-code' | 'generic') {
   return requestJson<{ prompt: string, tokenUrl: string }>(
     `${apiBase}/v1/feedback-shares/${encodeURIComponent(shareId)}/prompt?target=${encodeURIComponent(target)}`,
     {
       headers: {
-        ...authHeaders(reviewerToken),
+        ...authHeaders(accessToken),
       },
     },
   )

--- a/apps/dashboard/components/Header.tsx
+++ b/apps/dashboard/components/Header.tsx
@@ -1,9 +1,11 @@
+import type { User } from '@supabase/supabase-js'
 import { cn } from '../lib/utils'
 import type { Project } from '../api'
 import type { StatusFilter } from '../lib/types'
 import { LogoIcon, MoonIcon, PlusIcon, SearchIcon, SunIcon } from './icons'
 import { Spinner } from './primitives'
 import { AddProjectPopover } from './AddProjectPopover'
+import { UserMenu } from './UserMenu'
 
 interface HeaderProps {
   projects: Project[]
@@ -23,6 +25,8 @@ interface HeaderProps {
   onOpenCmd: () => void
   theme: 'light' | 'dark'
   toggleTheme: () => void
+  user: User
+  onSignOut: () => void
 }
 
 export function Header({
@@ -43,6 +47,8 @@ export function Header({
   onOpenCmd,
   theme,
   toggleTheme,
+  user,
+  onSignOut,
 }: HeaderProps) {
   return (
     <header className="flex items-center gap-3 px-5 h-[52px] shrink-0 border-b border-border bg-card">
@@ -134,9 +140,7 @@ export function Header({
         >
           {theme === 'light' ? <MoonIcon /> : <SunIcon />}
         </button>
-        <div className="w-7 h-7 rounded-full bg-primary/10 flex items-center justify-center text-xs font-bold text-primary">
-          TO
-        </div>
+        <UserMenu user={user} onSignOut={onSignOut} />
       </div>
     </header>
   )

--- a/apps/dashboard/components/LoginPage.tsx
+++ b/apps/dashboard/components/LoginPage.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react'
+import { supabase } from '../lib/supabase'
+import { LogoIcon } from './icons'
+import { Spinner } from './primitives'
+
+type Mode = 'signin' | 'signup'
+
+export function LoginPage() {
+  const [mode, setMode] = useState<Mode>('signin')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [signupSent, setSignupSent] = useState(false)
+
+  async function handleEmailSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setBusy(true)
+    try {
+      if (mode === 'signin') {
+        const { error: signinError } = await supabase.auth.signInWithPassword({ email, password })
+        if (signinError) throw signinError
+      } else {
+        const { error: signupError } = await supabase.auth.signUp({
+          email,
+          password,
+          options: { emailRedirectTo: window.location.origin },
+        })
+        if (signupError) throw signupError
+        setSignupSent(true)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Authentication failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleGoogle() {
+    setError(null)
+    setBusy(true)
+    try {
+      const { error: oauthError } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: { redirectTo: window.location.origin },
+      })
+      if (oauthError) throw oauthError
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Google sign-in failed')
+      setBusy(false)
+    }
+  }
+
+  if (signupSent) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background px-4">
+        <div className="w-full max-w-sm rounded-lg border border-border bg-card p-6 text-center">
+          <div className="w-10 h-10 rounded-md bg-primary mx-auto mb-3 flex items-center justify-center">
+            <LogoIcon />
+          </div>
+          <h1 className="text-base font-semibold text-foreground mb-1">Check your email</h1>
+          <p className="text-xs text-muted-foreground">
+            We sent a confirmation link to <span className="font-medium text-foreground">{email}</span>. Click it, then come back here to sign in.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm rounded-lg border border-border bg-card p-6">
+        <div className="flex flex-col items-center mb-5">
+          <div className="w-10 h-10 rounded-md bg-primary mb-3 flex items-center justify-center">
+            <LogoIcon />
+          </div>
+          <h1 className="text-base font-semibold text-foreground">
+            {mode === 'signin' ? 'Sign in to feedback' : 'Create your account'}
+          </h1>
+        </div>
+
+        <button
+          onClick={handleGoogle}
+          disabled={busy}
+          className="w-full flex items-center justify-center gap-2 h-9 rounded-md border border-border bg-background text-xs font-medium text-foreground hover:bg-accent disabled:opacity-50 transition-colors mb-3"
+        >
+          <GoogleMark />
+          Continue with Google
+        </button>
+
+        <div className="flex items-center gap-2 my-3">
+          <div className="flex-1 h-px bg-border" />
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">or</span>
+          <div className="flex-1 h-px bg-border" />
+        </div>
+
+        <form onSubmit={handleEmailSubmit} className="space-y-2">
+          <input
+            type="email"
+            required
+            autoComplete="email"
+            placeholder="you@company.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={busy}
+            className="w-full h-9 px-3 rounded-md border border-border bg-background text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary disabled:opacity-50"
+          />
+          <input
+            type="password"
+            required
+            autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={busy}
+            minLength={6}
+            className="w-full h-9 px-3 rounded-md border border-border bg-background text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary disabled:opacity-50"
+          />
+          {error && (
+            <p className="text-[11px] text-status-rejected">{error}</p>
+          )}
+          <button
+            type="submit"
+            disabled={busy}
+            className="w-full h-9 rounded-md bg-primary text-primary-foreground text-xs font-semibold flex items-center justify-center hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            {busy ? <Spinner size={14} strokeWidth={3} className="text-primary-foreground" /> : mode === 'signin' ? 'Sign in' : 'Create account'}
+          </button>
+        </form>
+
+        <button
+          onClick={() => { setMode((m) => m === 'signin' ? 'signup' : 'signin'); setError(null) }}
+          className="block w-full text-center text-[11px] text-muted-foreground hover:text-foreground transition-colors mt-4"
+        >
+          {mode === 'signin' ? 'No account? Sign up' : 'Already have an account? Sign in'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function GoogleMark() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 18 18" aria-hidden="true">
+      <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.71-1.58 2.68-3.9 2.68-6.62z" />
+      <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.81.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z" />
+      <path fill="#FBBC05" d="M3.97 10.72A5.4 5.4 0 0 1 3.68 9c0-.6.1-1.18.29-1.72V4.95H.96A9 9 0 0 0 0 9c0 1.45.35 2.83.96 4.05l3.01-2.33z" />
+      <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58A9 9 0 0 0 9 0a9 9 0 0 0-8.04 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z" />
+    </svg>
+  )
+}

--- a/apps/dashboard/components/UserMenu.tsx
+++ b/apps/dashboard/components/UserMenu.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+
+interface UserMenuProps {
+  user: User
+  onSignOut: () => void
+}
+
+export function UserMenu({ user, onSignOut }: UserMenuProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement | null>(null)
+  const initials = (user.email ?? '??').slice(0, 2).toUpperCase()
+
+  useEffect(() => {
+    if (!open) return
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    window.addEventListener('mousedown', onClick)
+    return () => window.removeEventListener('mousedown', onClick)
+  }, [open])
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-7 h-7 rounded-full bg-primary/10 flex items-center justify-center text-xs font-bold text-primary hover:bg-primary/20 transition-colors"
+        title={user.email ?? ''}
+      >
+        {initials}
+      </button>
+      {open && (
+        <div className="absolute right-0 top-9 w-56 rounded-md border border-border bg-card shadow-lg z-50 overflow-hidden">
+          <div className="px-3 py-2 border-b border-border">
+            <div className="text-[11px] text-muted-foreground">Signed in as</div>
+            <div className="text-xs font-medium text-foreground truncate">{user.email}</div>
+          </div>
+          <button
+            onClick={onSignOut}
+            className="w-full text-left px-3 py-2 text-xs text-foreground hover:bg-accent transition-colors"
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/hooks/useAuth.ts
+++ b/apps/dashboard/hooks/useAuth.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+import type { Session, User } from '@supabase/supabase-js'
+import { supabase } from '../lib/supabase'
+
+export interface UseAuthResult {
+  session: Session | null
+  user: User | null
+  loading: boolean
+  signOut: () => Promise<void>
+}
+
+export function useAuth(): UseAuthResult {
+  const [session, setSession] = useState<Session | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session)
+      setLoading(false)
+    })
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, next) => {
+      setSession(next)
+    })
+
+    return () => subscription.subscription.unsubscribe()
+  }, [])
+
+  return {
+    session,
+    user: session?.user ?? null,
+    loading,
+    signOut: async () => {
+      await supabase.auth.signOut()
+    },
+  }
+}

--- a/apps/dashboard/hooks/useComments.ts
+++ b/apps/dashboard/hooks/useComments.ts
@@ -8,7 +8,7 @@ export interface UseCommentsResult {
   refresh: () => Promise<void>
 }
 
-export function useComments(apiBase: string, reviewerToken: string, projectId: string | null): UseCommentsResult {
+export function useComments(apiBase: string, accessToken: string, projectId: string | null): UseCommentsResult {
   const [comments, setComments] = useState<CommentRecord[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -25,7 +25,7 @@ export function useComments(apiBase: string, reviewerToken: string, projectId: s
     setLoading(true)
     setError(null)
     try {
-      const data = await listComments(apiBase, reviewerToken, projectId)
+      const data = await listComments(apiBase, accessToken, projectId)
       // Race guard: drop response if user switched projects mid-flight.
       if (activeProjectRef.current !== projectId) return
       setComments(data)
@@ -35,7 +35,7 @@ export function useComments(apiBase: string, reviewerToken: string, projectId: s
     } finally {
       if (activeProjectRef.current === projectId) setLoading(false)
     }
-  }, [apiBase, reviewerToken, projectId])
+  }, [apiBase, accessToken, projectId])
 
   // Clear previous project's data before the next fetch lands.
   useEffect(() => {

--- a/apps/dashboard/hooks/useProjects.ts
+++ b/apps/dashboard/hooks/useProjects.ts
@@ -9,7 +9,7 @@ export interface UseProjectsResult {
   createProject: (name: string) => Promise<Project>
 }
 
-export function useProjects(apiBase: string, reviewerToken: string): UseProjectsResult {
+export function useProjects(apiBase: string, accessToken: string): UseProjectsResult {
   const [projects, setProjects] = useState<Project[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -18,24 +18,24 @@ export function useProjects(apiBase: string, reviewerToken: string): UseProjects
     setLoading(true)
     setError(null)
     try {
-      const data = await listProjects(apiBase, reviewerToken)
+      const data = await listProjects(apiBase, accessToken)
       setProjects(data)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load projects')
     } finally {
       setLoading(false)
     }
-  }, [apiBase, reviewerToken])
+  }, [apiBase, accessToken])
 
   useEffect(() => {
     refresh()
   }, [refresh])
 
   const createProject = useCallback(async (name: string) => {
-    const project = await apiCreateProject(apiBase, reviewerToken, name)
+    const project = await apiCreateProject(apiBase, accessToken, name)
     setProjects((prev) => [...prev, project])
     return project
-  }, [apiBase, reviewerToken])
+  }, [apiBase, accessToken])
 
   return { projects, loading, error, refresh, createProject }
 }

--- a/apps/dashboard/lib/supabase.ts
+++ b/apps/dashboard/lib/supabase.ts
@@ -1,0 +1,18 @@
+import { createClient } from '@supabase/supabase-js'
+
+// Injected at build time by vite.config.ts via `define` so the env var stays
+// unprefixed (no VITE_) and shared with the server-side client.
+declare const __SUPABASE_URL__: string
+declare const __SUPABASE_ANON_KEY__: string
+
+if (!__SUPABASE_URL__ || !__SUPABASE_ANON_KEY__) {
+  throw new Error('Missing SUPABASE_URL or SUPABASE_ANON_KEY')
+}
+
+export const supabase = createClient(__SUPABASE_URL__, __SUPABASE_ANON_KEY__, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+  },
+})

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -1,19 +1,29 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
-export default defineConfig({
-  root: __dirname,
-  envDir: path.resolve(__dirname, '../..'),
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, '.'),
+const envDir = path.resolve(__dirname, '../..')
+
+export default defineConfig(({ mode }) => {
+  // Merge process.env (Vercel runtime) with .env files (local dev).
+  const env = { ...loadEnv(mode, envDir, ''), ...process.env }
+  return {
+    root: __dirname,
+    envDir,
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, '.'),
+      },
     },
-  },
-  build: {
-    outDir: 'dist',
-    emptyOutDir: true,
-  },
+    define: {
+      __SUPABASE_URL__: JSON.stringify(env.SUPABASE_URL ?? ''),
+      __SUPABASE_ANON_KEY__: JSON.stringify(env.SUPABASE_KEY ?? ''),
+    },
+    build: {
+      outDir: 'dist',
+      emptyOutDir: true,
+    },
+  }
 })


### PR DESCRIPTION
- Every dashboard endpoint that used to check the shared `REVIEWER_API_TOKEN` now expects a Supabase user session instead — projects list, project comments, comment review/implementation status, and the share endpoints.
- For now, any signed-in user can see every project. The follow-up chain layers on membership + project claiming so the list filters per user.
- Each swapped route has a `TODO(membership)` marker pointing at where the per-project authorization check will go.
- Added small smoke tests on every previously-untested route to lock in the new guard behavior.
- Stacks on top of #102.