### PR TITLE
Lock projects to their members + add a claim flow

### DIFF
--- a/api/_lib/auth.test.ts
+++ b/api/_lib/auth.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('./supabase.js', () => ({ getSupabase: vi.fn() }))
+vi.mock('./store.js', () => ({ isProjectMember: vi.fn() }))
 
 import { getSupabase } from './supabase.js'
-import { requireReviewer, requireUser } from './auth.js'
+import { isProjectMember } from './store.js'
+import { requireProjectMembership, requireReviewer, requireUser } from './auth.js'
 
 interface MockRes {
   statusCode: number
@@ -132,5 +134,33 @@ describe('requireUser', () => {
     const res = mockRes()
     const user = await requireUser(mockReq({ authorization: 'Bearer tok' }), res as never)
     expect(user).toEqual({ userId: 'u-1', email: 'a@example.com' })
+  })
+})
+
+describe('requireProjectMembership', () => {
+  const USER = { userId: 'u-1', email: 'a@b.c' }
+
+  it('returns true when the user is a member', async () => {
+    vi.mocked(isProjectMember).mockResolvedValue(true)
+    const res = mockRes()
+    const ok = await requireProjectMembership(mockReq(), res as never, USER, 'p')
+    expect(ok).toBe(true)
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('writes 403 when the user is not a member', async () => {
+    vi.mocked(isProjectMember).mockResolvedValue(false)
+    const res = mockRes()
+    const ok = await requireProjectMembership(mockReq(), res as never, USER, 'p')
+    expect(ok).toBe(false)
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('writes 500 when the membership check throws', async () => {
+    vi.mocked(isProjectMember).mockRejectedValue(new Error('db down'))
+    const res = mockRes()
+    const ok = await requireProjectMembership(mockReq(), res as never, USER, 'p')
+    expect(ok).toBe(false)
+    expect(res.statusCode).toBe(500)
   })
 })

--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -1,8 +1,31 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { getBearerToken, getReviewerToken, jsonError } from './http.js'
+import { isProjectMember } from './store.js'
 import { getSupabase } from './supabase.js'
 
 export type AuthenticatedUser = { userId: string; email: string }
+
+/**
+ * Membership gate for any endpoint that operates within a single project's
+ * scope. Caller has already passed `requireUser`; this checks the user is in
+ * `project_members` for the given key. Writes 403 on miss so callers can
+ * `if (!(await requireProjectMembership(...))) return`.
+ */
+export async function requireProjectMembership(
+  req: VercelRequest,
+  res: VercelResponse,
+  user: AuthenticatedUser,
+  projectKey: string,
+): Promise<boolean> {
+  try {
+    if (await isProjectMember(user.userId, projectKey)) return true
+  } catch {
+    jsonError(req, res, 500, 'Membership check failed')
+    return false
+  }
+  jsonError(req, res, 403, 'Forbidden')
+  return false
+}
 
 export function requireReviewer(req: VercelRequest, res: VercelResponse) {
   const configured = process.env.REVIEWER_API_TOKEN

--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -1,14 +1,23 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('./supabase.js', () => ({ getSupabase: vi.fn() }))
+vi.mock('./supabase.js', () => ({ getSupabase: vi.fn(), getServiceSupabase: vi.fn() }))
 
-import { getSupabase } from './supabase.js'
+import { getServiceSupabase, getSupabase } from './supabase.js'
 import {
+  acceptInvite,
   claimProject,
+  createInvite,
+  createNotification,
+  declineInvite,
   ensurePublicProject,
+  findUserIdByEmail,
   getProjectMember,
   isProjectMember,
+  listInvitesForEmail,
+  listNotificationsForUser,
   listProjectsForUser,
+  markAllNotificationsRead,
+  markNotificationRead,
 } from './store.js'
 
 type ProjectRow = {
@@ -69,6 +78,7 @@ const PROJECT_ROW: ProjectRow = {
 
 beforeEach(() => {
   vi.mocked(getSupabase).mockReset()
+  vi.mocked(getServiceSupabase).mockReset()
 })
 
 describe('ensurePublicProject', () => {
@@ -287,5 +297,293 @@ describe('membership helpers + claim', () => {
       projectsUpdate: { data: null, error: { message: 'db boom' } },
     }) as never)
     await expect(claimProject('u', 'pk')).rejects.toThrow('db boom')
+  })
+})
+
+type NotifMocks = {
+  notifSingle?: { data: unknown; error: { message: string } | null }
+  notifList?: { data: unknown[] | null; error: { message: string } | null }
+  notifUpdate?: { data: unknown[] | null; error: { message: string } | null }
+  notifUpdateAllError?: { message: string } | null
+}
+
+function notifSupabase(m: NotifMocks = {}) {
+  return {
+    from: vi.fn((_table: string) => ({
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve(m.notifSingle ?? { data: null, error: null })),
+        })),
+      })),
+      select: vi.fn(() => {
+        const chain = {
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          limit: vi.fn(() => chain),
+          is: vi.fn(() => chain),
+          then: (r: (v: unknown) => unknown) =>
+            Promise.resolve(m.notifList ?? { data: [], error: null }).then(r),
+        }
+        return chain
+      }),
+      update: vi.fn(() => {
+        const chain = {
+          eq: vi.fn(() => chain),
+          is: vi.fn(() => chain),
+          select: vi.fn(() => Promise.resolve(m.notifUpdate ?? { data: [], error: null })),
+          then: (r: (v: unknown) => unknown) =>
+            Promise.resolve({ error: m.notifUpdateAllError ?? null }).then(r),
+        }
+        return chain
+      }),
+    })),
+  }
+}
+
+describe('notifications helpers', () => {
+  it('createNotification: success / error', async () => {
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifSingle: { data: { id: 'n', user_id: 'u', kind: 'invite.received', payload: { x: 1 }, read_at: null, created_at: 't' }, error: null },
+    }) as never)
+    const n = await createNotification({ userId: 'u', kind: 'invite.received', payload: { x: 1 } })
+    expect(n.id).toBe('n')
+
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifSingle: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(createNotification({ userId: 'u', kind: 'invite.received' })).rejects.toThrow('boom')
+  })
+
+  it('listNotificationsForUser: respects unreadOnly + default options + null fallback + error', async () => {
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifList: { data: [{ id: 'n1', user_id: 'u', kind: 'invite.received', payload: null, read_at: null, created_at: 't' }], error: null },
+    }) as never)
+    expect((await listNotificationsForUser('u', { unreadOnly: true, limit: 10 })).length).toBe(1)
+    expect((await listNotificationsForUser('u')).length).toBe(1)
+
+    // defensive `data || []` fallback
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifList: { data: null, error: null },
+    }) as never)
+    expect(await listNotificationsForUser('u')).toEqual([])
+
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifList: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(listNotificationsForUser('u')).rejects.toThrow('boom')
+  })
+
+  it('markNotificationRead: hit / miss / error', async () => {
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifUpdate: { data: [{ id: 'n' }], error: null },
+    }) as never)
+    expect(await markNotificationRead('n', 'u')).toBe(true)
+
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifUpdate: { data: [], error: null },
+    }) as never)
+    expect(await markNotificationRead('n', 'u')).toBe(false)
+
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifUpdate: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(markNotificationRead('n', 'u')).rejects.toThrow('boom')
+  })
+
+  it('markAllNotificationsRead: success / error', async () => {
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({}) as never)
+    await markAllNotificationsRead('u')
+
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifUpdateAllError: { message: 'boom' },
+    }) as never)
+    await expect(markAllNotificationsRead('u')).rejects.toThrow('boom')
+  })
+})
+
+type InviteRow = {
+  project_key: string
+  email: string
+  role: 'admin' | 'member'
+  invited_by: string
+  created_at: string
+}
+
+type InviteMocks = {
+  inviteSingle?: { data: InviteRow | null; error: { message: string } | null }
+  inviteList?: { data: InviteRow[] | null; error: { message: string } | null }
+  inviteInsertResult?: { data: InviteRow | null; error: { code?: string; message: string } | null }
+  inviteDeleteError?: { message: string } | null
+  memberInsertError?: { code?: string; message: string } | null
+}
+
+function inviteSupabase(m: InviteMocks = {}) {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'project_invites') {
+        return {
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve(m.inviteInsertResult ?? { data: null, error: null })),
+            })),
+          })),
+          select: vi.fn(() => {
+            const chain = {
+              eq: vi.fn(() => chain),
+              order: vi.fn(() => chain),
+              maybeSingle: vi.fn(() => Promise.resolve(m.inviteSingle ?? { data: null, error: null })),
+              then: (r: (v: unknown) => unknown) =>
+                Promise.resolve(m.inviteList ?? { data: [], error: null }).then(r),
+            }
+            return chain
+          }),
+          delete: vi.fn(() => {
+            const chain = {
+              eq: vi.fn(() => chain),
+              then: (r: (v: unknown) => unknown) =>
+                Promise.resolve({ error: m.inviteDeleteError ?? null }).then(r),
+            }
+            return chain
+          }),
+        }
+      }
+      if (table === 'project_members') {
+        return { insert: vi.fn(() => Promise.resolve({ error: m.memberInsertError ?? null })) }
+      }
+      throw new Error(`Unmocked table ${table}`)
+    }),
+  }
+}
+
+describe('invite helpers', () => {
+  const INVITE: InviteRow = { project_key: 'p', email: 'x@y.z', role: 'member', invited_by: 'inviter-1', created_at: 't' }
+
+  it('createInvite: success / already_invited / other error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteInsertResult: { data: INVITE, error: null },
+    }) as never)
+    expect((await createInvite({ projectKey: 'p', email: 'X@Y.Z', role: 'member', invitedBy: 'inviter-1' })).email).toBe('x@y.z')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteInsertResult: { data: null, error: { code: '23505', message: 'dup' } },
+    }) as never)
+    await expect(createInvite({ projectKey: 'p', email: 'x@y.z', role: 'member', invitedBy: 'i' })).rejects.toThrow('already_invited')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteInsertResult: { data: null, error: { code: '50000', message: 'boom' } },
+    }) as never)
+    await expect(createInvite({ projectKey: 'p', email: 'x@y.z', role: 'member', invitedBy: 'i' })).rejects.toThrow('boom')
+  })
+
+  it('listInvitesForEmail: success / null fallback / error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteList: { data: [INVITE], error: null },
+    }) as never)
+    expect((await listInvitesForEmail('X@Y.Z')).map((i) => i.projectKey)).toEqual(['p'])
+
+    // defensive `data || []` fallback
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteList: { data: null, error: null },
+    }) as never)
+    expect(await listInvitesForEmail('x@y.z')).toEqual([])
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteList: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(listInvitesForEmail('x@y.z')).rejects.toThrow('boom')
+  })
+
+  it('acceptInvite: not_found / happy / membership 23505 tolerated / other error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: null, error: null } }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('not_found')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: INVITE, error: null } }) as never)
+    expect(await acceptInvite('u', 'x@y.z', 'p')).toBe('inviter-1')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: INVITE, error: null },
+      memberInsertError: { code: '23505', message: 'dup' },
+    }) as never)
+    expect(await acceptInvite('u', 'x@y.z', 'p')).toBe('inviter-1')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: INVITE, error: null },
+      memberInsertError: { code: '50000', message: 'boom' },
+    }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('boom')
+  })
+
+  it('declineInvite: not_found / happy', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: null, error: null } }) as never)
+    await expect(declineInvite('x@y.z', 'p')).rejects.toThrow('not_found')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: INVITE, error: null } }) as never)
+    expect(await declineInvite('x@y.z', 'p')).toBe('inviter-1')
+  })
+
+  it('getInvite lookup error / deleteInvite error bubble through accept', async () => {
+    // getInvite error path
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: null, error: { message: 'lookup boom' } },
+    }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('lookup boom')
+
+    // deleteInvite error path (invite found, member insert ok, delete fails)
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: INVITE, error: null },
+      inviteDeleteError: { message: 'delete boom' },
+    }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('delete boom')
+  })
+})
+
+describe('findUserIdByEmail', () => {
+  const origFetch = globalThis.fetch
+  const origUrl = process.env.SUPABASE_URL
+  const origKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  beforeEach(() => {
+    process.env.SUPABASE_URL = 'https://supa.example'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key'
+  })
+
+  afterEach(() => {
+    globalThis.fetch = origFetch
+    process.env.SUPABASE_URL = origUrl
+    process.env.SUPABASE_SERVICE_ROLE_KEY = origKey
+  })
+
+  it('returns null when service role key is missing', async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns null when SUPABASE_URL is missing', async () => {
+    delete process.env.SUPABASE_URL
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns null when admin endpoint returns non-OK', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('nope', { status: 500 })) as never
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns the matching user id when found', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
+      users: [{ id: 'u-1', email: 'X@Y.Z' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } })) as never
+    expect(await findUserIdByEmail('x@y.z')).toBe('u-1')
+  })
+
+  it('returns null when fetch throws', async () => {
+    globalThis.fetch = vi.fn(async () => { throw new Error('net') }) as never
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns null when response shape is unexpected', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('{}', {
+      status: 200, headers: { 'content-type': 'application/json' },
+    })) as never
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
   })
 })

--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -3,7 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('./supabase.js', () => ({ getSupabase: vi.fn() }))
 
 import { getSupabase } from './supabase.js'
-import { ensurePublicProject } from './store.js'
+import {
+  claimProject,
+  ensurePublicProject,
+  getProjectMember,
+  isProjectMember,
+  listProjectsForUser,
+} from './store.js'
 
 type ProjectRow = {
   public_key: string
@@ -153,5 +159,133 @@ describe('ensurePublicProject', () => {
 
     const result = await ensurePublicProject('pk')
     expect(result.publicKey).toBe('pk')
+  })
+})
+
+type MembershipMocks = {
+  memberSingle?: { data: { role: 'admin' | 'member' } | null; error: { message: string } | null }
+  memberList?: { data: Array<{ project_key: string }> | null; error: { message: string } | null }
+  memberInsertError?: { code?: string; message: string } | null
+  projectsIn?: { data: ProjectRow[] | null; error: { message: string } | null }
+  projectsUpdate?: { data: ProjectRow[] | null; error: { message: string } | null }
+  projectsSingle?: { data: ProjectRow | null; error: { message: string } | null }
+}
+
+function membershipSupabase(m: MembershipMocks = {}) {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'project_members') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn((_k: string, _v: unknown) => {
+              const second = {
+                eq: vi.fn(() => ({
+                  maybeSingle: vi.fn(() => Promise.resolve(m.memberSingle ?? { data: null, error: null })),
+                })),
+                then: (r: (v: unknown) => unknown) => Promise.resolve(m.memberList ?? { data: [], error: null }).then(r),
+              }
+              return second
+            }),
+          })),
+          insert: vi.fn(() => Promise.resolve({ error: m.memberInsertError ?? null })),
+        }
+      }
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(() => ({ order: vi.fn(() => Promise.resolve(m.projectsIn ?? { data: [], error: null })) })),
+          eq: vi.fn(() => ({ maybeSingle: vi.fn(() => Promise.resolve(m.projectsSingle ?? { data: null, error: null })) })),
+        })),
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({ select: vi.fn(() => Promise.resolve(m.projectsUpdate ?? { data: [], error: null })) })),
+          })),
+        })),
+      }
+    }),
+  }
+}
+
+describe('membership helpers + claim', () => {
+  it('getProjectMember + isProjectMember cover hit / miss / error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      memberSingle: { data: { role: 'admin' }, error: null },
+    }) as never)
+    expect(await getProjectMember('u', 'p')).toEqual({ role: 'admin' })
+    expect(await isProjectMember('u', 'p')).toBe(true)
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      memberSingle: { data: null, error: null },
+    }) as never)
+    expect(await getProjectMember('u', 'p')).toBeNull()
+    expect(await isProjectMember('u', 'p')).toBe(false)
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      memberSingle: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(getProjectMember('u', 'p')).rejects.toThrow('boom')
+  })
+
+  it('listProjectsForUser returns empty / member-error / joined rows / projects-error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({ memberList: { data: [], error: null } }) as never)
+    expect(await listProjectsForUser('u')).toEqual([])
+
+    // defensive `data || []` fallback when supabase returns data:null, error:null
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({ memberList: { data: null, error: null } }) as never)
+    expect(await listProjectsForUser('u')).toEqual([])
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      memberList: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(listProjectsForUser('u')).rejects.toThrow('boom')
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      memberList: { data: [{ project_key: 'p1' }], error: null },
+      projectsIn: { data: [PROJECT_ROW], error: null },
+    }) as never)
+    expect((await listProjectsForUser('u')).map((p) => p.publicKey)).toEqual(['pk'])
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      memberList: { data: [{ project_key: 'p1' }], error: null },
+      projectsIn: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(listProjectsForUser('u')).rejects.toThrow('boom')
+  })
+
+  it('claimProject: success path', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [PROJECT_ROW], error: null },
+    }) as never)
+    expect((await claimProject('u', 'pk')).publicKey).toBe('pk')
+  })
+
+  it('claimProject: not_found / already_claimed / 23505 race / member-insert error / update error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+    }) as never)
+    await expect(claimProject('u', 'pk')).rejects.toThrow('not_found')
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: PROJECT_ROW, error: null },
+    }) as never)
+    await expect(claimProject('u', 'pk')).rejects.toThrow('already_claimed')
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [PROJECT_ROW], error: null },
+      memberInsertError: { code: '23505', message: 'dup' },
+    }) as never)
+    expect((await claimProject('u', 'pk')).publicKey).toBe('pk')
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [PROJECT_ROW], error: null },
+      memberInsertError: { code: '50000', message: 'boom' },
+    }) as never)
+    await expect(claimProject('u', 'pk')).rejects.toThrow('boom')
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: null, error: { message: 'db boom' } },
+    }) as never)
+    await expect(claimProject('u', 'pk')).rejects.toThrow('db boom')
   })
 })

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -26,6 +26,12 @@ type ProjectRow = {
   updated_at: string
 }
 
+type ProjectMemberRow = {
+  project_key: string
+  user_id: string
+  role: 'admin' | 'member'
+}
+
 type RepoConfigRow = {
   project_key: string
   repo_url: string | null
@@ -154,81 +160,84 @@ function mapEvent(row: EventRow) {
   }
 }
 
-export async function listProjects() {
+export async function listProjectsForUser(userId: string) {
   const supabase = getSupabase()
+  const { data: memberRows, error: memberError } = await supabase
+    .from('project_members')
+    .select('project_key')
+    .eq('user_id', userId)
+
+  if (memberError) throw new Error(memberError.message)
+  const keys = (memberRows || []).map((row) => String((row as { project_key: string }).project_key))
+  if (keys.length === 0) return []
+
   const { data, error } = await supabase
     .from('projects')
     .select('public_key, slug, name, created_at, updated_at')
+    .in('public_key', keys)
     .order('created_at', { ascending: true })
 
   if (error) throw new Error(error.message)
   return (data || []).map((row) => mapProject(row as ProjectRow))
 }
 
-function slugify(name: string) {
-  return name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 60)
-}
-
-function randomSuffix() {
-  return Math.random().toString(36).slice(2, 8)
-}
-
-export async function createProject(input: { name: string }) {
-  const trimmed = input.name.trim()
-  if (!trimmed) throw new Error('Project name required')
-
+export async function getProjectMember(
+  userId: string,
+  projectKey: string,
+): Promise<{ role: 'admin' | 'member' } | null> {
   const supabase = getSupabase()
-  const baseSlug = slugify(trimmed) || `project-${randomSuffix()}`
+  const { data, error } = await supabase
+    .from('project_members')
+    .select('project_key, user_id, role')
+    .eq('user_id', userId)
+    .eq('project_key', projectKey)
+    .maybeSingle()
 
-  let slug = baseSlug
-  let projectData: ProjectRow | null = null
-  let lastError: { code?: string; message: string } | null = null
+  if (error) throw new Error(error.message)
+  if (!data) return null
+  return { role: (data as ProjectMemberRow).role }
+}
 
-  for (let attempt = 0; attempt < 5; attempt++) {
-    const { data, error } = await supabase
-      .from('projects')
-      .insert([{
-        public_key: slug,
-        slug,
-        name: trimmed,
-        allowed_origins: [],
-      }] as never)
-      .select('public_key, slug, name, created_at, updated_at')
-      .single()
+export async function isProjectMember(userId: string, projectKey: string): Promise<boolean> {
+  return (await getProjectMember(userId, projectKey)) !== null
+}
 
-    if (!error) {
-      projectData = data as ProjectRow
-      break
-    }
+/**
+ * Atomically take ownership of an unclaimed project. Conditional UPDATE
+ * gates the race: only the first caller flips `claimable=false`, the rest
+ * see zero rows and get `already_claimed`. Membership INSERT after the flip
+ * is idempotent — a duplicate (23505) just means we already own it.
+ */
+export async function claimProject(
+  userId: string,
+  projectKey: string,
+): Promise<ReturnType<typeof mapProject>> {
+  const supabase = getSupabase()
 
-    // 23505 = unique_violation. Retry with new suffix; bail on anything else.
-    if (error.code !== '23505') throw new Error(error.message)
-    lastError = error
-    slug = `${baseSlug}-${randomSuffix()}`
+  const { data: updatedRows, error: updateError } = await supabase
+    .from('projects')
+    .update({ claimable: false, updated_at: new Date().toISOString() })
+    .eq('public_key', projectKey)
+    .eq('claimable', true)
+    .select('public_key, slug, name, created_at, updated_at')
+
+  if (updateError) throw new Error(updateError.message)
+
+  if (!updatedRows || updatedRows.length === 0) {
+    const existing = await getProject(projectKey)
+    if (!existing) throw new Error('not_found')
+    throw new Error('already_claimed')
   }
 
-  if (!projectData) {
-    throw new Error(lastError?.message || 'Could not allocate unique project slug')
+  const { error: memberError } = await supabase
+    .from('project_members')
+    .insert([{ project_key: projectKey, user_id: userId, role: 'admin' }] as never)
+
+  if (memberError && memberError.code !== '23505') {
+    throw new Error(memberError.message)
   }
 
-  const { error: repoError } = await supabase
-    .from('project_repo_configs')
-    .insert([{
-      project_key: slug,
-      default_branch: 'main',
-    }] as never)
-
-  if (repoError) {
-    await supabase.from('projects').delete().eq('public_key', slug)
-    throw new Error(repoError.message)
-  }
-
-  return mapProject(projectData)
+  return mapProject(updatedRows[0] as ProjectRow)
 }
 
 export async function getProject(projectKey: string) {

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from './supabase.js'
+import { getServiceSupabase, getSupabase } from './supabase.js'
 import { fromLegacyStatus, toLegacyStatus, type ImplementationStatus, type ReviewStatus } from './status.js'
 
 type CommentRow = {
@@ -770,5 +770,214 @@ export async function saveOperationKey(shareId: string, agentId: string, idempot
     }] as never)
 
   if (error) throw new Error(error.message)
+}
+
+export type NotificationKind = 'invite.received' | 'invite.accepted' | 'invite.declined'
+
+type NotificationRow = {
+  id: string
+  user_id: string
+  kind: NotificationKind
+  payload: Record<string, unknown>
+  read_at: string | null
+  created_at: string
+}
+
+function mapNotification(row: NotificationRow) {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    kind: row.kind,
+    payload: row.payload || {},
+    readAt: row.read_at,
+    createdAt: row.created_at,
+  }
+}
+
+// Notifications uses the service-role client because the table has RLS
+// (`auth.uid() = user_id`) enabled for safe per-user realtime subscriptions.
+// The backend has no user JWT in its supabase client, so anon-key queries
+// would always see zero rows / fail to insert. Service role bypasses RLS;
+// these helpers enforce the user_id scope themselves.
+export async function createNotification(input: {
+  userId: string
+  kind: NotificationKind
+  payload?: Record<string, unknown>
+}) {
+  const supabase = getServiceSupabase()
+  const { data, error } = await supabase
+    .from('notifications')
+    .insert([{ user_id: input.userId, kind: input.kind, payload: input.payload ?? {} }] as never)
+    .select('id, user_id, kind, payload, read_at, created_at')
+    .single()
+  if (error) throw new Error(error.message)
+  return mapNotification(data as NotificationRow)
+}
+
+export async function listNotificationsForUser(
+  userId: string,
+  opts: { unreadOnly?: boolean; limit?: number } = {},
+) {
+  const supabase = getServiceSupabase()
+  let query = supabase
+    .from('notifications')
+    .select('id, user_id, kind, payload, read_at, created_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(opts.limit ?? 50)
+  if (opts.unreadOnly) query = query.is('read_at', null)
+  const { data, error } = await query
+  if (error) throw new Error(error.message)
+  return (data || []).map((row) => mapNotification(row as NotificationRow))
+}
+
+export async function markNotificationRead(notificationId: string, userId: string): Promise<boolean> {
+  const supabase = getServiceSupabase()
+  const { data, error } = await supabase
+    .from('notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('id', notificationId)
+    .eq('user_id', userId)
+    .is('read_at', null)
+    .select('id')
+  if (error) throw new Error(error.message)
+  return Array.isArray(data) && data.length > 0
+}
+
+export async function markAllNotificationsRead(userId: string) {
+  const supabase = getServiceSupabase()
+  const { error } = await supabase
+    .from('notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('user_id', userId)
+    .is('read_at', null)
+  if (error) throw new Error(error.message)
+}
+
+type InviteRow = {
+  project_key: string
+  email: string
+  role: 'admin' | 'member'
+  invited_by: string
+  created_at: string
+}
+
+function mapInvite(row: InviteRow) {
+  return {
+    projectKey: row.project_key,
+    email: row.email,
+    role: row.role,
+    invitedBy: row.invited_by,
+    createdAt: row.created_at,
+  }
+}
+
+export async function createInvite(input: {
+  projectKey: string
+  email: string
+  role: 'admin' | 'member'
+  invitedBy: string
+}) {
+  const supabase = getSupabase()
+  const email = input.email.toLowerCase().trim()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .insert([{
+      project_key: input.projectKey,
+      email,
+      role: input.role,
+      invited_by: input.invitedBy,
+    }] as never)
+    .select('project_key, email, role, invited_by, created_at')
+    .single()
+  if (error) {
+    if (error.code === '23505') throw new Error('already_invited')
+    throw new Error(error.message)
+  }
+  return mapInvite(data as InviteRow)
+}
+
+export async function listInvitesForEmail(email: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .select('project_key, email, role, invited_by, created_at')
+    .eq('email', email.toLowerCase().trim())
+    .order('created_at', { ascending: false })
+  if (error) throw new Error(error.message)
+  return (data || []).map((row) => mapInvite(row as InviteRow))
+}
+
+async function getInvite(email: string, projectKey: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .select('project_key, email, role, invited_by, created_at')
+    .eq('email', email.toLowerCase().trim())
+    .eq('project_key', projectKey)
+    .maybeSingle()
+  if (error) throw new Error(error.message)
+  return data ? mapInvite(data as InviteRow) : null
+}
+
+async function deleteInvite(email: string, projectKey: string) {
+  const supabase = getSupabase()
+  const { error } = await supabase
+    .from('project_invites')
+    .delete()
+    .eq('email', email.toLowerCase().trim())
+    .eq('project_key', projectKey)
+  if (error) throw new Error(error.message)
+}
+
+/**
+ * Atomic invite acceptance: verify the invite exists for this email, insert
+ * the project_members row (idempotent via 23505), delete the invite. Returns
+ * the inviter's user_id so the caller can emit an `invite.accepted` notif.
+ */
+export async function acceptInvite(userId: string, email: string, projectKey: string): Promise<string> {
+  const invite = await getInvite(email, projectKey)
+  if (!invite) throw new Error('not_found')
+
+  const supabase = getSupabase()
+  const { error: insertError } = await supabase
+    .from('project_members')
+    .insert([{ project_key: projectKey, user_id: userId, role: invite.role }] as never)
+  if (insertError && insertError.code !== '23505') throw new Error(insertError.message)
+
+  await deleteInvite(email, projectKey)
+  return invite.invitedBy
+}
+
+export async function declineInvite(email: string, projectKey: string): Promise<string> {
+  const invite = await getInvite(email, projectKey)
+  if (!invite) throw new Error('not_found')
+  await deleteInvite(email, projectKey)
+  return invite.invitedBy
+}
+
+/**
+ * Look up the auth.users id for an email. Uses the service role admin API if
+ * a SUPABASE_SERVICE_ROLE_KEY is configured; otherwise returns null. The null
+ * fallback is intentional — the invite still gets created, just no realtime
+ * notif fires for the invitee (they'll see it on next login via GET /invites).
+ */
+export async function findUserIdByEmail(email: string): Promise<string | null> {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!serviceKey) return null
+  const url = process.env.SUPABASE_URL
+  if (!url) return null
+  try {
+    const res = await fetch(`${url}/auth/v1/admin/users?email=${encodeURIComponent(email)}`, {
+      headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as { users?: Array<{ id?: string; email?: string }> }
+    const users = Array.isArray(body.users) ? body.users : []
+    const match = users.find((u) => u.email?.toLowerCase() === email.toLowerCase())
+    return match?.id ?? null
+  } catch {
+    return null
+  }
 }
 

--- a/api/_lib/supabase.test.ts
+++ b/api/_lib/supabase.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: vi.fn() })),
+}))
+
+import { createClient } from '@supabase/supabase-js'
+import { getServiceSupabase, getSupabase } from './supabase.js'
+
+const origUrl = process.env.SUPABASE_URL
+const origKey = process.env.SUPABASE_KEY
+const origServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+beforeEach(() => {
+  vi.mocked(createClient).mockClear()
+  process.env.SUPABASE_URL = 'https://supa.example'
+  process.env.SUPABASE_KEY = 'anon-key'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key'
+})
+
+afterEach(() => {
+  process.env.SUPABASE_URL = origUrl
+  process.env.SUPABASE_KEY = origKey
+  process.env.SUPABASE_SERVICE_ROLE_KEY = origServiceKey
+})
+
+describe('getSupabase', () => {
+  it('builds an anon-key client', () => {
+    getSupabase()
+    expect(createClient).toHaveBeenCalledWith('https://supa.example', 'anon-key')
+  })
+
+  it('throws when SUPABASE_URL is missing', () => {
+    delete process.env.SUPABASE_URL
+    expect(() => getSupabase()).toThrow(/missing Supabase credentials/)
+  })
+
+  it('throws when SUPABASE_KEY is missing', () => {
+    delete process.env.SUPABASE_KEY
+    expect(() => getSupabase()).toThrow(/missing Supabase credentials/)
+  })
+})
+
+describe('getServiceSupabase', () => {
+  it('builds a service-role client with persistSession disabled', () => {
+    getServiceSupabase()
+    expect(createClient).toHaveBeenCalledWith(
+      'https://supa.example',
+      'svc-key',
+      { auth: { persistSession: false, autoRefreshToken: false } },
+    )
+  })
+
+  it('throws when SUPABASE_SERVICE_ROLE_KEY is missing', () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    expect(() => getServiceSupabase()).toThrow(/missing Supabase credentials/)
+  })
+
+  it('throws when SUPABASE_URL is missing', () => {
+    delete process.env.SUPABASE_URL
+    expect(() => getServiceSupabase()).toThrow(/missing Supabase credentials/)
+  })
+})

--- a/api/_lib/supabase.ts
+++ b/api/_lib/supabase.ts
@@ -11,3 +11,21 @@ export function getSupabase(): SupabaseClient {
   return createClient(supabaseUrl, supabaseKey)
 }
 
+/**
+ * Service-role client. Bypasses RLS, so use it only for backend writes/reads
+ * on RLS-protected tables (currently: `notifications`). Frontend code must
+ * never call this. SUPABASE_SERVICE_ROLE_KEY is required.
+ */
+export function getServiceSupabase(): SupabaseClient {
+  const supabaseUrl = process.env.SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceKey) {
+    throw new Error('Server misconfigured: missing Supabase credentials')
+  }
+
+  return createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+}
+

--- a/api/v1/comments/[commentId]/implementation-status.test.ts
+++ b/api/v1/comments/[commentId]/implementation-status.test.ts
@@ -1,14 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/auth.js', () => ({
+  requireUser: vi.fn(),
+  requireProjectMembership: vi.fn(),
+}))
 vi.mock('../../../_lib/store.js', () => ({
   createFeedbackEvent: vi.fn(),
   findActiveSharesForComment: vi.fn(),
+  getComment: vi.fn(),
   updateImplementationStatus: vi.fn(),
 }))
 
 import handler from './implementation-status.js'
-import { requireUser } from '../../../_lib/auth.js'
+import { requireProjectMembership, requireUser } from '../../../_lib/auth.js'
+import {
+  createFeedbackEvent,
+  findActiveSharesForComment,
+  getComment,
+  updateImplementationStatus,
+} from '../../../_lib/store.js'
 
 function mockRes() {
   return {
@@ -26,6 +36,11 @@ const call = (req: unknown, res: unknown) =>
 
 beforeEach(() => {
   vi.mocked(requireUser).mockReset()
+  vi.mocked(requireProjectMembership).mockReset()
+  vi.mocked(getComment).mockReset()
+  vi.mocked(updateImplementationStatus).mockReset()
+  vi.mocked(findActiveSharesForComment).mockReset()
+  vi.mocked(createFeedbackEvent).mockReset()
 })
 
 describe('api/v1/comments/[commentId]/implementation-status', () => {
@@ -34,17 +49,57 @@ describe('api/v1/comments/[commentId]/implementation-status', () => {
       res.status(401).json({ error: 'Unauthorized' })
       return null
     })
-
     const res = mockRes()
-    await call({ method: 'PATCH', query: { commentId: 'c' }, body: {}, headers: {} }, res)
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { implementationStatus: 'claimed' }, headers: {} }, res)
     expect(res.statusCode).toBe(401)
   })
 
-  it('proceeds past the guard when requireUser returns a user', async () => {
+  it('validates body + comment lookup + membership', async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
 
-    const res = mockRes()
-    await call({ method: 'PATCH', query: {}, body: {}, headers: {} }, res)
+    let res = mockRes()
+    await call({ method: 'PATCH', query: {}, body: { implementationStatus: 'claimed' }, headers: {} }, res)
     expect(res.statusCode).toBe(400)
+
+    res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { implementationStatus: 'bogus' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(getComment).mockResolvedValueOnce(null)
+    res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { implementationStatus: 'claimed' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(getComment).mockResolvedValueOnce({ id: 'c', projectId: null } as never)
+    res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { implementationStatus: 'claimed' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(getComment).mockResolvedValueOnce({ id: 'c', projectId: 'p' } as never)
+    vi.mocked(requireProjectMembership).mockImplementationOnce(async (_q, r) => {
+      r.status(403).json({ error: 'Forbidden' })
+      return false
+    })
+    res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { implementationStatus: 'claimed' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('updates implementation status and emits events; returns 500 on store throw', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getComment).mockResolvedValue({ id: 'c', projectId: 'p' } as never)
+    vi.mocked(requireProjectMembership).mockResolvedValue(true)
+    vi.mocked(updateImplementationStatus).mockResolvedValueOnce({ id: 'c' } as never)
+    vi.mocked(findActiveSharesForComment).mockResolvedValueOnce([{ id: 's1' }] as never)
+
+    let res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { implementationStatus: 'claimed' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(createFeedbackEvent).toHaveBeenCalledWith(expect.objectContaining({ eventType: 'comment.implementation_changed' }))
+
+    vi.mocked(updateImplementationStatus).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { implementationStatus: 'claimed' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
   })
 })

--- a/api/v1/comments/[commentId]/implementation-status.ts
+++ b/api/v1/comments/[commentId]/implementation-status.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireUser } from '../../../_lib/auth.js'
-import { createFeedbackEvent, findActiveSharesForComment, updateImplementationStatus } from '../../../_lib/store.js'
+import { requireProjectMembership, requireUser } from '../../../_lib/auth.js'
+import { createFeedbackEvent, findActiveSharesForComment, getComment, updateImplementationStatus } from '../../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
 import { IMPLEMENTATION_STATUSES, type ImplementationStatus } from '../../../_lib/status.js'
 
@@ -9,8 +9,8 @@ const VALID_STATUSES = new Set<ImplementationStatus>(IMPLEMENTATION_STATUSES)
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['PATCH', 'OPTIONS'])) return
   if (req.method !== 'PATCH') return methodNotAllowed(req, res, ['PATCH', 'OPTIONS'])
-  // TODO(membership): fetch comment → require membership on comment.projectId.
-  if (!(await requireUser(req, res))) return
+  const user = await requireUser(req, res)
+  if (!user) return
 
   try {
     const commentId = getStringQuery(req.query.commentId)
@@ -20,6 +20,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!implementationStatus || !VALID_STATUSES.has(implementationStatus)) {
       return jsonError(req, res, 400, `implementationStatus must be one of: ${IMPLEMENTATION_STATUSES.join(', ')}`)
     }
+
+    const existing = await getComment(commentId)
+    if (!existing || !existing.projectId) return jsonError(req, res, 404, 'Comment not found')
+    if (!(await requireProjectMembership(req, res, user, existing.projectId))) return
 
     const [comment, activeShares] = await Promise.all([
       updateImplementationStatus(commentId, { implementationStatus }),

--- a/api/v1/comments/[commentId]/review-status.test.ts
+++ b/api/v1/comments/[commentId]/review-status.test.ts
@@ -1,14 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/auth.js', () => ({
+  requireUser: vi.fn(),
+  requireProjectMembership: vi.fn(),
+}))
 vi.mock('../../../_lib/store.js', () => ({
   createFeedbackEvent: vi.fn(),
   findActiveSharesForComment: vi.fn(),
+  getComment: vi.fn(),
   updateReviewStatus: vi.fn(),
 }))
 
 import handler from './review-status.js'
-import { requireUser } from '../../../_lib/auth.js'
+import { requireProjectMembership, requireUser } from '../../../_lib/auth.js'
+import {
+  createFeedbackEvent,
+  findActiveSharesForComment,
+  getComment,
+  updateReviewStatus,
+} from '../../../_lib/store.js'
 
 function mockRes() {
   return {
@@ -26,6 +36,11 @@ const call = (req: unknown, res: unknown) =>
 
 beforeEach(() => {
   vi.mocked(requireUser).mockReset()
+  vi.mocked(requireProjectMembership).mockReset()
+  vi.mocked(getComment).mockReset()
+  vi.mocked(updateReviewStatus).mockReset()
+  vi.mocked(findActiveSharesForComment).mockReset()
+  vi.mocked(createFeedbackEvent).mockReset()
 })
 
 describe('api/v1/comments/[commentId]/review-status', () => {
@@ -34,17 +49,62 @@ describe('api/v1/comments/[commentId]/review-status', () => {
       res.status(401).json({ error: 'Unauthorized' })
       return null
     })
-
     const res = mockRes()
-    await call({ method: 'PATCH', query: { commentId: 'c' }, body: {}, headers: {} }, res)
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { reviewStatus: 'accepted' }, headers: {} }, res)
     expect(res.statusCode).toBe(401)
   })
 
-  it('proceeds past the guard when requireUser returns a user', async () => {
+  it('validates body + comment lookup + membership', async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
 
-    const res = mockRes()
-    await call({ method: 'PATCH', query: {}, body: {}, headers: {} }, res)
+    // missing commentId
+    let res = mockRes()
+    await call({ method: 'PATCH', query: {}, body: { reviewStatus: 'accepted' }, headers: {} }, res)
     expect(res.statusCode).toBe(400)
+
+    // invalid reviewStatus
+    res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { reviewStatus: 'bogus' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // comment not found
+    vi.mocked(getComment).mockResolvedValueOnce(null)
+    res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { reviewStatus: 'accepted' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    // comment with null projectId
+    vi.mocked(getComment).mockResolvedValueOnce({ id: 'c', projectId: null } as never)
+    res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { reviewStatus: 'accepted' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    // not a member
+    vi.mocked(getComment).mockResolvedValueOnce({ id: 'c', projectId: 'p' } as never)
+    vi.mocked(requireProjectMembership).mockImplementationOnce(async (_q, r) => {
+      r.status(403).json({ error: 'Forbidden' })
+      return false
+    })
+    res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { reviewStatus: 'accepted' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('updates review status and emits events; returns 500 on store throw', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getComment).mockResolvedValue({ id: 'c', projectId: 'p' } as never)
+    vi.mocked(requireProjectMembership).mockResolvedValue(true)
+    vi.mocked(updateReviewStatus).mockResolvedValueOnce({ id: 'c' } as never)
+    vi.mocked(findActiveSharesForComment).mockResolvedValueOnce([{ id: 's1' }] as never)
+
+    let res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { reviewStatus: 'accepted' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(createFeedbackEvent).toHaveBeenCalledWith(expect.objectContaining({ eventType: 'comment.reviewed' }))
+
+    vi.mocked(updateReviewStatus).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'PATCH', query: { commentId: 'c' }, body: { reviewStatus: 'accepted' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
   })
 })

--- a/api/v1/comments/[commentId]/review-status.ts
+++ b/api/v1/comments/[commentId]/review-status.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireUser } from '../../../_lib/auth.js'
-import { createFeedbackEvent, findActiveSharesForComment, updateReviewStatus } from '../../../_lib/store.js'
+import { requireProjectMembership, requireUser } from '../../../_lib/auth.js'
+import { createFeedbackEvent, findActiveSharesForComment, getComment, updateReviewStatus } from '../../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
 import type { ReviewStatus } from '../../../_lib/status.js'
 
@@ -9,8 +9,8 @@ const VALID_STATUSES = new Set<ReviewStatus>(['open', 'accepted', 'rejected'])
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['PATCH', 'OPTIONS'])) return
   if (req.method !== 'PATCH') return methodNotAllowed(req, res, ['PATCH', 'OPTIONS'])
-  // TODO(membership): fetch comment → require membership on comment.projectId.
-  if (!(await requireUser(req, res))) return
+  const user = await requireUser(req, res)
+  if (!user) return
 
   try {
     const commentId = getStringQuery(req.query.commentId)
@@ -20,6 +20,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!reviewStatus || !VALID_STATUSES.has(reviewStatus)) {
       return jsonError(req, res, 400, 'reviewStatus must be open, accepted, or rejected')
     }
+
+    const existing = await getComment(commentId)
+    if (!existing || !existing.projectId) return jsonError(req, res, 404, 'Comment not found')
+    if (!(await requireProjectMembership(req, res, user, existing.projectId))) return
 
     const comment = await updateReviewStatus(commentId, reviewStatus)
     const activeShares = await findActiveSharesForComment(commentId)

--- a/api/v1/feedback-shares/[shareId]/prompt.test.ts
+++ b/api/v1/feedback-shares/[shareId]/prompt.test.ts
@@ -1,16 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/auth.js', () => ({
+  requireUser: vi.fn(),
+  requireProjectMembership: vi.fn(),
+}))
 vi.mock('../../../_lib/store.js', () => ({
   getProject: vi.fn(),
   getRepoConfig: vi.fn(),
   getShareById: vi.fn(),
 }))
-vi.mock('../../../_lib/prompts.js', () => ({ buildPrompt: vi.fn() }))
-vi.mock('../../../_lib/tokens.js', () => ({ decryptToken: vi.fn() }))
+vi.mock('../../../_lib/prompts.js', () => ({ buildPrompt: vi.fn(() => 'PROMPT_TEXT') }))
+vi.mock('../../../_lib/tokens.js', () => ({ decryptToken: vi.fn(() => 'tok') }))
 
 import handler from './prompt.js'
-import { requireUser } from '../../../_lib/auth.js'
+import { requireProjectMembership, requireUser } from '../../../_lib/auth.js'
+import { getProject, getRepoConfig, getShareById } from '../../../_lib/store.js'
 
 function mockRes() {
   return {
@@ -25,9 +29,15 @@ function mockRes() {
 }
 const call = (req: unknown, res: unknown) =>
   (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+const SHARE = { id: 's', projectId: 'p', slug: 'sl', scopePageUrl: null, accessTokenCiphertext: 'c' }
 
 beforeEach(() => {
+  process.env.APP_URL = 'https://app.example'
   vi.mocked(requireUser).mockReset()
+  vi.mocked(requireProjectMembership).mockReset()
+  vi.mocked(getShareById).mockReset()
+  vi.mocked(getProject).mockReset()
+  vi.mocked(getRepoConfig).mockReset()
 })
 
 describe('api/v1/feedback-shares/[shareId]/prompt', () => {
@@ -36,17 +46,55 @@ describe('api/v1/feedback-shares/[shareId]/prompt', () => {
       res.status(401).json({ error: 'Unauthorized' })
       return null
     })
-
     const res = mockRes()
     await call({ method: 'GET', query: { shareId: 's' }, headers: {} }, res)
     expect(res.statusCode).toBe(401)
   })
 
-  it('proceeds past the guard when requireUser returns a user', async () => {
+  it('validates shareId / share lookup / membership / project lookup', async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
 
-    const res = mockRes()
+    let res = mockRes()
     await call({ method: 'GET', query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(400)
+
+    vi.mocked(getShareById).mockResolvedValueOnce(null)
+    res = mockRes()
+    await call({ method: 'GET', query: { shareId: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(getShareById).mockResolvedValueOnce(SHARE as never)
+    vi.mocked(requireProjectMembership).mockImplementationOnce(async (_q, r) => {
+      r.status(403).json({ error: 'Forbidden' })
+      return false
+    })
+    res = mockRes()
+    await call({ method: 'GET', query: { shareId: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    vi.mocked(getShareById).mockResolvedValueOnce(SHARE as never)
+    vi.mocked(requireProjectMembership).mockResolvedValueOnce(true)
+    vi.mocked(getProject).mockResolvedValueOnce(null)
+    res = mockRes()
+    await call({ method: 'GET', query: { shareId: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('returns the prompt on success; 500 on store throw', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getShareById).mockResolvedValueOnce(SHARE as never)
+    vi.mocked(requireProjectMembership).mockResolvedValueOnce(true)
+    vi.mocked(getProject).mockResolvedValueOnce({ publicKey: 'p', name: 'P' } as never)
+    vi.mocked(getRepoConfig).mockResolvedValueOnce(null)
+
+    let res = mockRes()
+    await call({ method: 'GET', query: { shareId: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ prompt: 'PROMPT_TEXT' })
+
+    vi.mocked(getShareById).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'GET', query: { shareId: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
   })
 })

--- a/api/v1/feedback-shares/[shareId]/prompt.ts
+++ b/api/v1/feedback-shares/[shareId]/prompt.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireUser } from '../../../_lib/auth.js'
+import { requireProjectMembership, requireUser } from '../../../_lib/auth.js'
 import { getAppUrl, handleOptions, jsonError, methodNotAllowed, setCors, getStringQuery } from '../../../_lib/http.js'
 import { getProject, getRepoConfig, getShareById } from '../../../_lib/store.js'
 import { buildPrompt } from '../../../_lib/prompts.js'
@@ -8,8 +8,8 @@ import { decryptToken } from '../../../_lib/tokens.js'
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
   if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
-  // TODO(membership): fetch share → require membership on share.projectId.
-  if (!(await requireUser(req, res))) return
+  const user = await requireUser(req, res)
+  if (!user) return
 
   try {
     const shareId = getStringQuery(req.query.shareId)
@@ -18,6 +18,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const share = await getShareById(shareId)
     if (!share) return jsonError(req, res, 404, 'Share not found')
+    if (!(await requireProjectMembership(req, res, user, share.projectId))) return
 
     const project = await getProject(share.projectId)
     if (!project) return jsonError(req, res, 404, 'Project not found')

--- a/api/v1/feedback-shares/index.test.ts
+++ b/api/v1/feedback-shares/index.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../_lib/auth.js', () => ({
   requireUser: vi.fn(),
+  requireProjectMembership: vi.fn(),
 }))
 
 vi.mock('../../_lib/store.js', () => ({
@@ -20,7 +21,7 @@ vi.mock('../../_lib/tokens.js', () => ({
 }))
 
 import handler from './index.js'
-import { requireUser } from '../../_lib/auth.js'
+import { requireProjectMembership, requireUser } from '../../_lib/auth.js'
 import {
   addShareItems,
   createFeedbackEvent,
@@ -72,6 +73,8 @@ beforeEach(() => {
   process.env.APP_URL = 'https://app.example'
   vi.mocked(requireUser).mockReset()
   vi.mocked(requireUser).mockResolvedValue({ userId: 'u-test', email: 'test@example.com' })
+  vi.mocked(requireProjectMembership).mockReset()
+  vi.mocked(requireProjectMembership).mockResolvedValue(true)
   vi.mocked(listAcceptedCommentsForPage).mockReset()
   vi.mocked(listAcceptedCommentsByIds).mockReset()
   vi.mocked(createShare).mockReset()
@@ -89,6 +92,19 @@ describe('api/v1/feedback-shares', () => {
     const res = mockRes()
     await call(mockReq({ body: {} }), res)
     expect(res.statusCode).toBe(401)
+  })
+
+  it('returns 403 when user is not a project member', async () => {
+    vi.mocked(requireProjectMembership).mockImplementation(async (_req, res) => {
+      res.status(403).json({ error: 'Forbidden' })
+      return false
+    })
+
+    const res = mockRes()
+    await call(mockReq({
+      body: { projectId: 'demo-project', scopeType: 'page', pageUrl: 'https://x' },
+    }), res)
+    expect(res.statusCode).toBe(403)
   })
 
   it('creates a page-scoped share from accepted comments', async () => {

--- a/api/v1/feedback-shares/index.ts
+++ b/api/v1/feedback-shares/index.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireUser } from '../../_lib/auth.js'
+import { requireProjectMembership, requireUser } from '../../_lib/auth.js'
 import { createFeedbackEvent, createShare, addShareItems, listAcceptedCommentsByIds, listAcceptedCommentsForPage } from '../../_lib/store.js'
 import { generateAccessToken, generateSlug, hashToken, encryptToken } from '../../_lib/tokens.js'
 import { getAppUrl, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
@@ -7,14 +7,15 @@ import { getAppUrl, handleOptions, jsonError, methodNotAllowed, setCors } from '
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
   if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
-  // TODO(membership): require membership on body.projectId.
-  if (!(await requireUser(req, res))) return
+  const user = await requireUser(req, res)
+  if (!user) return
 
   try {
     const { projectId, scopeType, pageUrl, commentIds } = req.body ?? {}
     if (!projectId || (scopeType !== 'page' && scopeType !== 'selection')) {
       return jsonError(req, res, 400, 'scopeType must be page or selection')
     }
+    if (!(await requireProjectMembership(req, res, user, projectId))) return
 
     const comments = scopeType === 'page'
       ? await listAcceptedCommentsForPage(projectId, pageUrl)

--- a/api/v1/invites/accept.test.ts
+++ b/api/v1/invites/accept.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({
+  acceptInvite: vi.fn(),
+  createNotification: vi.fn(),
+}))
+
+import handler from './accept.js'
+import { requireUser } from '../../_lib/auth.js'
+import { acceptInvite, createNotification } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(acceptInvite).mockReset()
+  vi.mocked(createNotification).mockReset()
+})
+
+describe('api/v1/invites/accept', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('tolerates absent body (req.body ?? {} fallback)', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('non-POST + unauthed', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('validates body + not_found + happy path + 500', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    let res = mockRes()
+    await call({ method: 'POST', body: {}, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(acceptInvite).mockRejectedValueOnce(new Error('not_found'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(acceptInvite).mockResolvedValueOnce('inviter-1')
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'inviter-1', kind: 'invite.accepted',
+    }))
+
+    // notif emit fails → accept still returns 200 (fanout is fire-and-forget)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(acceptInvite).mockResolvedValueOnce('inviter-1')
+    vi.mocked(createNotification).mockRejectedValueOnce(new Error('notif down'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    vi.mocked(acceptInvite).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+
+    // non-Error throw → 500
+    vi.mocked(acceptInvite).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+})

--- a/api/v1/invites/accept.ts
+++ b/api/v1/invites/accept.ts
@@ -1,0 +1,36 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { acceptInvite, createNotification } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const body = (req.body ?? {}) as { projectKey?: unknown }
+  const projectKey = typeof body.projectKey === 'string' ? body.projectKey.trim() : ''
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectKey')
+
+  try {
+    const inviterId = await acceptInvite(user.userId, user.email, projectKey)
+    // Notif fanout failure can't undo membership; log + continue.
+    try {
+      await createNotification({
+        userId: inviterId,
+        kind: 'invite.accepted',
+        payload: { projectKey, acceptedBy: user.userId, email: user.email },
+      })
+    } catch (notifError) {
+      console.warn('invite.accepted notif failed:', notifError)
+    }
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json({ projectKey })
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : undefined
+    if (msg === 'not_found') return jsonError(req, res, 404, 'Invite not found')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/invites/decline.test.ts
+++ b/api/v1/invites/decline.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({
+  declineInvite: vi.fn(),
+  createNotification: vi.fn(),
+}))
+
+import handler from './decline.js'
+import { requireUser } from '../../_lib/auth.js'
+import { createNotification, declineInvite } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(declineInvite).mockReset()
+  vi.mocked(createNotification).mockReset()
+})
+
+describe('api/v1/invites/decline', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('tolerates absent body (req.body ?? {} fallback)', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('non-POST + unauthed + validation + not_found + happy + 500', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    res = mockRes()
+    await call({ method: 'POST', body: {}, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(declineInvite).mockRejectedValueOnce(new Error('not_found'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(declineInvite).mockResolvedValueOnce('inviter-1')
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'inviter-1', kind: 'invite.declined',
+    }))
+
+    // notif emit fails → decline still returns 200 (fanout is fire-and-forget)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(declineInvite).mockResolvedValueOnce('inviter-1')
+    vi.mocked(createNotification).mockRejectedValueOnce(new Error('notif down'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    vi.mocked(declineInvite).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+
+    // non-Error throw → 500
+    vi.mocked(declineInvite).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+})

--- a/api/v1/invites/decline.ts
+++ b/api/v1/invites/decline.ts
@@ -1,0 +1,36 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { createNotification, declineInvite } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const body = (req.body ?? {}) as { projectKey?: unknown }
+  const projectKey = typeof body.projectKey === 'string' ? body.projectKey.trim() : ''
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectKey')
+
+  try {
+    const inviterId = await declineInvite(user.email, projectKey)
+    // Notif fanout failure can't undo decline; log + continue.
+    try {
+      await createNotification({
+        userId: inviterId,
+        kind: 'invite.declined',
+        payload: { projectKey, declinedBy: user.userId, email: user.email },
+      })
+    } catch (notifError) {
+      console.warn('invite.declined notif failed:', notifError)
+    }
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json({ projectKey })
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : undefined
+    if (msg === 'not_found') return jsonError(req, res, 404, 'Invite not found')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/invites/index.test.ts
+++ b/api/v1/invites/index.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({ listInvitesForEmail: vi.fn() }))
+
+import handler from './index.js'
+import { requireUser } from '../../_lib/auth.js'
+import { listInvitesForEmail } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(listInvitesForEmail).mockReset()
+})
+
+describe('api/v1/invites', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('returns 500 on non-Error throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(listInvitesForEmail).mockImplementationOnce(() => { throw 'string-not-error' })
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+
+  it('non-GET 405; unauthed 401; happy path lists invites; 500 on throw', async () => {
+    let res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(listInvitesForEmail).mockResolvedValueOnce([{ projectKey: 'p' }] as never)
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(listInvitesForEmail).toHaveBeenCalledWith('a@b.c')
+
+    vi.mocked(listInvitesForEmail).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/invites/index.ts
+++ b/api/v1/invites/index.ts
@@ -1,0 +1,20 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { listInvitesForEmail } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  try {
+    const invites = await listInvitesForEmail(user.email)
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json(invites)
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/notifications/[notificationId]/read.test.ts
+++ b/api/v1/notifications/[notificationId]/read.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({ markNotificationRead: vi.fn() }))
+
+import handler from './read.js'
+import { requireUser } from '../../../_lib/auth.js'
+import { markNotificationRead } from '../../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(markNotificationRead).mockReset()
+})
+
+describe('api/v1/notifications/[notificationId]/read', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('returns 500 on non-Error throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(markNotificationRead).mockImplementationOnce(() => { throw 'string-not-error' })
+    const res = mockRes()
+    await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+
+  it('non-POST 405; unauthed 401; missing id; happy / not_found / 500', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(markNotificationRead).mockResolvedValueOnce(true)
+    res = mockRes()
+    await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(markNotificationRead).toHaveBeenCalledWith('n', 'u')
+
+    vi.mocked(markNotificationRead).mockResolvedValueOnce(false)
+    res = mockRes()
+    await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(markNotificationRead).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/notifications/[notificationId]/read.ts
+++ b/api/v1/notifications/[notificationId]/read.ts
@@ -1,0 +1,24 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../../_lib/auth.js'
+import { markNotificationRead } from '../../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const notificationId = getStringQuery(req.query.notificationId)
+  if (!notificationId) return jsonError(req, res, 400, 'Missing notificationId')
+
+  try {
+    const updated = await markNotificationRead(notificationId, user.userId)
+    if (!updated) return jsonError(req, res, 404, 'Notification not found')
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json({ id: notificationId, read: true })
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/notifications/index.test.ts
+++ b/api/v1/notifications/index.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({ listNotificationsForUser: vi.fn() }))
+
+import handler from './index.js'
+import { requireUser } from '../../_lib/auth.js'
+import { listNotificationsForUser } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(listNotificationsForUser).mockReset()
+})
+
+describe('api/v1/notifications', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('returns 500 on non-Error throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u-1', email: 'a@b.c' })
+    vi.mocked(listNotificationsForUser).mockImplementationOnce(() => { throw 'string-not-error' })
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+
+  it('non-GET 405; unauthed 401; happy path + unreadOnly flag; 500 on throw', async () => {
+    let res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u-1', email: 'a@b.c' })
+    vi.mocked(listNotificationsForUser).mockResolvedValueOnce([{ id: 'n1' }] as never)
+    res = mockRes()
+    await call({ method: 'GET', query: { unreadOnly: 'true' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(listNotificationsForUser).toHaveBeenCalledWith('u-1', { unreadOnly: true })
+
+    vi.mocked(listNotificationsForUser).mockResolvedValueOnce([] as never)
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(listNotificationsForUser).toHaveBeenLastCalledWith('u-1', { unreadOnly: false })
+
+    vi.mocked(listNotificationsForUser).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/notifications/index.ts
+++ b/api/v1/notifications/index.ts
@@ -1,0 +1,22 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { listNotificationsForUser } from '../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const unreadOnly = getStringQuery(req.query.unreadOnly) === 'true'
+
+  try {
+    const notifications = await listNotificationsForUser(user.userId, { unreadOnly })
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json(notifications)
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/notifications/read-all.test.ts
+++ b/api/v1/notifications/read-all.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({ markAllNotificationsRead: vi.fn() }))
+
+import handler from './read-all.js'
+import { requireUser } from '../../_lib/auth.js'
+import { markAllNotificationsRead } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(markAllNotificationsRead).mockReset()
+})
+
+describe('api/v1/notifications/read-all', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('returns 500 on non-Error throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(markAllNotificationsRead).mockImplementationOnce(() => { throw 'string-not-error' })
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+
+  it('non-POST 405; unauthed 401; happy + 500', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(markAllNotificationsRead).mockResolvedValueOnce(undefined as never)
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(markAllNotificationsRead).toHaveBeenCalledWith('u')
+
+    vi.mocked(markAllNotificationsRead).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/notifications/read-all.ts
+++ b/api/v1/notifications/read-all.ts
@@ -1,0 +1,20 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { markAllNotificationsRead } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  try {
+    await markAllNotificationsRead(user.userId)
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json({ ok: true })
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/projects/[projectId]/comments.test.ts
+++ b/api/v1/projects/[projectId]/comments.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/auth.js', () => ({
+  requireUser: vi.fn(),
+  requireProjectMembership: vi.fn(),
+}))
 vi.mock('../../../_lib/store.js', () => ({ listComments: vi.fn() }))
 
 import handler from './comments.js'
-import { requireUser } from '../../../_lib/auth.js'
+import { requireProjectMembership, requireUser } from '../../../_lib/auth.js'
+import { listComments } from '../../../_lib/store.js'
 
 function mockRes() {
   return {
@@ -22,6 +26,8 @@ const call = (req: unknown, res: unknown) =>
 
 beforeEach(() => {
   vi.mocked(requireUser).mockReset()
+  vi.mocked(requireProjectMembership).mockReset()
+  vi.mocked(listComments).mockReset()
 })
 
 describe('api/v1/projects/[projectId]/comments', () => {
@@ -30,17 +36,49 @@ describe('api/v1/projects/[projectId]/comments', () => {
       res.status(401).json({ error: 'Unauthorized' })
       return null
     })
-
     const res = mockRes()
     await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
     expect(res.statusCode).toBe(401)
   })
 
-  it('proceeds past the guard when requireUser returns a user', async () => {
+  it('validates projectId + membership + invalid filters', async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
 
-    const res = mockRes()
+    let res = mockRes()
     await call({ method: 'GET', query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(400)
+
+    vi.mocked(requireProjectMembership).mockImplementationOnce(async (_q, r) => {
+      r.status(403).json({ error: 'Forbidden' })
+      return false
+    })
+    res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    vi.mocked(requireProjectMembership).mockResolvedValue(true)
+    res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p', reviewStatus: 'nope' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p', implementationStatus: 'nope' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('lists comments for members; returns 500 on store throw', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(requireProjectMembership).mockResolvedValue(true)
+    vi.mocked(listComments).mockResolvedValueOnce([{ id: 'c1' }] as never)
+
+    let res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual([{ id: 'c1' }])
+
+    vi.mocked(listComments).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
   })
 })

--- a/api/v1/projects/[projectId]/comments.ts
+++ b/api/v1/projects/[projectId]/comments.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { requireUser } from '../../../_lib/auth.js'
+import { requireProjectMembership, requireUser } from '../../../_lib/auth.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
 import { listComments } from '../../../_lib/store.js'
 import type { ImplementationStatus, ReviewStatus } from '../../../_lib/status.js'
@@ -10,12 +10,13 @@ const IMPLEMENTATION_STATUSES = new Set<ImplementationStatus>(['unassigned', 'cl
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
   if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
-  // TODO(membership): require requireProjectMembership(user, projectId).
-  if (!(await requireUser(req, res))) return
+  const user = await requireUser(req, res)
+  if (!user) return
 
   try {
     const projectId = getStringQuery(req.query.projectId)
     if (!projectId) return jsonError(req, res, 400, 'Missing projectId')
+    if (!(await requireProjectMembership(req, res, user, projectId))) return
 
     const pageUrl = getStringQuery(req.query.pageUrl)
     const reviewStatus = getStringQuery(req.query.reviewStatus)

--- a/api/v1/projects/[projectId]/invites.test.ts
+++ b/api/v1/projects/[projectId]/invites.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({
+  createInvite: vi.fn(),
+  createNotification: vi.fn(),
+  findUserIdByEmail: vi.fn(),
+  getProjectMember: vi.fn(),
+}))
+
+import handler from './invites.js'
+import { requireUser } from '../../../_lib/auth.js'
+import { createInvite, createNotification, findUserIdByEmail, getProjectMember } from '../../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(getProjectMember).mockReset()
+  vi.mocked(createInvite).mockReset()
+  vi.mocked(findUserIdByEmail).mockReset()
+  vi.mocked(createNotification).mockReset()
+})
+
+describe('api/v1/projects/[projectId]/invites', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('tolerates absent body / non-string email', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    // no body at all → 400 Invalid email (req.body ?? {} path)
+    let res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // non-string email → 400
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 123 }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects non-POST + unauthenticated', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('validates projectKey + email + admin role + already_invited + happy path', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    // missing projectKey
+    let res = mockRes()
+    await call({ method: 'POST', query: {}, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // bad email
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'nope' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // non-member
+    vi.mocked(getProjectMember).mockResolvedValueOnce(null)
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    // member but not admin
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'member' })
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    // already_invited
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockRejectedValueOnce(new Error('already_invited'))
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(409)
+
+    // happy path: invitee exists → notification fired
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
+    vi.mocked(findUserIdByEmail).mockResolvedValueOnce('invitee-1')
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z', role: 'admin' }, headers: {} }, res)
+    expect(res.statusCode).toBe(201)
+    expect(createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'invitee-1', kind: 'invite.received',
+    }))
+
+    // happy path: invitee has no account → notification skipped
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
+    vi.mocked(findUserIdByEmail).mockResolvedValueOnce(null)
+    vi.mocked(createNotification).mockClear()
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(201)
+    expect(createNotification).not.toHaveBeenCalled()
+
+    // notif emit fails → invite still returns 201 (fanout is fire-and-forget)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
+    vi.mocked(findUserIdByEmail).mockResolvedValueOnce('invitee-1')
+    vi.mocked(createNotification).mockRejectedValueOnce(new Error('notif down'))
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(201)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    // generic 500
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockRejectedValueOnce(new Error('db down'))
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+
+    // non-Error throw → 500
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+})

--- a/api/v1/projects/[projectId]/invites.ts
+++ b/api/v1/projects/[projectId]/invites.ts
@@ -1,0 +1,61 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../../_lib/auth.js'
+import {
+  createInvite,
+  createNotification,
+  findUserIdByEmail,
+  getProjectMember,
+} from '../../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  // Route param is `projectId` to match the sibling dir (Vercel rejects two
+  // different dynamic-segment names at the same path level). The value is
+  // still a project public_key — we use that semantic name internally.
+  const projectKey = getStringQuery(req.query.projectId)
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectId')
+
+  const body = (req.body ?? {}) as { email?: unknown; role?: unknown }
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
+  const role = body.role === 'admin' ? 'admin' : 'member'
+  if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+    return jsonError(req, res, 400, 'Invalid email')
+  }
+
+  try {
+    const membership = await getProjectMember(user.userId, projectKey)
+    if (!membership) return jsonError(req, res, 403, 'Forbidden')
+    if (membership.role !== 'admin') return jsonError(req, res, 403, 'Admin role required')
+
+    const invite = await createInvite({ projectKey, email, role, invitedBy: user.userId })
+
+    // Notif emit is fire-and-forget: invite row is already persisted, and the
+    // invitee will still see it on next GET /invites even if realtime fanout
+    // fails (e.g. notifications table missing, transient DB error).
+    try {
+      const inviteeUserId = await findUserIdByEmail(email)
+      if (inviteeUserId) {
+        await createNotification({
+          userId: inviteeUserId,
+          kind: 'invite.received',
+          payload: { projectKey, email, role, invitedBy: user.userId },
+        })
+      }
+    } catch (notifError) {
+      console.warn('invite.received notif failed:', notifError)
+    }
+
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(201).json(invite)
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : undefined
+    if (msg === 'already_invited') return jsonError(req, res, 409, 'Already invited')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/projects/claim.test.ts
+++ b/api/v1/projects/claim.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({ claimProject: vi.fn() }))
+
+import handler from './claim.js'
+import { requireUser } from '../../_lib/auth.js'
+import { claimProject } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(claimProject).mockReset()
+})
+
+describe('api/v1/projects/claim', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('tolerates absent body / non-Error throw', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    // no body → req.body ?? {} fallback → 400 Missing projectKey
+    let res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // claimProject throws something that isn't an Error → falls back to "Unexpected error"
+    vi.mocked(claimProject).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'k' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+  })
+
+  it('rejects non-POST + unauthenticated', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' })
+      return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'k' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('happy path + missing projectKey / not_found / already_claimed / other error', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    let res = mockRes()
+    await call({ method: 'POST', body: {}, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(claimProject).mockResolvedValueOnce({ publicKey: 'k' } as never)
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'k' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(claimProject).toHaveBeenCalledWith('u', 'k')
+
+    vi.mocked(claimProject).mockRejectedValueOnce(new Error('not_found'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'k' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(claimProject).mockRejectedValueOnce(new Error('already_claimed'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'k' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(409)
+
+    vi.mocked(claimProject).mockRejectedValueOnce(new Error('db down'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'k' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/projects/claim.test.ts
+++ b/api/v1/projects/claim.test.ts
@@ -41,12 +41,12 @@ describe('api/v1/projects/claim', () => {
     await call({ method: 'POST', query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(400)
 
-    // claimProject throws something that isn't an Error → falls back to "Unexpected error"
+    // claimProject throws something that isn't an Error → falls back to 500
     vi.mocked(claimProject).mockImplementationOnce(() => { throw 'string-not-error' })
     res = mockRes()
     await call({ method: 'POST', body: { projectKey: 'k' }, query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(500)
-    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
   })
 
   it('rejects non-POST + unauthenticated', async () => {

--- a/api/v1/projects/claim.ts
+++ b/api/v1/projects/claim.ts
@@ -1,0 +1,26 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+import { claimProject } from '../../_lib/store.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const body = (req.body ?? {}) as { projectKey?: unknown }
+  const projectKey = typeof body.projectKey === 'string' ? body.projectKey.trim() : ''
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectKey')
+
+  try {
+    const project = await claimProject(user.userId, projectKey)
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json(project)
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unexpected error'
+    if (msg === 'not_found') return jsonError(req, res, 404, 'Project not found')
+    if (msg === 'already_claimed') return jsonError(req, res, 409, 'Project already claimed')
+    return jsonError(req, res, 500, msg)
+  }
+}

--- a/api/v1/projects/claim.ts
+++ b/api/v1/projects/claim.ts
@@ -18,9 +18,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     setCors(req, res, ['POST', 'OPTIONS'])
     return res.status(200).json(project)
   } catch (error) {
-    const msg = error instanceof Error ? error.message : 'Unexpected error'
+    const msg = error instanceof Error ? error.message : undefined
     if (msg === 'not_found') return jsonError(req, res, 404, 'Project not found')
     if (msg === 'already_claimed') return jsonError(req, res, 409, 'Project already claimed')
-    return jsonError(req, res, 500, msg)
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
   }
 }

--- a/api/v1/projects/index.test.ts
+++ b/api/v1/projects/index.test.ts
@@ -1,13 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
-vi.mock('../../_lib/store.js', () => ({
-  createProject: vi.fn(),
-  listProjects: vi.fn(),
-}))
+vi.mock('../../_lib/store.js', () => ({ listProjectsForUser: vi.fn() }))
 
 import handler from './index.js'
 import { requireUser } from '../../_lib/auth.js'
+import { listProjectsForUser } from '../../_lib/store.js'
 
 function mockRes() {
   return {
@@ -25,25 +23,42 @@ const call = (req: unknown, res: unknown) =>
 
 beforeEach(() => {
   vi.mocked(requireUser).mockReset()
+  vi.mocked(listProjectsForUser).mockReset()
 })
 
 describe('api/v1/projects', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
   it('returns 401 when requireUser rejects', async () => {
     vi.mocked(requireUser).mockImplementation(async (_req, res) => {
       res.status(401).json({ error: 'Unauthorized' })
       return null
     })
-
     const res = mockRes()
     await call({ method: 'GET', query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(401)
   })
 
-  it('proceeds past the guard when requireUser returns a user', async () => {
+  it('405 for POST, 200 for GET, 500 on store throw', async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
 
-    const res = mockRes()
+    let res = mockRes()
     await call({ method: 'POST', query: {}, body: {}, headers: {} }, res)
-    expect(res.statusCode).toBe(400)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(listProjectsForUser).mockResolvedValueOnce([{ publicKey: 'p1' }] as never)
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(listProjectsForUser).toHaveBeenCalledWith('u')
+
+    vi.mocked(listProjectsForUser).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
   })
 })

--- a/api/v1/projects/index.ts
+++ b/api/v1/projects/index.ts
@@ -1,29 +1,18 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { requireUser } from '../../_lib/auth.js'
 import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
-import { createProject, listProjects } from '../../_lib/store.js'
+import { listProjectsForUser } from '../../_lib/store.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  if (handleOptions(req, res, ['GET', 'POST', 'OPTIONS'])) return
-  if (req.method !== 'GET' && req.method !== 'POST') return methodNotAllowed(req, res, ['GET', 'POST', 'OPTIONS'])
-  // TODO(membership): filter listProjects by membership + drop POST in favor of claim endpoint.
-  if (!(await requireUser(req, res))) return
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
 
   try {
-    if (req.method === 'GET') {
-      const projects = await listProjects()
-      setCors(req, res, ['GET', 'POST', 'OPTIONS'])
-      return res.status(200).json(projects)
-    }
-
-    const body = (req.body ?? {}) as { name?: unknown }
-    const rawName = typeof body.name === 'string' ? body.name.trim() : ''
-    if (!rawName) return jsonError(req, res, 400, 'Missing name')
-    if (rawName.length > 80) return jsonError(req, res, 400, 'Name too long')
-
-    const project = await createProject({ name: rawName })
-    setCors(req, res, ['GET', 'POST', 'OPTIONS'])
-    return res.status(201).json(project)
+    const projects = await listProjectsForUser(user.userId)
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json(projects)
   } catch (error) {
     return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
   }

--- a/api/v1/projects/index.ts
+++ b/api/v1/projects/index.ts
@@ -14,6 +14,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     setCors(req, res, ['GET', 'OPTIONS'])
     return res.status(200).json(projects)
   } catch (error) {
-    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
   }
 }

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -67,6 +67,21 @@ export function App() {
   return <AuthenticatedApp accessToken={session.access_token} user={user} onSignOut={signOut} />
 }
 
+// TODO(ui-notifications): add a bell icon to the topbar. On mount, GET
+// /api/v1/notifications and subscribe live:
+//   supabase.channel('notifications')
+//     .on('postgres_changes',
+//         { event: 'INSERT', schema: 'public', table: 'notifications',
+//           filter: `user_id=eq.${user.id}` },
+//         (p) => setNotifications(n => [p.new, ...n]))
+//     .subscribe()
+// Show unread count; POST /api/v1/notifications/:id/read on click; offer
+// "Mark all read" → POST /api/v1/notifications/read-all.
+// Invite acceptance UI: list GET /api/v1/invites in a panel with
+// Accept (POST /api/v1/invites/accept { projectKey }) and
+// Decline (POST /api/v1/invites/decline { projectKey }) buttons.
+// Admin-side invite send: POST /api/v1/projects/:projectKey/invites
+// { email, role } (admin role required).
 function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: string; user: import('@supabase/supabase-js').User; onSignOut: () => void }) {
   const { projects, loading: projectsLoading, error: projectsError, createProject } = useProjects(API_BASE, accessToken)
   const [selectedProject, setSelectedProject] = useState<string>('')

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -309,6 +309,10 @@ function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: strin
     }
   }, [agentSession, copyPrompt, selectedAgentMeta])
 
+  // TODO(ui-claim-flow): swap this create flow for a claim flow. Prompt the
+  // user for a projectKey (paste from widget install snippet) and call
+  // POST /v1/projects/claim. New projects now come into being via the widget
+  // hitting public endpoints (ensurePublicProject); the dashboard only claims.
   const handleAddProject = useCallback(async (name: string) => {
     setAddProjectError(null)
     setAddProjectBusy(true)

--- a/apps/dashboard/api.ts
+++ b/apps/dashboard/api.ts
@@ -126,6 +126,13 @@ export function listProjects(apiBase: string, accessToken: string) {
   })
 }
 
+// TODO(ui-claim-flow): the POST /v1/projects endpoint has been removed.
+// Replace this with a claim flow that calls POST /v1/projects/claim with a
+// projectKey the user enters (or pastes from the widget install). New projects
+// now materialize via the widget's ensurePublicProject path on first comment;
+// the dashboard's role is to claim ownership of an unclaimed (claimable=true)
+// project. Until this is rewired, the dashboard's "Create new project" button
+// will 405.
 export function createProject(apiBase: string, accessToken: string, name: string) {
   return requestJson<Project>(`${apiBase}/v1/projects`, {
     method: 'POST',

--- a/db/migrations/0002_wild_black_bird.sql
+++ b/db/migrations/0002_wild_black_bird.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "notifications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"kind" text NOT NULL,
+	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"read_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "notifications_kind_check" CHECK ("notifications"."kind" in ('invite.received', 'invite.accepted', 'invite.declined'))
+);
+--> statement-breakpoint
+CREATE INDEX "notifications_user_created_idx" ON "notifications" USING btree ("user_id","created_at" DESC NULLS LAST);--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_auth_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "notifications_select_own" ON "notifications" FOR SELECT USING (auth.uid() = user_id);--> statement-breakpoint
+ALTER PUBLICATION supabase_realtime ADD TABLE "notifications";

--- a/db/migrations/meta/0002_snapshot.json
+++ b/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1102 @@
+{
+  "id": "3d7f732e-a64a-464e-992e-06473eb2b386",
+  "prevId": "d3faf753-9cf9-4399-87e1-99c8d7524f21",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_presence_share_seen_idx": {
+          "name": "agent_presence_share_seen_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_presence_share_id_feedback_shares_id_fk": {
+          "name": "agent_presence_share_id_feedback_shares_id_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_presence_share_id_agent_id_pk": {
+          "name": "agent_presence_share_id_agent_id_pk",
+          "columns": [
+            "share_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "implementation_status": {
+          "name": "implementation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unassigned'"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_project_created_idx": {
+          "name": "comments_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_project_url_idx": {
+          "name": "comments_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_project_status_idx": {
+          "name": "comments_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "implementation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_events": {
+      "name": "feedback_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feedback_events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_events_share_id_idx": {
+          "name": "feedback_events_share_id_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_events_share_id_feedback_shares_id_fk": {
+          "name": "feedback_events_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_events",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_events_comment_id_comments_id_fk": {
+          "name": "feedback_events_comment_id_comments_id_fk",
+          "tableFrom": "feedback_events",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_operation_keys": {
+      "name": "feedback_operation_keys",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_event_id": {
+          "name": "feedback_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_operation_keys_share_id_feedback_shares_id_fk": {
+          "name": "feedback_operation_keys_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_operation_keys_feedback_event_id_feedback_events_id_fk": {
+          "name": "feedback_operation_keys_feedback_event_id_feedback_events_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "tableTo": "feedback_events",
+          "columnsFrom": [
+            "feedback_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_operation_keys_share_id_agent_id_idempotency_key_pk": {
+          "name": "feedback_operation_keys_share_id_agent_id_idempotency_key_pk",
+          "columns": [
+            "share_id",
+            "agent_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_share_items": {
+      "name": "feedback_share_items",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_share_items_share_id_feedback_shares_id_fk": {
+          "name": "feedback_share_items_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_share_items",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_share_items_comment_id_comments_id_fk": {
+          "name": "feedback_share_items_comment_id_comments_id_fk",
+          "tableFrom": "feedback_share_items",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_share_items_share_id_comment_id_pk": {
+          "name": "feedback_share_items_share_id_comment_id_pk",
+          "columns": [
+            "share_id",
+            "comment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_shares": {
+      "name": "feedback_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_page_url": {
+          "name": "scope_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_shares_one_project_scope_per_project": {
+          "name": "feedback_shares_one_project_scope_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "scope_type = 'project' and revoked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_shares_project_id_projects_public_key_fk": {
+          "name": "feedback_shares_project_id_projects_public_key_fk",
+          "tableFrom": "feedback_shares",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_shares_slug_unique": {
+          "name": "feedback_shares_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feedback_shares_scope_type_check": {
+          "name": "feedback_shares_scope_type_check",
+          "value": "\"feedback_shares\".\"scope_type\" in ('page', 'selection', 'project')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_kind_check": {
+          "name": "notifications_kind_check",
+          "value": "\"notifications\".\"kind\" in ('invite.received', 'invite.accepted', 'invite.declined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_invites": {
+      "name": "project_invites",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invites_email_idx": {
+          "name": "project_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invites_project_key_projects_public_key_fk": {
+          "name": "project_invites_project_key_projects_public_key_fk",
+          "tableFrom": "project_invites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_invites_project_key_email_pk": {
+          "name": "project_invites_project_key_email_pk",
+          "columns": [
+            "project_key",
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_invites_role_check": {
+          "name": "project_invites_role_check",
+          "value": "\"project_invites\".\"role\" in ('admin', 'member')"
+        },
+        "project_invites_email_lower_check": {
+          "name": "project_invites_email_lower_check",
+          "value": "\"project_invites\".\"email\" = lower(\"project_invites\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_key_projects_public_key_fk": {
+          "name": "project_members_project_key_projects_public_key_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_key_user_id_pk": {
+          "name": "project_members_project_key_user_id_pk",
+          "columns": [
+            "project_key",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_members_role_check": {
+          "name": "project_members_role_check",
+          "value": "\"project_members\".\"role\" in ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_repo_configs": {
+      "name": "project_repo_configs",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_command": {
+          "name": "dev_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command": {
+          "name": "build_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instructions": {
+          "name": "agent_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_repo_configs_project_key_projects_public_key_fk": {
+          "name": "project_repo_configs_project_key_projects_public_key_fk",
+          "tableFrom": "project_repo_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claimable": {
+          "name": "claimable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1779348294740,
       "tag": "0001_fluffy_nuke",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1779692374320,
+      "tag": "0002_wild_black_bird",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -188,6 +188,29 @@ export const agentPresence = pgTable(
   }),
 )
 
+// In-app notification feed. user_id references auth.users(id); the FK is
+// added by hand in the migration SQL (same pattern as projectMembers).
+// RLS + supabase_realtime publication also configured by hand in that
+// migration so the dashboard can subscribe with the anon key.
+export const notifications = pgTable(
+  'notifications',
+  {
+    id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+    userId: uuid('user_id').notNull(),
+    kind: text('kind').notNull(),
+    payload: jsonb('payload').notNull().default(sql`'{}'::jsonb`),
+    readAt: timestamp('read_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    userCreatedIdx: index('notifications_user_created_idx').on(t.userId, t.createdAt.desc()),
+    kindCheck: check(
+      'notifications_kind_check',
+      sql`${t.kind} in ('invite.received', 'invite.accepted', 'invite.declined')`,
+    ),
+  }),
+)
+
 export const feedbackOperationKeys = pgTable(
   'feedback_operation_keys',
   {


### PR DESCRIPTION
- Every dashboard route now checks that the caller is actually a member of the project they're touching. Until now, anyone signed in could read or change anything in any project.
- Add a claim flow: knowing a project key isn't enough anymore, you claim it once and become its admin.
- Drop the old "create project" endpoint. New projects come into being naturally through the widget hitting the site, and the dashboard just claims them.
- Heads up: the dashboard's "Create new project" button stops working until the follow-up UI PR rewires it to claim instead of create. A `TODO(ui-claim-flow)` marks the spot.