### PR TITLE
feat(dashboard): forgot password + 3-moment onboarding

### DIFF
--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -13,12 +13,46 @@ import { AgentSidebar } from './components/AgentSidebar'
 import { StatusBar } from './components/StatusBar'
 import { CommandPalette } from './components/CommandPalette'
 import { LoginPage } from './components/LoginPage'
+import { ResetPasswordPage } from './components/ResetPasswordPage'
+import { WelcomeScreen } from './components/WelcomeScreen'
+import { AddProjectPopover } from './components/AddProjectPopover'
 import { Spinner } from './components/primitives'
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'https://crrt.ai/api'
+const ONBOARDED_KEY = 'crrt:dashboard:onboarded'
+
+function isOnboarded() {
+  try {
+    return window.localStorage.getItem(ONBOARDED_KEY) === '1'
+  } catch {
+    return true
+  }
+}
+
+function markOnboarded() {
+  try {
+    window.localStorage.setItem(ONBOARDED_KEY, '1')
+  } catch {
+    /* localStorage unavailable */
+  }
+}
 
 export function App() {
   const { session, user, loading: authLoading, signOut } = useAuth()
+  const [pathname, setPathname] = useState(typeof window === 'undefined' ? '/' : window.location.pathname)
+
+  useEffect(() => {
+    function onPop() {
+      setPathname(window.location.pathname)
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [])
+
+  // /reset-password handles its own auth state via the recovery deep link;
+  // render it regardless of session so the user can complete the flow even
+  // if their previous session is stale.
+  if (pathname === '/reset-password') return <ResetPasswordPage />
 
   if (authLoading) {
     return (
@@ -290,6 +324,35 @@ function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: strin
       setAddProjectBusy(false)
     }
   }, [createProject])
+
+  // Onboarding gate: show the welcome screen when this account has no
+  // projects and hasn't been onboarded before. Once they click the CTA we
+  // mark the flag so the welcome doesn't reappear if they cancel out of
+  // the create-project modal.
+  const [onboarded, setOnboarded] = useState(() => (typeof window === 'undefined' ? true : isOnboarded()))
+  const showWelcome = !projectsLoading && projects.length === 0 && !onboarded
+
+  if (showWelcome) {
+    return (
+      <>
+        <WelcomeScreen
+          onCreateProject={() => {
+            markOnboarded()
+            setOnboarded(true)
+            setAddProjectOpen(true)
+          }}
+        />
+        {addProjectOpen && (
+          <AddProjectPopover
+            onAdd={handleAddProject}
+            onClose={() => setAddProjectOpen(false)}
+            busy={addProjectBusy}
+            error={addProjectError}
+          />
+        )}
+      </>
+    )
+  }
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">

--- a/apps/dashboard/components/CommentDetail.tsx
+++ b/apps/dashboard/components/CommentDetail.tsx
@@ -14,7 +14,7 @@ import {
   XIcon,
 } from './icons'
 import { ActionBtn, Kbd } from './primitives'
-import { AddToCodeButton } from './AddToCodeButton'
+import { ProjectEmptyState } from './ProjectEmptyState'
 
 interface CommentDetailProps {
   selectedComment: Comment | null
@@ -187,13 +187,7 @@ export function CommentDetail({
           </div>
         </>
       ) : selectedProject && !commentsLoading && !commentsError && projectComments.length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center text-center px-8">
-          <p className="text-base font-semibold text-foreground mb-1">No feedback yet</p>
-          <p className="text-sm text-muted-foreground max-w-sm mb-6">
-            Mount the widget in your app to start collecting visual feedback. Reviewers can drop pins on any page and their comments land here.
-          </p>
-          <AddToCodeButton projectId={selectedProject} apiBase={apiBase} variant="large" />
-        </div>
+        <ProjectEmptyState projectId={selectedProject} apiBase={apiBase} />
       ) : (
         <div className="flex-1 flex flex-col items-center justify-center text-center px-8">
           <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center mb-4">

--- a/apps/dashboard/components/LoginPage.tsx
+++ b/apps/dashboard/components/LoginPage.tsx
@@ -1,19 +1,41 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
-import { LogoIcon } from './icons'
 import { Spinner } from './primitives'
 
 type Mode = 'signin' | 'signup'
 
+function modeFromPath(pathname: string): Mode {
+  return pathname === '/signup' ? 'signup' : 'signin'
+}
+
 export function LoginPage() {
-  const [mode, setMode] = useState<Mode>('signin')
+  const [mode, setMode] = useState<Mode>(() =>
+    typeof window === 'undefined' ? 'signin' : modeFromPath(window.location.pathname),
+  )
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [signupSent, setSignupSent] = useState(false)
 
-  async function handleEmailSubmit(e: React.FormEvent) {
+  // Sync mode if the user uses browser back / forward.
+  useEffect(() => {
+    function onPop() {
+      setMode(modeFromPath(window.location.pathname))
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [])
+
+  function navigate(path: '/login' | '/signup' | '/') {
+    if (window.location.pathname === path) return
+    window.history.pushState({}, '', path)
+    setMode(modeFromPath(path))
+    setError(null)
+    setSignupSent(false)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError(null)
     setBusy(true)
@@ -21,6 +43,7 @@ export function LoginPage() {
       if (mode === 'signin') {
         const { error: signinError } = await supabase.auth.signInWithPassword({ email, password })
         if (signinError) throw signinError
+        navigate('/')
       } else {
         const { error: signupError } = await supabase.auth.signUp({
           email,
@@ -37,116 +60,413 @@ export function LoginPage() {
     }
   }
 
-  async function handleGoogle() {
-    setError(null)
-    setBusy(true)
-    try {
-      const { error: oauthError } = await supabase.auth.signInWithOAuth({
-        provider: 'google',
-        options: { redirectTo: window.location.origin },
-      })
-      if (oauthError) throw oauthError
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Google sign-in failed')
-      setBusy(false)
-    }
-  }
+  if (signupSent) return <CheckEmail email={email} onBackToSignIn={() => navigate('/login')} />
 
-  if (signupSent) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background px-4">
-        <div className="w-full max-w-sm rounded-lg border border-border bg-card p-6 text-center">
-          <div className="w-10 h-10 rounded-md bg-primary mx-auto mb-3 flex items-center justify-center">
-            <LogoIcon />
-          </div>
-          <h1 className="text-base font-semibold text-foreground mb-1">Check your email</h1>
-          <p className="text-xs text-muted-foreground">
-            We sent a confirmation link to <span className="font-medium text-foreground">{email}</span>. Click it, then come back here to sign in.
-          </p>
-        </div>
-      </div>
-    )
-  }
+  const isSignup = mode === 'signup'
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background px-4">
-      <div className="w-full max-w-sm rounded-lg border border-border bg-card p-6">
-        <div className="flex flex-col items-center mb-5">
-          <div className="w-10 h-10 rounded-md bg-primary mb-3 flex items-center justify-center">
-            <LogoIcon />
-          </div>
-          <h1 className="text-base font-semibold text-foreground">
-            {mode === 'signin' ? 'Sign in to feedback' : 'Create your account'}
-          </h1>
-        </div>
-
-        <button
-          onClick={handleGoogle}
-          disabled={busy}
-          className="w-full flex items-center justify-center gap-2 h-9 rounded-md border border-border bg-background text-xs font-medium text-foreground hover:bg-accent disabled:opacity-50 transition-colors mb-3"
+    <div
+      className="scanlines"
+      style={{
+        minHeight: '100svh',
+        background: 'var(--background)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        paddingTop: 'clamp(40px, 10vh, 120px)',
+        paddingBottom: 'clamp(32px, 8vh, 80px)',
+        paddingLeft: 'clamp(24px, 7vw, 32px)',
+        paddingRight: 'clamp(24px, 7vw, 32px)',
+        position: 'relative',
+      }}
+    >
+      {/* Section marker — matches landing's "/ 01 hero" grammar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          marginBottom: 'clamp(28px, 6vh, 40px)',
+          maxWidth: 420,
+          width: '100%',
+        }}
+      >
+        <span className="crrt-section-marker" style={{ fontSize: 13, whiteSpace: 'nowrap' }}>/ 00 auth</span>
+        <span style={{ flex: 1, height: 1, background: 'var(--border)', minWidth: 12 }} />
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 15,
+            letterSpacing: '0.08em',
+            color: 'var(--crrt-phosphor)',
+            whiteSpace: 'nowrap',
+          }}
         >
-          <GoogleMark />
-          Continue with Google
-        </button>
-
-        <div className="flex items-center gap-2 my-3">
-          <div className="flex-1 h-px bg-border" />
-          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">or</span>
-          <div className="flex-1 h-px bg-border" />
-        </div>
-
-        <form onSubmit={handleEmailSubmit} className="space-y-2">
-          <input
-            type="email"
-            required
-            autoComplete="email"
-            placeholder="you@company.com"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            disabled={busy}
-            className="w-full h-9 px-3 rounded-md border border-border bg-background text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary disabled:opacity-50"
+          <span
+            aria-hidden="true"
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: 'var(--crrt-phosphor)',
+              animation: 'crrt-pulse 2400ms ease-in-out infinite',
+            }}
           />
-          <input
-            type="password"
-            required
-            autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            disabled={busy}
-            minLength={6}
-            className="w-full h-9 px-3 rounded-md border border-border bg-background text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary disabled:opacity-50"
-          />
-          {error && (
-            <p className="text-[11px] text-status-rejected">{error}</p>
-          )}
-          <button
-            type="submit"
-            disabled={busy}
-            className="w-full h-9 rounded-md bg-primary text-primary-foreground text-xs font-semibold flex items-center justify-center hover:bg-primary/90 disabled:opacity-50 transition-colors"
-          >
-            {busy ? <Spinner size={14} strokeWidth={3} className="text-primary-foreground" /> : mode === 'signin' ? 'Sign in' : 'Create account'}
-          </button>
-        </form>
-
-        <button
-          onClick={() => { setMode((m) => m === 'signin' ? 'signup' : 'signin'); setError(null) }}
-          className="block w-full text-center text-[11px] text-muted-foreground hover:text-foreground transition-colors mt-4"
-        >
-          {mode === 'signin' ? 'No account? Sign up' : 'Already have an account? Sign in'}
-        </button>
+          secure session
+        </span>
       </div>
+
+      {/* CRRT identity mark */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(24px, 5vh, 36px)' }}>
+        <img
+          src="/crrt-isologo.png"
+          alt=""
+          width={40}
+          height={40}
+          style={{ imageRendering: 'pixelated', width: 'clamp(32px, 8vw, 40px)', height: 'clamp(32px, 8vw, 40px)' }}
+        />
+        <span
+          style={{
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 'clamp(22px, 5.5vw, 26px)',
+            letterSpacing: '0.06em',
+            color: 'var(--foreground)',
+          }}
+        >
+          CRRT.
+        </span>
+      </div>
+
+      {/* Title with terminal cursor */}
+      <h1
+        style={{
+          margin: 0,
+          fontFamily: 'var(--crrt-font-mono)',
+          fontWeight: 700,
+          fontSize: 'clamp(26px, 7.5vw, 36px)',
+          lineHeight: 1.15,
+          letterSpacing: '-0.015em',
+          color: 'var(--foreground)',
+          textAlign: 'center',
+          marginBottom: 12,
+          textWrap: 'balance',
+        }}
+      >
+        <span className="crrt-cursor">{isSignup ? 'create your crrt' : 'welcome back'}</span>
+      </h1>
+      <p
+        style={{
+          margin: 0,
+          fontFamily: 'var(--crrt-font-body)',
+          fontSize: 'clamp(14px, 3.5vw, 15px)',
+          lineHeight: 1.5,
+          color: 'var(--muted-foreground)',
+          textAlign: 'center',
+          marginBottom: 'clamp(24px, 5vh, 32px)',
+          maxWidth: 420,
+          textWrap: 'pretty',
+        }}
+      >
+        {isSignup
+          ? 'one account. unlimited projects. visual feedback for your team.'
+          : 'sign in to keep shipping fixes from real feedback.'}
+      </p>
+
+      {/* Form */}
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          width: '100%',
+          maxWidth: 420,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+        }}
+      >
+        <FieldLabel htmlFor="auth-email">email</FieldLabel>
+        <AuthInput
+          id="auth-email"
+          type="email"
+          autoComplete="email"
+          required
+          spellCheck={false}
+          placeholder="you@team.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          disabled={busy}
+        />
+
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginTop: 6 }}>
+          <FieldLabel htmlFor="auth-password">password</FieldLabel>
+          {!isSignup && (
+            <button
+              type="button"
+              onClick={() => {/* TODO: forgot password */}}
+              style={{
+                fontFamily: 'var(--crrt-font-body)',
+                fontSize: 13,
+                color: 'var(--muted-foreground)',
+                background: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                padding: 0,
+                transition: 'color 150ms',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--foreground)')}
+              onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--muted-foreground)')}
+            >
+              forgot password? →
+            </button>
+          )}
+        </div>
+        <AuthInput
+          id="auth-password"
+          type="password"
+          autoComplete={isSignup ? 'new-password' : 'current-password'}
+          required
+          minLength={6}
+          spellCheck={false}
+          placeholder="••••••••"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={busy}
+        />
+
+        {error && (
+          <p
+            role="alert"
+            aria-live="polite"
+            style={{
+              margin: '6px 0 0',
+              fontFamily: 'var(--crrt-font-body)',
+              fontSize: 13,
+              color: 'var(--status-rejected)',
+            }}
+          >
+            ✗ {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={busy}
+          style={{
+            marginTop: 16,
+            height: 46,
+            padding: '0 20px',
+            background: busy ? 'var(--muted)' : 'var(--crrt-carrot)',
+            color: busy ? 'var(--muted-foreground)' : 'var(--crrt-white)',
+            border: 'none',
+            borderRadius: 999,
+            fontFamily: 'var(--crrt-font-mono)',
+            fontSize: 15,
+            fontWeight: 700,
+            letterSpacing: '0.02em',
+            cursor: busy ? 'not-allowed' : 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            transition: 'transform 80ms ease, opacity 150ms',
+          }}
+          onMouseDown={(e) => !busy && (e.currentTarget.style.transform = 'scale(0.985)')}
+          onMouseUp={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+          onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+        >
+          {busy ? (
+            <>
+              <Spinner size={14} strokeWidth={3} className="text-current" />
+              authenticating…
+            </>
+          ) : (
+            <>▸ {isSignup ? 'create account' : 'authenticate'}</>
+          )}
+        </button>
+      </form>
+
+      {/* Mode toggle */}
+      <p
+        style={{
+          marginTop: 28,
+          fontFamily: 'var(--crrt-font-body)',
+          fontSize: 14,
+          color: 'var(--muted-foreground)',
+        }}
+      >
+        {isSignup ? (
+          <>
+            have an account?{' '}
+            <a
+              href="/login"
+              onClick={(e) => {
+                e.preventDefault()
+                navigate('/login')
+              }}
+              style={{ color: 'var(--crrt-carrot)', textDecoration: 'none' }}
+            >
+              sign in →
+            </a>
+          </>
+        ) : (
+          <>
+            new here?{' '}
+            <a
+              href="/signup"
+              onClick={(e) => {
+                e.preventDefault()
+                navigate('/signup')
+              }}
+              style={{ color: 'var(--crrt-carrot)', textDecoration: 'none' }}
+            >
+              create an account →
+            </a>
+          </>
+        )}
+      </p>
     </div>
   )
 }
 
-function GoogleMark() {
+function FieldLabel({ htmlFor, children }: { htmlFor: string; children: React.ReactNode }) {
   return (
-    <svg width="14" height="14" viewBox="0 0 18 18" aria-hidden="true">
-      <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.71-1.58 2.68-3.9 2.68-6.62z" />
-      <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.81.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z" />
-      <path fill="#FBBC05" d="M3.97 10.72A5.4 5.4 0 0 1 3.68 9c0-.6.1-1.18.29-1.72V4.95H.96A9 9 0 0 0 0 9c0 1.45.35 2.83.96 4.05l3.01-2.33z" />
-      <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58A9 9 0 0 0 9 0a9 9 0 0 0-8.04 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z" />
-    </svg>
+    <label
+      htmlFor={htmlFor}
+      style={{
+        fontFamily: 'var(--crrt-font-mono)',
+        fontSize: 12,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        color: 'var(--muted-foreground)',
+      }}
+    >
+      {children}
+    </label>
+  )
+}
+
+function AuthInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      style={{
+        width: '100%',
+        height: 48,
+        padding: '0 16px',
+        background: 'var(--card)',
+        border: '1px solid var(--border)',
+        borderRadius: 8,
+        fontFamily: 'var(--crrt-font-body)',
+        // 16px minimum prevents iOS Safari from auto-zooming on focus.
+        fontSize: 16,
+        color: 'var(--foreground)',
+        outline: 'none',
+        transition: 'border-color 150ms, box-shadow 150ms',
+      }}
+      onFocus={(e) => {
+        e.currentTarget.style.borderColor = 'var(--crrt-carrot)'
+        e.currentTarget.style.boxShadow = '0 0 0 1px var(--crrt-carrot), 0 0 12px rgba(255, 176, 0, 0.18)'
+      }}
+      onBlur={(e) => {
+        e.currentTarget.style.borderColor = 'var(--border)'
+        e.currentTarget.style.boxShadow = 'none'
+      }}
+    />
+  )
+}
+
+function CheckEmail({ email, onBackToSignIn }: { email: string; onBackToSignIn: () => void }) {
+  return (
+    <div
+      className="scanlines"
+      style={{
+        minHeight: '100svh',
+        background: 'var(--background)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        paddingTop: 'clamp(40px, 10vh, 120px)',
+        paddingBottom: 'clamp(32px, 8vh, 80px)',
+        paddingLeft: 'clamp(24px, 7vw, 32px)',
+        paddingRight: 'clamp(24px, 7vw, 32px)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(24px, 5vh, 36px)' }}>
+        <img
+          src="/crrt-isologo.png"
+          alt=""
+          width={40}
+          height={40}
+          style={{ imageRendering: 'pixelated', width: 'clamp(32px, 8vw, 40px)', height: 'clamp(32px, 8vw, 40px)' }}
+        />
+        <span
+          style={{
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 'clamp(22px, 5.5vw, 26px)',
+            letterSpacing: '0.06em',
+            color: 'var(--foreground)',
+          }}
+        >
+          CRRT.
+        </span>
+      </div>
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 460,
+          border: '1px solid var(--border)',
+          borderRadius: 12,
+          background: 'var(--card)',
+          padding: 'clamp(20px, 5vw, 28px)',
+          textAlign: 'center',
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 'clamp(18px, 5vw, 22px)',
+            letterSpacing: '0.08em',
+            color: 'var(--crrt-phosphor)',
+            marginBottom: 12,
+          }}
+        >
+          ✓ check your email
+        </p>
+        <p
+          style={{
+            margin: 0,
+            fontFamily: 'var(--crrt-font-body)',
+            fontSize: 'clamp(14px, 3.5vw, 15px)',
+            lineHeight: 1.55,
+            color: 'var(--muted-foreground)',
+            marginBottom: 22,
+            textWrap: 'pretty',
+          }}
+        >
+          we sent a confirmation link to{' '}
+          <span style={{ color: 'var(--foreground)', fontWeight: 600 }}>{email}</span>. click it,
+          then come back here to sign in.
+        </p>
+        <button
+          type="button"
+          onClick={onBackToSignIn}
+          style={{
+            fontFamily: 'var(--crrt-font-body)',
+            fontSize: 14,
+            color: 'var(--crrt-carrot)',
+            background: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          ← back to sign in
+        </button>
+      </div>
+    </div>
   )
 }

--- a/apps/dashboard/components/LoginPage.tsx
+++ b/apps/dashboard/components/LoginPage.tsx
@@ -2,11 +2,15 @@ import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
 import { Spinner } from './primitives'
 
-type Mode = 'signin' | 'signup'
+type Mode = 'signin' | 'signup' | 'forgot'
 
 function modeFromPath(pathname: string): Mode {
-  return pathname === '/signup' ? 'signup' : 'signin'
+  if (pathname === '/signup') return 'signup'
+  if (pathname === '/forgot-password') return 'forgot'
+  return 'signin'
 }
+
+type AuthPath = '/login' | '/signup' | '/forgot-password' | '/'
 
 export function LoginPage() {
   const [mode, setMode] = useState<Mode>(() =>
@@ -17,22 +21,27 @@ export function LoginPage() {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [signupSent, setSignupSent] = useState(false)
+  const [resetSent, setResetSent] = useState(false)
 
   // Sync mode if the user uses browser back / forward.
   useEffect(() => {
     function onPop() {
       setMode(modeFromPath(window.location.pathname))
+      setError(null)
+      setSignupSent(false)
+      setResetSent(false)
     }
     window.addEventListener('popstate', onPop)
     return () => window.removeEventListener('popstate', onPop)
   }, [])
 
-  function navigate(path: '/login' | '/signup' | '/') {
+  function navigate(path: AuthPath) {
     if (window.location.pathname === path) return
     window.history.pushState({}, '', path)
     setMode(modeFromPath(path))
     setError(null)
     setSignupSent(false)
+    setResetSent(false)
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -44,7 +53,7 @@ export function LoginPage() {
         const { error: signinError } = await supabase.auth.signInWithPassword({ email, password })
         if (signinError) throw signinError
         navigate('/')
-      } else {
+      } else if (mode === 'signup') {
         const { error: signupError } = await supabase.auth.signUp({
           email,
           password,
@@ -52,6 +61,12 @@ export function LoginPage() {
         })
         if (signupError) throw signupError
         setSignupSent(true)
+      } else {
+        const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
+          redirectTo: `${window.location.origin}/reset-password`,
+        })
+        if (resetError) throw resetError
+        setResetSent(true)
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Authentication failed')
@@ -60,9 +75,11 @@ export function LoginPage() {
     }
   }
 
-  if (signupSent) return <CheckEmail email={email} onBackToSignIn={() => navigate('/login')} />
+  if (signupSent) return <CheckEmail email={email} variant="signup" onBackToSignIn={() => navigate('/login')} />
+  if (resetSent) return <CheckEmail email={email} variant="reset" onBackToSignIn={() => navigate('/login')} />
 
   const isSignup = mode === 'signup'
+  const isForgot = mode === 'forgot'
 
   return (
     <div
@@ -156,7 +173,9 @@ export function LoginPage() {
           textWrap: 'balance',
         }}
       >
-        <span className="crrt-cursor">{isSignup ? 'create your crrt' : 'welcome back'}</span>
+        <span className="crrt-cursor">
+          {isSignup ? 'create your crrt' : isForgot ? 'reset your password' : 'welcome back'}
+        </span>
       </h1>
       <p
         style={{
@@ -173,7 +192,9 @@ export function LoginPage() {
       >
         {isSignup
           ? 'one account. unlimited projects. visual feedback for your team.'
-          : 'sign in to keep shipping fixes from real feedback.'}
+          : isForgot
+            ? "enter the email you signed up with. we'll send you a link to set a new password."
+            : 'sign in to keep shipping fixes from real feedback.'}
       </p>
 
       {/* Form */}
@@ -200,41 +221,46 @@ export function LoginPage() {
           disabled={busy}
         />
 
-        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginTop: 6 }}>
-          <FieldLabel htmlFor="auth-password">password</FieldLabel>
-          {!isSignup && (
-            <button
-              type="button"
-              onClick={() => {/* TODO: forgot password */}}
-              style={{
-                fontFamily: 'var(--crrt-font-body)',
-                fontSize: 13,
-                color: 'var(--muted-foreground)',
-                background: 'transparent',
-                border: 'none',
-                cursor: 'pointer',
-                padding: 0,
-                transition: 'color 150ms',
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--foreground)')}
-              onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--muted-foreground)')}
-            >
-              forgot password? →
-            </button>
-          )}
-        </div>
-        <AuthInput
-          id="auth-password"
-          type="password"
-          autoComplete={isSignup ? 'new-password' : 'current-password'}
-          required
-          minLength={6}
-          spellCheck={false}
-          placeholder="••••••••"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          disabled={busy}
-        />
+        {!isForgot && (
+          <>
+            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginTop: 6 }}>
+              <FieldLabel htmlFor="auth-password">password</FieldLabel>
+              {!isSignup && (
+                <a
+                  href="/forgot-password"
+                  onClick={(e) => {
+                    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
+                    e.preventDefault()
+                    navigate('/forgot-password')
+                  }}
+                  style={{
+                    fontFamily: 'var(--crrt-font-body)',
+                    fontSize: 13,
+                    color: 'var(--muted-foreground)',
+                    textDecoration: 'none',
+                    transition: 'color 150ms',
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--foreground)')}
+                  onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--muted-foreground)')}
+                >
+                  forgot password? →
+                </a>
+              )}
+            </div>
+            <AuthInput
+              id="auth-password"
+              type="password"
+              autoComplete={isSignup ? 'new-password' : 'current-password'}
+              required
+              minLength={6}
+              spellCheck={false}
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={busy}
+            />
+          </>
+        )}
 
         {error && (
           <p
@@ -283,7 +309,7 @@ export function LoginPage() {
               authenticating…
             </>
           ) : (
-            <>▸ {isSignup ? 'create account' : 'authenticate'}</>
+            <>▸ {isSignup ? 'create account' : isForgot ? 'send reset link' : 'authenticate'}</>
           )}
         </button>
       </form>
@@ -303,6 +329,7 @@ export function LoginPage() {
             <a
               href="/login"
               onClick={(e) => {
+                if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
                 e.preventDefault()
                 navigate('/login')
               }}
@@ -311,12 +338,28 @@ export function LoginPage() {
               sign in →
             </a>
           </>
+        ) : isForgot ? (
+          <>
+            remembered it?{' '}
+            <a
+              href="/login"
+              onClick={(e) => {
+                if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
+                e.preventDefault()
+                navigate('/login')
+              }}
+              style={{ color: 'var(--crrt-carrot)', textDecoration: 'none' }}
+            >
+              back to sign in →
+            </a>
+          </>
         ) : (
           <>
             new here?{' '}
             <a
               href="/signup"
               onClick={(e) => {
+                if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
                 e.preventDefault()
                 navigate('/signup')
               }}
@@ -378,7 +421,28 @@ function AuthInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
   )
 }
 
-function CheckEmail({ email, onBackToSignIn }: { email: string; onBackToSignIn: () => void }) {
+function CheckEmail({
+  email,
+  variant,
+  onBackToSignIn,
+}: {
+  email: string
+  variant: 'signup' | 'reset'
+  onBackToSignIn: () => void
+}) {
+  const heading = variant === 'reset' ? '✓ check your inbox' : '✓ check your email'
+  const body =
+    variant === 'reset' ? (
+      <>
+        we sent a password reset link to{' '}
+        <span style={{ color: 'var(--foreground)', fontWeight: 600 }}>{email}</span>. open it to choose a new password.
+      </>
+    ) : (
+      <>
+        we sent a confirmation link to{' '}
+        <span style={{ color: 'var(--foreground)', fontWeight: 600 }}>{email}</span>. click it, then come back here to sign in.
+      </>
+    )
   return (
     <div
       className="scanlines"
@@ -435,7 +499,7 @@ function CheckEmail({ email, onBackToSignIn }: { email: string; onBackToSignIn: 
             marginBottom: 12,
           }}
         >
-          ✓ check your email
+          {heading}
         </p>
         <p
           style={{
@@ -448,9 +512,7 @@ function CheckEmail({ email, onBackToSignIn }: { email: string; onBackToSignIn: 
             textWrap: 'pretty',
           }}
         >
-          we sent a confirmation link to{' '}
-          <span style={{ color: 'var(--foreground)', fontWeight: 600 }}>{email}</span>. click it,
-          then come back here to sign in.
+          {body}
         </p>
         <button
           type="button"

--- a/apps/dashboard/components/ProjectEmptyState.tsx
+++ b/apps/dashboard/components/ProjectEmptyState.tsx
@@ -1,0 +1,221 @@
+import { useState } from 'react'
+
+interface ProjectEmptyStateProps {
+  /** Project public key shown inline in the mount snippet. */
+  projectId: string
+  /** Backend URL shown inline in the mount snippet. */
+  apiBase: string
+}
+
+/**
+ * Onboarding moment 2: the rich empty state shown in CommentDetail once a
+ * project exists but it hasn't received any comments yet. Walks the user
+ * through the two install snippets with copy buttons so they can drop the
+ * widget into their app without leaving the dashboard.
+ */
+export function ProjectEmptyState({ projectId, apiBase }: ProjectEmptyStateProps) {
+  const installCode = `pnpm add @thedesignproject/crrt`
+  const mountCode = `import { FeedbackWidget } from '@thedesignproject/crrt'
+
+export default function App() {
+  return (
+    <>
+      <YourApp />
+      <FeedbackWidget
+        projectId="${projectId}"
+        apiBase="${apiBase}"
+      />
+    </>
+  )
+}`
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-2xl mx-auto px-6 sm:px-8 py-8 sm:py-12 detail-enter">
+        {/* Header */}
+        <div className="flex items-center gap-2 mb-2 text-xs">
+          <span aria-hidden="true">🥕</span>
+          <span
+            style={{
+              fontFamily: 'var(--crrt-font-crt)',
+              fontSize: 13,
+              letterSpacing: '0.08em',
+              color: 'var(--crrt-phosphor)',
+              textTransform: 'uppercase',
+            }}
+          >
+            your project is live
+          </span>
+        </div>
+        <h2
+          style={{
+            margin: 0,
+            fontFamily: 'var(--crrt-font-mono)',
+            fontWeight: 700,
+            fontSize: 'clamp(22px, 4vw, 28px)',
+            letterSpacing: '-0.015em',
+            color: 'var(--foreground)',
+            marginBottom: 12,
+            textWrap: 'balance',
+          }}
+        >
+          Drop the widget into your app.
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            fontFamily: 'var(--crrt-font-body, var(--crrt-font-sans))',
+            fontSize: 15,
+            lineHeight: 1.55,
+            color: 'var(--muted-foreground)',
+            marginBottom: 32,
+            maxWidth: 520,
+            textWrap: 'pretty',
+          }}
+        >
+          Two snippets and you're collecting feedback. We'll show comments here as soon as the first one lands.
+        </p>
+
+        <Snippet number="01" title="INSTALL" code={installCode} />
+        <div style={{ height: 12 }} />
+        <Snippet number="02" title="MOUNT IN YOUR APP ROOT" code={mountCode} />
+
+        {/* Waiting status — terminal-flavored "watching for first CRRT" */}
+        <div
+          style={{
+            marginTop: 32,
+            padding: '14px 16px',
+            border: '1px solid var(--border)',
+            borderRadius: 10,
+            background: 'var(--card)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: 'var(--crrt-phosphor)',
+              flexShrink: 0,
+              animation: 'crrt-pulse 2400ms ease-in-out infinite',
+            }}
+          />
+          <p
+            style={{
+              margin: 0,
+              fontFamily: 'var(--crrt-font-mono)',
+              fontSize: 13,
+              color: 'var(--muted-foreground)',
+            }}
+          >
+            waiting for your first crrt…
+          </p>
+        </div>
+
+        {/* Docs link */}
+        <p style={{ margin: '20px 0 0', fontSize: 13, color: 'var(--muted-foreground)' }}>
+          Need more detail?{' '}
+          <a
+            href="/docs/install"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--crrt-carrot)', textDecoration: 'none' }}
+          >
+            Read the install guide →
+          </a>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function Snippet({ number, title, code }: { number: string; title: string; code: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <div
+      style={{
+        background: 'var(--card)',
+        border: '1px solid var(--border)',
+        borderRadius: 12,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        className="flex items-center justify-between"
+        style={{
+          padding: '10px 14px',
+          borderBottom: '1px solid var(--border)',
+          gap: 12,
+        }}
+      >
+        <span style={{ display: 'flex', alignItems: 'baseline', gap: 8, minWidth: 0 }}>
+          <span
+            style={{
+              fontFamily: 'var(--crrt-font-mono)',
+              fontSize: 13,
+              fontWeight: 700,
+              color: 'var(--crrt-carrot)',
+              letterSpacing: '-0.01em',
+            }}
+          >
+            {number}.
+          </span>
+          <span
+            style={{
+              fontFamily: 'var(--crrt-font-crt)',
+              fontSize: 12,
+              letterSpacing: '0.08em',
+              color: 'var(--muted-foreground)',
+              textTransform: 'uppercase',
+            }}
+          >
+            {title}
+          </span>
+        </span>
+        <button
+          type="button"
+          onClick={async () => {
+            try {
+              await navigator.clipboard.writeText(code)
+              setCopied(true)
+              setTimeout(() => setCopied(false), 1200)
+            } catch {
+              /* clipboard unavailable */
+            }
+          }}
+          style={{
+            fontFamily: 'var(--crrt-font-mono)',
+            fontSize: 11,
+            color: copied ? 'var(--crrt-carrot)' : 'var(--muted-foreground)',
+            background: 'transparent',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            padding: '4px 10px',
+            cursor: 'pointer',
+          }}
+        >
+          {copied ? 'copied' : 'copy'}
+        </button>
+      </div>
+      <pre
+        style={{
+          margin: 0,
+          padding: 16,
+          fontFamily: 'var(--crrt-font-mono)',
+          fontSize: 13,
+          lineHeight: 1.6,
+          color: 'var(--foreground)',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          overflowX: 'auto',
+        }}
+      >
+        <code>{code}</code>
+      </pre>
+    </div>
+  )
+}

--- a/apps/dashboard/components/ResetPasswordPage.tsx
+++ b/apps/dashboard/components/ResetPasswordPage.tsx
@@ -1,0 +1,406 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../lib/supabase'
+import { Spinner } from './primitives'
+
+/**
+ * Handles the deep link Supabase sends after a `resetPasswordForEmail`. The
+ * link arrives at /reset-password with the recovery tokens in the URL hash
+ * — Supabase's auth client picks them up automatically and emits a
+ * `PASSWORD_RECOVERY` event, leaving the user transiently authenticated so
+ * that `updateUser({ password })` is allowed. On success we kick the user
+ * back to /login.
+ */
+export function ResetPasswordPage() {
+  const [ready, setReady] = useState(false)
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [done, setDone] = useState(false)
+
+  // Wait for Supabase to surface the PASSWORD_RECOVERY event from the URL
+  // hash. If the user lands here without a recovery context (e.g. opens the
+  // link in a different browser), we still let them try — the update call
+  // will just fail and we'll surface the error.
+  useEffect(() => {
+    let cancelled = false
+    const { data: sub } = supabase.auth.onAuthStateChange((event) => {
+      if (cancelled) return
+      if (event === 'PASSWORD_RECOVERY') setReady(true)
+    })
+    // Also probe getSession in case the event already fired before we
+    // subscribed (race on first render).
+    supabase.auth.getSession().then(({ data }) => {
+      if (!cancelled && data.session) setReady(true)
+    })
+    // If neither resolves within 600ms, allow the form anyway so the user
+    // gets feedback instead of a stuck loader.
+    const fallback = window.setTimeout(() => {
+      if (!cancelled) setReady(true)
+    }, 600)
+    return () => {
+      cancelled = true
+      sub.subscription.unsubscribe()
+      window.clearTimeout(fallback)
+    }
+  }, [])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    if (password.length < 6) {
+      setError('password must be at least 6 characters')
+      return
+    }
+    if (password !== confirm) {
+      setError("passwords don't match")
+      return
+    }
+    setBusy(true)
+    try {
+      const { error: updateError } = await supabase.auth.updateUser({ password })
+      if (updateError) throw updateError
+      setDone(true)
+      // Sign out so the next visit lands on /login cleanly with the new
+      // password active.
+      await supabase.auth.signOut()
+      window.setTimeout(() => {
+        window.location.href = '/login'
+      }, 1400)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not update password')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (done) return <SuccessScreen />
+
+  return (
+    <div
+      className="scanlines"
+      style={{
+        minHeight: '100svh',
+        background: 'var(--background)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        paddingTop: 'clamp(40px, 10vh, 120px)',
+        paddingBottom: 'clamp(32px, 8vh, 80px)',
+        paddingLeft: 'clamp(24px, 7vw, 32px)',
+        paddingRight: 'clamp(24px, 7vw, 32px)',
+      }}
+    >
+      {/* Section marker */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          marginBottom: 'clamp(28px, 6vh, 40px)',
+          maxWidth: 420,
+          width: '100%',
+        }}
+      >
+        <span className="crrt-section-marker" style={{ fontSize: 13, whiteSpace: 'nowrap' }}>/ 00 reset</span>
+        <span style={{ flex: 1, height: 1, background: 'var(--border)', minWidth: 12 }} />
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 15,
+            letterSpacing: '0.08em',
+            color: 'var(--crrt-phosphor)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: 'var(--crrt-phosphor)',
+              animation: 'crrt-pulse 2400ms ease-in-out infinite',
+            }}
+          />
+          secure link
+        </span>
+      </div>
+
+      {/* CRRT identity mark */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(24px, 5vh, 36px)' }}>
+        <img
+          src="/crrt-isologo.png"
+          alt=""
+          width={40}
+          height={40}
+          style={{ imageRendering: 'pixelated', width: 'clamp(32px, 8vw, 40px)', height: 'clamp(32px, 8vw, 40px)' }}
+        />
+        <span
+          style={{
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 'clamp(22px, 5.5vw, 26px)',
+            letterSpacing: '0.06em',
+            color: 'var(--foreground)',
+          }}
+        >
+          CRRT.
+        </span>
+      </div>
+
+      <h1
+        style={{
+          margin: 0,
+          fontFamily: 'var(--crrt-font-mono)',
+          fontWeight: 700,
+          fontSize: 'clamp(26px, 7.5vw, 36px)',
+          lineHeight: 1.15,
+          letterSpacing: '-0.015em',
+          color: 'var(--foreground)',
+          textAlign: 'center',
+          marginBottom: 12,
+          textWrap: 'balance',
+        }}
+      >
+        <span className="crrt-cursor">set a new password</span>
+      </h1>
+      <p
+        style={{
+          margin: 0,
+          fontFamily: 'var(--crrt-font-body)',
+          fontSize: 'clamp(14px, 3.5vw, 15px)',
+          lineHeight: 1.5,
+          color: 'var(--muted-foreground)',
+          textAlign: 'center',
+          marginBottom: 'clamp(24px, 5vh, 32px)',
+          maxWidth: 420,
+          textWrap: 'pretty',
+        }}
+      >
+        choose something you can remember. at least 6 characters.
+      </p>
+
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          width: '100%',
+          maxWidth: 420,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+          opacity: ready ? 1 : 0.6,
+          transition: 'opacity 240ms ease',
+        }}
+      >
+        <FieldLabel htmlFor="reset-password">new password</FieldLabel>
+        <AuthInput
+          id="reset-password"
+          type="password"
+          autoComplete="new-password"
+          required
+          minLength={6}
+          spellCheck={false}
+          placeholder="••••••••"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={busy}
+        />
+        <FieldLabel htmlFor="reset-confirm">confirm</FieldLabel>
+        <AuthInput
+          id="reset-confirm"
+          type="password"
+          autoComplete="new-password"
+          required
+          minLength={6}
+          spellCheck={false}
+          placeholder="••••••••"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          disabled={busy}
+        />
+
+        {error && (
+          <p
+            role="alert"
+            aria-live="polite"
+            style={{
+              margin: '6px 0 0',
+              fontFamily: 'var(--crrt-font-body)',
+              fontSize: 13,
+              color: 'var(--status-rejected)',
+            }}
+          >
+            ✗ {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={busy}
+          style={{
+            marginTop: 16,
+            height: 46,
+            padding: '0 20px',
+            background: busy ? 'var(--muted)' : 'var(--crrt-carrot)',
+            color: busy ? 'var(--muted-foreground)' : 'var(--crrt-white)',
+            border: 'none',
+            borderRadius: 999,
+            fontFamily: 'var(--crrt-font-mono)',
+            fontSize: 15,
+            fontWeight: 700,
+            letterSpacing: '0.02em',
+            cursor: busy ? 'not-allowed' : 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            transition: 'transform 80ms ease',
+          }}
+          onMouseDown={(e) => !busy && (e.currentTarget.style.transform = 'scale(0.985)')}
+          onMouseUp={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+          onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+        >
+          {busy ? (
+            <>
+              <Spinner size={14} strokeWidth={3} className="text-current" />
+              updating…
+            </>
+          ) : (
+            <>▸ update password</>
+          )}
+        </button>
+      </form>
+
+      <p style={{ marginTop: 28, fontFamily: 'var(--crrt-font-body)', fontSize: 14, color: 'var(--muted-foreground)' }}>
+        remembered it?{' '}
+        <a href="/login" style={{ color: 'var(--crrt-carrot)', textDecoration: 'none' }}>
+          back to sign in →
+        </a>
+      </p>
+    </div>
+  )
+}
+
+function SuccessScreen() {
+  return (
+    <div
+      className="scanlines"
+      style={{
+        minHeight: '100svh',
+        background: 'var(--background)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        paddingTop: 'clamp(40px, 10vh, 120px)',
+        paddingLeft: 'clamp(24px, 7vw, 32px)',
+        paddingRight: 'clamp(24px, 7vw, 32px)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 36 }}>
+        <img
+          src="/crrt-isologo.png"
+          alt=""
+          width={40}
+          height={40}
+          style={{ imageRendering: 'pixelated' }}
+        />
+        <span
+          style={{
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 26,
+            letterSpacing: '0.06em',
+            color: 'var(--foreground)',
+          }}
+        >
+          CRRT.
+        </span>
+      </div>
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 460,
+          border: '1px solid var(--border)',
+          borderRadius: 12,
+          background: 'var(--card)',
+          padding: 'clamp(20px, 5vw, 28px)',
+          textAlign: 'center',
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 22,
+            letterSpacing: '0.08em',
+            color: 'var(--crrt-phosphor)',
+            marginBottom: 10,
+          }}
+        >
+          ✓ password updated
+        </p>
+        <p
+          style={{
+            margin: 0,
+            fontFamily: 'var(--crrt-font-body)',
+            fontSize: 15,
+            lineHeight: 1.55,
+            color: 'var(--muted-foreground)',
+          }}
+        >
+          you'll be redirected to sign in in a moment…
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function FieldLabel({ htmlFor, children }: { htmlFor: string; children: React.ReactNode }) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      style={{
+        fontFamily: 'var(--crrt-font-mono)',
+        fontSize: 12,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        color: 'var(--muted-foreground)',
+      }}
+    >
+      {children}
+    </label>
+  )
+}
+
+function AuthInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      style={{
+        width: '100%',
+        height: 48,
+        padding: '0 16px',
+        background: 'var(--card)',
+        border: '1px solid var(--border)',
+        borderRadius: 8,
+        fontFamily: 'var(--crrt-font-body)',
+        fontSize: 16,
+        color: 'var(--foreground)',
+        outline: 'none',
+        transition: 'border-color 150ms, box-shadow 150ms',
+      }}
+      onFocus={(e) => {
+        e.currentTarget.style.borderColor = 'var(--crrt-carrot)'
+        e.currentTarget.style.boxShadow = '0 0 0 1px var(--crrt-carrot), 0 0 12px rgba(255, 176, 0, 0.18)'
+      }}
+      onBlur={(e) => {
+        e.currentTarget.style.borderColor = 'var(--border)'
+        e.currentTarget.style.boxShadow = 'none'
+      }}
+    />
+  )
+}

--- a/apps/dashboard/components/WelcomeScreen.tsx
+++ b/apps/dashboard/components/WelcomeScreen.tsx
@@ -1,0 +1,176 @@
+interface WelcomeScreenProps {
+  /** Called when the user clicks the "create your first project" CTA. */
+  onCreateProject: () => void
+}
+
+/**
+ * Onboarding moment 1: shown to an authenticated user whose account has zero
+ * projects AND who hasn't been onboarded before (see ONBOARDED_KEY). One CTA,
+ * no welcome tour — the rest of the introduction happens through the rich
+ * empty state that follows (moment 2).
+ */
+export function WelcomeScreen({ onCreateProject }: WelcomeScreenProps) {
+  return (
+    <div
+      className="scanlines"
+      style={{
+        minHeight: '100svh',
+        background: 'var(--background)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        paddingTop: 'clamp(40px, 10vh, 120px)',
+        paddingBottom: 'clamp(32px, 8vh, 80px)',
+        paddingLeft: 'clamp(24px, 7vw, 32px)',
+        paddingRight: 'clamp(24px, 7vw, 32px)',
+      }}
+    >
+      {/* Section marker */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          marginBottom: 'clamp(28px, 6vh, 40px)',
+          maxWidth: 480,
+          width: '100%',
+        }}
+      >
+        <span className="crrt-section-marker" style={{ fontSize: 13, whiteSpace: 'nowrap' }}>/ 00 setup</span>
+        <span style={{ flex: 1, height: 1, background: 'var(--border)', minWidth: 12 }} />
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 15,
+            letterSpacing: '0.08em',
+            color: 'var(--crrt-phosphor)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: 'var(--crrt-phosphor)',
+              animation: 'crrt-pulse 2400ms ease-in-out infinite',
+            }}
+          />
+          ready when you are
+        </span>
+      </div>
+
+      {/* CRRT identity mark */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(24px, 5vh, 36px)' }}>
+        <img
+          src="/crrt-isologo.png"
+          alt=""
+          width={40}
+          height={40}
+          style={{
+            imageRendering: 'pixelated',
+            width: 'clamp(32px, 8vw, 40px)',
+            height: 'clamp(32px, 8vw, 40px)',
+          }}
+        />
+        <span
+          style={{
+            fontFamily: 'var(--crrt-font-crt)',
+            fontSize: 'clamp(22px, 5.5vw, 26px)',
+            letterSpacing: '0.06em',
+            color: 'var(--foreground)',
+          }}
+        >
+          CRRT.
+        </span>
+      </div>
+
+      {/* Title with terminal cursor */}
+      <h1
+        style={{
+          margin: 0,
+          fontFamily: 'var(--crrt-font-mono)',
+          fontWeight: 700,
+          fontSize: 'clamp(28px, 8vw, 40px)',
+          lineHeight: 1.15,
+          letterSpacing: '-0.015em',
+          color: 'var(--foreground)',
+          textAlign: 'center',
+          marginBottom: 14,
+          textWrap: 'balance',
+        }}
+      >
+        <span className="crrt-cursor">welcome to crrt</span>
+      </h1>
+
+      <p
+        style={{
+          margin: 0,
+          fontFamily: 'var(--crrt-font-body)',
+          fontSize: 'clamp(15px, 3.6vw, 17px)',
+          lineHeight: 1.55,
+          color: 'var(--muted-foreground)',
+          textAlign: 'center',
+          marginBottom: 'clamp(28px, 6vh, 40px)',
+          maxWidth: 480,
+          textWrap: 'pretty',
+        }}
+      >
+        drop visual feedback on any element of your product. triage. hand off to your AI agent. ship the fix.
+      </p>
+
+      {/* Primary CTA */}
+      <button
+        type="button"
+        onClick={onCreateProject}
+        style={{
+          height: 52,
+          padding: '0 24px',
+          background: 'var(--crrt-carrot)',
+          color: 'var(--crrt-white)',
+          border: 'none',
+          borderRadius: 999,
+          fontFamily: 'var(--crrt-font-mono)',
+          fontSize: 15,
+          fontWeight: 700,
+          letterSpacing: '0.02em',
+          cursor: 'pointer',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 10,
+          boxShadow: '0 8px 16px rgba(232, 133, 61, 0.32), 0 1px 0 rgba(255, 255, 255, 0.12) inset',
+          transition: 'transform 80ms ease, box-shadow 220ms ease',
+        }}
+        onMouseDown={(e) => (e.currentTarget.style.transform = 'scale(0.985)')}
+        onMouseUp={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+        onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+      >
+        ▸ create your first project
+      </button>
+
+      {/* Secondary link to docs */}
+      <a
+        href="/docs/install"
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          marginTop: 20,
+          fontFamily: 'var(--crrt-font-body)',
+          fontSize: 13,
+          color: 'var(--muted-foreground)',
+          textDecoration: 'none',
+          transition: 'color 150ms',
+        }}
+        onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--foreground)')}
+        onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--muted-foreground)')}
+      >
+        learn more →
+      </a>
+    </div>
+  )
+}

--- a/apps/dashboard/globals.css
+++ b/apps/dashboard/globals.css
@@ -121,6 +121,52 @@
   }
 }
 
+/* Subtle CRT scanline overlay — mirrors apps/landing/globals.css so the
+   auth surface speaks the same visual language as the marketing site. */
+.scanlines {
+  position: relative;
+}
+.scanlines::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    180deg,
+    transparent 0px,
+    transparent 2px,
+    rgba(255, 255, 255, 0.012) 2px,
+    rgba(255, 255, 255, 0.012) 3px
+  );
+  mix-blend-mode: overlay;
+}
+
+/* Neutral body font (sans-serif Geist) — used in places where Geist Mono
+   reads too technical for paragraph copy (auth page subtitles, helper text,
+   inputs). The mono and CRT fonts stay reserved for headings, labels,
+   buttons, and terminal-flavor moments. */
+:root {
+  --crrt-font-body: 'Geist', system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+/* Section marker — same grammar as the landing's "/ 01 hero" labels. */
+.crrt-section-marker {
+  font-family: var(--crrt-font-mono);
+  font-size: 12px;
+  color: var(--muted-foreground);
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+}
+
+/* Blinking terminal cursor for headings. */
+.crrt-cursor::after {
+  content: '_';
+  display: inline-block;
+  margin-left: 0.05em;
+  color: var(--crrt-phosphor);
+  animation: crrt-cursor-blink 1060ms steps(1, end) infinite;
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar {
   width: 5px;

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -3,10 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="/crrt-isologo.png" />
     <title>CRRT 🥕 Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/apps/dashboard/lib/mocks.ts
+++ b/apps/dashboard/lib/mocks.ts
@@ -1,6 +1,11 @@
 import type { CommentRecord, Project } from '../api'
 
-export const mocksEnabled = import.meta.env.VITE_USE_MOCKS === '1'
+// VITE_USE_MOCKS:
+//   '1'     → populated fixtures (default mock mode)
+//   'empty' → empty account, useful for previewing the onboarding flow
+//   unset   → real API
+export const mocksEnabled = import.meta.env.VITE_USE_MOCKS === '1' || import.meta.env.VITE_USE_MOCKS === 'empty'
+export const mocksEmpty = import.meta.env.VITE_USE_MOCKS === 'empty'
 
 const now = Date.now()
 const ago = (mins: number) => new Date(now - mins * 60_000).toISOString()
@@ -142,9 +147,11 @@ const PROJECT_COMMENTS: Record<string, CommentRecord[]> = {
 }
 
 export function getMockProjects(): Project[] {
+  if (mocksEmpty) return []
   return MOCK_PROJECTS
 }
 
 export function getMockComments(projectId: string): CommentRecord[] {
+  if (mocksEmpty) return []
   return PROJECT_COMMENTS[projectId] ?? []
 }


### PR DESCRIPTION
## Summary

Builds on #107 (LoginPage redesign — now merged) to close two auth-completeness gaps in front of any membership / quota work. Touches only `apps/dashboard/**`. No backend, DB, widget, or membership changes.

## 1. Forgot password

- `forgot password? →` link in LoginPage now navigates to a real **`/forgot-password`** route (third mode on the same component, same pathname-based router we use for `/login` and `/signup`).
- That mode hides the password field, swaps the CTA to "send reset link", and calls `supabase.auth.resetPasswordForEmail` with the redirect pointing at `/reset-password` on the current origin.
- After submission the user lands on the "check your inbox" card (the existing `CheckEmail` component, now variant-aware so it can speak both signup and reset contexts).
- New **`/reset-password`** page renders independently of session state, listens for the `PASSWORD_RECOVERY` event Supabase emits after the deep link is opened, lets the user choose a new password, calls `updateUser({ password })`, signs out, and bounces back to `/login`.

## 2. Onboarding — 3 moments (no tour library, no skip wizard)

- **Moment 1**: `WelcomeScreen` renders full-viewport for an authenticated user whose account has zero projects and who hasn't been onboarded before. Same visual grammar as the LoginPage redesign (section marker, isologo + wordmark, blinking terminal cursor on the title, scanlines). Single CTA `▸ create your first project` opens the existing add-project modal.
- **Moment 2**: new `ProjectEmptyState` replaces the bare "No feedback yet" copy inside `CommentDetail` with the actual install + mount snippets (project ID and `apiBase` already filled in) and a phosphor pulse signalling "waiting for your first crrt…".
- **Moment 3**: a `crrt:dashboard:onboarded` localStorage flag is set the instant the user clicks the WelcomeScreen CTA, so cancelling out of the create-project modal doesn't trap them in the welcome on subsequent renders.

## Side touches

- `mocks.ts` gains a **`VITE_USE_MOCKS=empty`** mode that returns an empty account (no projects, no comments). Useful for previewing the welcome flow locally without flipping any seed data. Default `VITE_USE_MOCKS=1` still returns the populated fixtures.
- LoginPage now uses anchor links (with cmd/ctrl/middle-click passthrough) for the mode toggles, so the routes are still shareable / openable in a new tab.

## Test plan

- [ ] `bun run typecheck` — clean.
- [ ] `bun run test` — 227/227.
- [ ] Forgot password flow:
  - [ ] On `/login`, click `forgot password? →` → URL becomes `/forgot-password`, title swaps, password input disappears.
  - [ ] Submit → "check your inbox" card with the user's email.
  - [ ] Open the reset link → lands on `/reset-password`, sets a new password, redirects to `/login`.
  - [ ] Browser back/forward syncs the LoginPage mode.
- [ ] Onboarding flow:
  - [ ] Set `VITE_USE_MOCKS=empty` in `.env.local`, restart dev server, hard-reload.
  - [ ] After auth, you land on `WelcomeScreen`.
  - [ ] Click `▸ create your first project` → modal opens, localStorage flag set.
  - [ ] Cancel the modal → you go to the empty dashboard (no welcome again).
  - [ ] Create a project → `ProjectEmptyState` renders with snippets and the live "waiting" indicator.
  - [ ] Clear localStorage + `VITE_USE_MOCKS=empty` → welcome reappears.

## Out of scope

- Membership enforcement at the API layer (the `TODO(membership)` in `api/v1/projects/index.ts:9` stays open).
- Quota / project-cap UX.
- A real welcome tour with overlays — explicitly chose the 3-moment composition over a tooltip tour to avoid pulling a dependency and to keep the flow native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)