### PR TITLE
refactor(dashboard): redesign LoginPage in CRRT identity + responsive

### DIFF
--- a/apps/dashboard/components/LoginPage.tsx
+++ b/apps/dashboard/components/LoginPage.tsx
@@ -1,19 +1,41 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
-import { LogoIcon } from './icons'
 import { Spinner } from './primitives'
 
 type Mode = 'signin' | 'signup'
 
+function modeFromPath(pathname: string): Mode {
+  return pathname === '/signup' ? 'signup' : 'signin'
+}
+
 export function LoginPage() {
-  const [mode, setMode] = useState<Mode>('signin')
+  const [mode, setMode] = useState<Mode>(() =>
+    typeof window === 'undefined' ? 'signin' : modeFromPath(window.location.pathname),
+  )
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [signupSent, setSignupSent] = useState(false)
 
-  async function handleEmailSubmit(e: React.FormEvent) {
+  // Sync mode if the user uses browser back / forward.
+  useEffect(() => {
+    function onPop() {
+      setMode(modeFromPath(window.location.pathname))
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [])
+
+  function navigate(path: '/login' | '/signup' | '/') {
+    if (window.location.pathname === path) return
+    window.history.pushState({}, '', path)
+    setMode(modeFromPath(path))
+    setError(null)
+    setSignupSent(false)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError(null)
     setBusy(true)
@@ -21,6 +43,7 @@ export function LoginPage() {
       if (mode === 'signin') {
         const { error: signinError } = await supabase.auth.signInWithPassword({ email, password })
         if (signinError) throw signinError
+        navigate('/')
       } else {
         const { error: signupError } = await supabase.auth.signUp({
           email,
@@ -37,116 +60,413 @@ export function LoginPage() {
     }
   }
 
-  async function handleGoogle() {
-    setError(null)
-    setBusy(true)
-    try {
-      const { error: oauthError } = await supabase.auth.signInWithOAuth({
-        provider: 'google',
-        options: { redirectTo: window.location.origin },
-      })
-      if (oauthError) throw oauthError
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Google sign-in failed')
-      setBusy(false)
-    }
-  }
+  if (signupSent) return <CheckEmail email={email} onBackToSignIn={() => navigate('/login')} />
 
-  if (signupSent) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background px-4">
-        <div className="w-full max-w-sm rounded-lg border border-border bg-card p-6 text-center">
-          <div className="w-10 h-10 rounded-md bg-primary mx-auto mb-3 flex items-center justify-center">
-            <LogoIcon />
-          </div>
-          <h1 className="text-base font-semibold text-foreground mb-1">Check your email</h1>
-          <p className="text-xs text-muted-foreground">
-            We sent a confirmation link to <span className="font-medium text-foreground">{email}</span>. Click it, then come back here to sign in.
-          </p>
-        </div>
-      </div>
-    )
-  }
+  const isSignup = mode === 'signup'
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background px-4">
-      <div className="w-full max-w-sm rounded-lg border border-border bg-card p-6">
-        <div className="flex flex-col items-center mb-5">
-          <div className="w-10 h-10 rounded-md bg-primary mb-3 flex items-center justify-center">
-            <LogoIcon />
-          </div>
-          <h1 className="text-base font-semibold text-foreground">
-            {mode === 'signin' ? 'Sign in to feedback' : 'Create your account'}
-          </h1>
-        </div>
-
-        <button
-          onClick={handleGoogle}
-          disabled={busy}
-          className="w-full flex items-center justify-center gap-2 h-9 rounded-md border border-border bg-background text-xs font-medium text-foreground hover:bg-accent disabled:opacity-50 transition-colors mb-3"
+    <div
+      className="scanlines"
+      style={{
+        minHeight: '100svh',
+        background: 'var(--background)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        paddingTop: 'clamp(40px, 10vh, 120px)',
+        paddingBottom: 'clamp(32px, 8vh, 80px)',
+        paddingLeft: 'clamp(24px, 7vw, 32px)',
+        paddingRight: 'clamp(24px, 7vw, 32px)',
+        position: 'relative',
+      }}
+    >
+      {/* Section marker — matches landing's "/ 01 hero" grammar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          marginBottom: 'clamp(28px, 6vh, 40px)',
+          maxWidth: 420,
+          width: '100%',
+        }}
+      >
+        <span className="crrt-section-marker" style={{ fontSize: 13, whiteSpace: 'nowrap' }}>/ 00 auth</span>
+        <span style={{ flex: 1, height: 1, background: 'var(--border)', minWidth: 12 }} />
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 15,
+            letterSpacing: '0.08em',
+            color: 'var(--crrt-phosphor)',
+            whiteSpace: 'nowrap',
+          }}
         >
-          <GoogleMark />
-          Continue with Google
-        </button>
-
-        <div className="flex items-center gap-2 my-3">
-          <div className="flex-1 h-px bg-border" />
-          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">or</span>
-          <div className="flex-1 h-px bg-border" />
-        </div>
-
-        <form onSubmit={handleEmailSubmit} className="space-y-2">
-          <input
-            type="email"
-            required
-            autoComplete="email"
-            placeholder="you@company.com"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            disabled={busy}
-            className="w-full h-9 px-3 rounded-md border border-border bg-background text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary disabled:opacity-50"
+          <span
+            aria-hidden="true"
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: 'var(--crrt-phosphor)',
+              animation: 'crrt-pulse 2400ms ease-in-out infinite',
+            }}
           />
-          <input
-            type="password"
-            required
-            autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            disabled={busy}
-            minLength={6}
-            className="w-full h-9 px-3 rounded-md border border-border bg-background text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary disabled:opacity-50"
-          />
-          {error && (
-            <p className="text-[11px] text-status-rejected">{error}</p>
-          )}
-          <button
-            type="submit"
-            disabled={busy}
-            className="w-full h-9 rounded-md bg-primary text-primary-foreground text-xs font-semibold flex items-center justify-center hover:bg-primary/90 disabled:opacity-50 transition-colors"
-          >
-            {busy ? <Spinner size={14} strokeWidth={3} className="text-primary-foreground" /> : mode === 'signin' ? 'Sign in' : 'Create account'}
-          </button>
-        </form>
-
-        <button
-          onClick={() => { setMode((m) => m === 'signin' ? 'signup' : 'signin'); setError(null) }}
-          className="block w-full text-center text-[11px] text-muted-foreground hover:text-foreground transition-colors mt-4"
-        >
-          {mode === 'signin' ? 'No account? Sign up' : 'Already have an account? Sign in'}
-        </button>
+          secure session
+        </span>
       </div>
+
+      {/* CRRT identity mark */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(24px, 5vh, 36px)' }}>
+        <img
+          src="/crrt-isologo.png"
+          alt=""
+          width={40}
+          height={40}
+          style={{ imageRendering: 'pixelated', width: 'clamp(32px, 8vw, 40px)', height: 'clamp(32px, 8vw, 40px)' }}
+        />
+        <span
+          style={{
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 'clamp(22px, 5.5vw, 26px)',
+            letterSpacing: '0.06em',
+            color: 'var(--foreground)',
+          }}
+        >
+          CRRT.
+        </span>
+      </div>
+
+      {/* Title with terminal cursor */}
+      <h1
+        style={{
+          margin: 0,
+          fontFamily: 'var(--crrt-font-mono)',
+          fontWeight: 700,
+          fontSize: 'clamp(26px, 7.5vw, 36px)',
+          lineHeight: 1.15,
+          letterSpacing: '-0.015em',
+          color: 'var(--foreground)',
+          textAlign: 'center',
+          marginBottom: 12,
+          textWrap: 'balance',
+        }}
+      >
+        <span className="crrt-cursor">{isSignup ? 'create your crrt' : 'welcome back'}</span>
+      </h1>
+      <p
+        style={{
+          margin: 0,
+          fontFamily: 'var(--crrt-font-body)',
+          fontSize: 'clamp(14px, 3.5vw, 15px)',
+          lineHeight: 1.5,
+          color: 'var(--muted-foreground)',
+          textAlign: 'center',
+          marginBottom: 'clamp(24px, 5vh, 32px)',
+          maxWidth: 420,
+          textWrap: 'pretty',
+        }}
+      >
+        {isSignup
+          ? 'one account. unlimited projects. visual feedback for your team.'
+          : 'sign in to keep shipping fixes from real feedback.'}
+      </p>
+
+      {/* Form */}
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          width: '100%',
+          maxWidth: 420,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+        }}
+      >
+        <FieldLabel htmlFor="auth-email">email</FieldLabel>
+        <AuthInput
+          id="auth-email"
+          type="email"
+          autoComplete="email"
+          required
+          spellCheck={false}
+          placeholder="you@team.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          disabled={busy}
+        />
+
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginTop: 6 }}>
+          <FieldLabel htmlFor="auth-password">password</FieldLabel>
+          {!isSignup && (
+            <button
+              type="button"
+              onClick={() => {/* TODO: forgot password */}}
+              style={{
+                fontFamily: 'var(--crrt-font-body)',
+                fontSize: 13,
+                color: 'var(--muted-foreground)',
+                background: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                padding: 0,
+                transition: 'color 150ms',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--foreground)')}
+              onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--muted-foreground)')}
+            >
+              forgot password? →
+            </button>
+          )}
+        </div>
+        <AuthInput
+          id="auth-password"
+          type="password"
+          autoComplete={isSignup ? 'new-password' : 'current-password'}
+          required
+          minLength={6}
+          spellCheck={false}
+          placeholder="••••••••"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={busy}
+        />
+
+        {error && (
+          <p
+            role="alert"
+            aria-live="polite"
+            style={{
+              margin: '6px 0 0',
+              fontFamily: 'var(--crrt-font-body)',
+              fontSize: 13,
+              color: 'var(--status-rejected)',
+            }}
+          >
+            ✗ {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={busy}
+          style={{
+            marginTop: 16,
+            height: 46,
+            padding: '0 20px',
+            background: busy ? 'var(--muted)' : 'var(--crrt-carrot)',
+            color: busy ? 'var(--muted-foreground)' : 'var(--crrt-white)',
+            border: 'none',
+            borderRadius: 999,
+            fontFamily: 'var(--crrt-font-mono)',
+            fontSize: 15,
+            fontWeight: 700,
+            letterSpacing: '0.02em',
+            cursor: busy ? 'not-allowed' : 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            transition: 'transform 80ms ease, opacity 150ms',
+          }}
+          onMouseDown={(e) => !busy && (e.currentTarget.style.transform = 'scale(0.985)')}
+          onMouseUp={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+          onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+        >
+          {busy ? (
+            <>
+              <Spinner size={14} strokeWidth={3} className="text-current" />
+              authenticating…
+            </>
+          ) : (
+            <>▸ {isSignup ? 'create account' : 'authenticate'}</>
+          )}
+        </button>
+      </form>
+
+      {/* Mode toggle */}
+      <p
+        style={{
+          marginTop: 28,
+          fontFamily: 'var(--crrt-font-body)',
+          fontSize: 14,
+          color: 'var(--muted-foreground)',
+        }}
+      >
+        {isSignup ? (
+          <>
+            have an account?{' '}
+            <a
+              href="/login"
+              onClick={(e) => {
+                e.preventDefault()
+                navigate('/login')
+              }}
+              style={{ color: 'var(--crrt-carrot)', textDecoration: 'none' }}
+            >
+              sign in →
+            </a>
+          </>
+        ) : (
+          <>
+            new here?{' '}
+            <a
+              href="/signup"
+              onClick={(e) => {
+                e.preventDefault()
+                navigate('/signup')
+              }}
+              style={{ color: 'var(--crrt-carrot)', textDecoration: 'none' }}
+            >
+              create an account →
+            </a>
+          </>
+        )}
+      </p>
     </div>
   )
 }
 
-function GoogleMark() {
+function FieldLabel({ htmlFor, children }: { htmlFor: string; children: React.ReactNode }) {
   return (
-    <svg width="14" height="14" viewBox="0 0 18 18" aria-hidden="true">
-      <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.71-1.58 2.68-3.9 2.68-6.62z" />
-      <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.81.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z" />
-      <path fill="#FBBC05" d="M3.97 10.72A5.4 5.4 0 0 1 3.68 9c0-.6.1-1.18.29-1.72V4.95H.96A9 9 0 0 0 0 9c0 1.45.35 2.83.96 4.05l3.01-2.33z" />
-      <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58A9 9 0 0 0 9 0a9 9 0 0 0-8.04 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z" />
-    </svg>
+    <label
+      htmlFor={htmlFor}
+      style={{
+        fontFamily: 'var(--crrt-font-mono)',
+        fontSize: 12,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        color: 'var(--muted-foreground)',
+      }}
+    >
+      {children}
+    </label>
+  )
+}
+
+function AuthInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      style={{
+        width: '100%',
+        height: 48,
+        padding: '0 16px',
+        background: 'var(--card)',
+        border: '1px solid var(--border)',
+        borderRadius: 8,
+        fontFamily: 'var(--crrt-font-body)',
+        // 16px minimum prevents iOS Safari from auto-zooming on focus.
+        fontSize: 16,
+        color: 'var(--foreground)',
+        outline: 'none',
+        transition: 'border-color 150ms, box-shadow 150ms',
+      }}
+      onFocus={(e) => {
+        e.currentTarget.style.borderColor = 'var(--crrt-carrot)'
+        e.currentTarget.style.boxShadow = '0 0 0 1px var(--crrt-carrot), 0 0 12px rgba(255, 176, 0, 0.18)'
+      }}
+      onBlur={(e) => {
+        e.currentTarget.style.borderColor = 'var(--border)'
+        e.currentTarget.style.boxShadow = 'none'
+      }}
+    />
+  )
+}
+
+function CheckEmail({ email, onBackToSignIn }: { email: string; onBackToSignIn: () => void }) {
+  return (
+    <div
+      className="scanlines"
+      style={{
+        minHeight: '100svh',
+        background: 'var(--background)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        paddingTop: 'clamp(40px, 10vh, 120px)',
+        paddingBottom: 'clamp(32px, 8vh, 80px)',
+        paddingLeft: 'clamp(24px, 7vw, 32px)',
+        paddingRight: 'clamp(24px, 7vw, 32px)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(24px, 5vh, 36px)' }}>
+        <img
+          src="/crrt-isologo.png"
+          alt=""
+          width={40}
+          height={40}
+          style={{ imageRendering: 'pixelated', width: 'clamp(32px, 8vw, 40px)', height: 'clamp(32px, 8vw, 40px)' }}
+        />
+        <span
+          style={{
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 'clamp(22px, 5.5vw, 26px)',
+            letterSpacing: '0.06em',
+            color: 'var(--foreground)',
+          }}
+        >
+          CRRT.
+        </span>
+      </div>
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 460,
+          border: '1px solid var(--border)',
+          borderRadius: 12,
+          background: 'var(--card)',
+          padding: 'clamp(20px, 5vw, 28px)',
+          textAlign: 'center',
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 'clamp(18px, 5vw, 22px)',
+            letterSpacing: '0.08em',
+            color: 'var(--crrt-phosphor)',
+            marginBottom: 12,
+          }}
+        >
+          ✓ check your email
+        </p>
+        <p
+          style={{
+            margin: 0,
+            fontFamily: 'var(--crrt-font-body)',
+            fontSize: 'clamp(14px, 3.5vw, 15px)',
+            lineHeight: 1.55,
+            color: 'var(--muted-foreground)',
+            marginBottom: 22,
+            textWrap: 'pretty',
+          }}
+        >
+          we sent a confirmation link to{' '}
+          <span style={{ color: 'var(--foreground)', fontWeight: 600 }}>{email}</span>. click it,
+          then come back here to sign in.
+        </p>
+        <button
+          type="button"
+          onClick={onBackToSignIn}
+          style={{
+            fontFamily: 'var(--crrt-font-body)',
+            fontSize: 14,
+            color: 'var(--crrt-carrot)',
+            background: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          ← back to sign in
+        </button>
+      </div>
+    </div>
   )
 }

--- a/apps/dashboard/globals.css
+++ b/apps/dashboard/globals.css
@@ -121,6 +121,52 @@
   }
 }
 
+/* Subtle CRT scanline overlay — mirrors apps/landing/globals.css so the
+   auth surface speaks the same visual language as the marketing site. */
+.scanlines {
+  position: relative;
+}
+.scanlines::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    180deg,
+    transparent 0px,
+    transparent 2px,
+    rgba(255, 255, 255, 0.012) 2px,
+    rgba(255, 255, 255, 0.012) 3px
+  );
+  mix-blend-mode: overlay;
+}
+
+/* Neutral body font (sans-serif Geist) — used in places where Geist Mono
+   reads too technical for paragraph copy (auth page subtitles, helper text,
+   inputs). The mono and CRT fonts stay reserved for headings, labels,
+   buttons, and terminal-flavor moments. */
+:root {
+  --crrt-font-body: 'Geist', system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+/* Section marker — same grammar as the landing's "/ 01 hero" labels. */
+.crrt-section-marker {
+  font-family: var(--crrt-font-mono);
+  font-size: 12px;
+  color: var(--muted-foreground);
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+}
+
+/* Blinking terminal cursor for headings. */
+.crrt-cursor::after {
+  content: '_';
+  display: inline-block;
+  margin-left: 0.05em;
+  color: var(--crrt-phosphor);
+  animation: crrt-cursor-blink 1060ms steps(1, end) infinite;
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar {
   width: 5px;

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -3,10 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="/crrt-isologo.png" />
     <title>CRRT 🥕 Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

Re-skin the LoginPage to match the CRRT visual identity that landed in #105 + the landing pass in #106. No new auth scope — still email + password, Google OAuth stays disabled. Touches only `apps/dashboard/**`.

## What changes

**Visual / brand**
- `/ 00 auth ─── ● secure session` section marker at the top, same grammar as the landing's section labels.
- CRRT isologo + VT323 wordmark centered (same lockup as the dashboard header).
- Title in Geist Mono with a blinking terminal cursor: `welcome back_` / `create your crrt_`. Uses the existing `crrt-cursor-blink` keyframe from `tokens.css`.
- White-on-carrot CTA pill (`▸ authenticate` / `▸ create account`) — same treatment as the landing's `.pill-carrot`.
- Subtle scanlines overlay (`.scanlines` utility, copied from landing).
- Favicon now set via `/crrt-isologo.png`.

**Typography**
- New `--crrt-font-body` variable (Geist sans) loaded via the dashboard's `index.html` Google Fonts import — used for paragraph copy where Geist Mono read too technical for legibility. Headings, labels, button, and CRT moments keep mono / VT323.

**Routing**
- `/login` and `/signup` are now real URLs. The mode toggle uses `history.pushState`; a `popstate` listener syncs the form. Browser back/forward, deep links, and analytics see distinct routes.
- After a successful sign-in, the page navigates to `/`.

**Responsive (no media queries — all `clamp()`)**
- Container padding scales 24px → 32px horizontally, 40px → 120px vertically.
- Title 26px → 36px, subtitle 14px → 15px, logo + wordmark scale by viewport width.
- Inputs locked to `font-size: 16` to prevent iOS Safari auto-zoom on focus.
- 48px input height, 46px button — both above the 44px touch-target minimum.
- `text-wrap: balance` on the title, `text-wrap: pretty` on the body copy to avoid widows.

**Other**
- `forgot password? →` slot in the markup as a styled placeholder; wiring is a separate PR.
- New CSS utilities live in `apps/dashboard/globals.css`: `.scanlines`, `.crrt-section-marker`, `.crrt-cursor`.

## What does *not* change

- No DB / API / membership / RLS work.
- Google OAuth stays disabled.
- No forgot-password flow yet.
- No onboarding after signup.

## Test plan

- [ ] `bun run typecheck` — clean.
- [ ] `bun run test` — 227/227.
- [ ] Manual at `bun run dev:dashboard:ui-only` (with `VITE_USE_MOCKS=0` in `.env.local` so the LoginPage actually renders):
  - [ ] `/` and `/login` show signin mode; `/signup` shows signup mode.
  - [ ] Browser back/forward toggles the mode.
  - [ ] Title shows blinking terminal cursor.
  - [ ] Inputs focus → carrot border + phosphor glow.
  - [ ] CTA shows `▸ authenticate` / `▸ create account` with white text on carrot.
  - [ ] Mobile (DevTools iPhone SE): no input auto-zoom, layout breathes, button still tappable.
  - [ ] After successful signup → "check your email" card with carrot back-link.
  - [ ] Favicon visible in tab.
  
  
  
<img width="848" height="742" alt="image" src="https://github.com/user-attachments/assets/6d95081d-a3e3-4614-95db-cc18c1f76fb0" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)