### PR TITLE
In-app notifications, live

### DIFF
--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -1,14 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('./supabase.js', () => ({ getSupabase: vi.fn() }))
+vi.mock('./supabase.js', () => ({ getSupabase: vi.fn(), getServiceSupabase: vi.fn() }))
 
-import { getSupabase } from './supabase.js'
+import { getServiceSupabase, getSupabase } from './supabase.js'
 import {
   claimProject,
+  createNotification,
   ensurePublicProject,
   getProjectMember,
   isProjectMember,
+  listNotificationsForUser,
   listProjectsForUser,
+  markAllNotificationsRead,
+  markNotificationRead,
 } from './store.js'
 
 type ProjectRow = {
@@ -69,6 +73,7 @@ const PROJECT_ROW: ProjectRow = {
 
 beforeEach(() => {
   vi.mocked(getSupabase).mockReset()
+  vi.mocked(getServiceSupabase).mockReset()
 })
 
 describe('ensurePublicProject', () => {
@@ -287,5 +292,106 @@ describe('membership helpers + claim', () => {
       projectsUpdate: { data: null, error: { message: 'db boom' } },
     }) as never)
     await expect(claimProject('u', 'pk')).rejects.toThrow('db boom')
+  })
+})
+
+type NotifMocks = {
+  notifSingle?: { data: unknown; error: { message: string } | null }
+  notifList?: { data: unknown[] | null; error: { message: string } | null }
+  notifUpdate?: { data: unknown[] | null; error: { message: string } | null }
+  notifUpdateAllError?: { message: string } | null
+}
+
+function notifSupabase(m: NotifMocks = {}) {
+  return {
+    from: vi.fn((_table: string) => ({
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve(m.notifSingle ?? { data: null, error: null })),
+        })),
+      })),
+      select: vi.fn(() => {
+        const chain = {
+          eq: vi.fn(() => chain),
+          order: vi.fn(() => chain),
+          limit: vi.fn(() => chain),
+          is: vi.fn(() => chain),
+          then: (r: (v: unknown) => unknown) =>
+            Promise.resolve(m.notifList ?? { data: [], error: null }).then(r),
+        }
+        return chain
+      }),
+      update: vi.fn(() => {
+        const chain = {
+          eq: vi.fn(() => chain),
+          is: vi.fn(() => chain),
+          select: vi.fn(() => Promise.resolve(m.notifUpdate ?? { data: [], error: null })),
+          then: (r: (v: unknown) => unknown) =>
+            Promise.resolve({ error: m.notifUpdateAllError ?? null }).then(r),
+        }
+        return chain
+      }),
+    })),
+  }
+}
+
+describe('notifications helpers', () => {
+  it('createNotification: success / error', async () => {
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifSingle: { data: { id: 'n', user_id: 'u', kind: 'invite.received', payload: { x: 1 }, read_at: null, created_at: 't' }, error: null },
+    }) as never)
+    const n = await createNotification({ userId: 'u', kind: 'invite.received', payload: { x: 1 } })
+    expect(n.id).toBe('n')
+
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifSingle: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(createNotification({ userId: 'u', kind: 'invite.received' })).rejects.toThrow('boom')
+  })
+
+  it('listNotificationsForUser: respects unreadOnly + default options + null fallback + error', async () => {
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifList: { data: [{ id: 'n1', user_id: 'u', kind: 'invite.received', payload: null, read_at: null, created_at: 't' }], error: null },
+    }) as never)
+    expect((await listNotificationsForUser('u', { unreadOnly: true, limit: 10 })).length).toBe(1)
+    expect((await listNotificationsForUser('u')).length).toBe(1)
+
+    // defensive `data || []` fallback
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifList: { data: null, error: null },
+    }) as never)
+    expect(await listNotificationsForUser('u')).toEqual([])
+
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifList: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(listNotificationsForUser('u')).rejects.toThrow('boom')
+  })
+
+  it('markNotificationRead: hit / miss / error', async () => {
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifUpdate: { data: [{ id: 'n' }], error: null },
+    }) as never)
+    expect(await markNotificationRead('n', 'u')).toBe(true)
+
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifUpdate: { data: [], error: null },
+    }) as never)
+    expect(await markNotificationRead('n', 'u')).toBe(false)
+
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifUpdate: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(markNotificationRead('n', 'u')).rejects.toThrow('boom')
+  })
+
+  it('markAllNotificationsRead: success / error', async () => {
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({}) as never)
+    await markAllNotificationsRead('u')
+
+    vi.mocked(getServiceSupabase).mockReturnValue(notifSupabase({
+      notifUpdateAllError: { message: 'boom' },
+    }) as never)
+    await expect(markAllNotificationsRead('u')).rejects.toThrow('boom')
   })
 })

--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -1,14 +1,19 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('./supabase.js', () => ({ getSupabase: vi.fn(), getServiceSupabase: vi.fn() }))
 
 import { getServiceSupabase, getSupabase } from './supabase.js'
 import {
+  acceptInvite,
   claimProject,
+  createInvite,
   createNotification,
+  declineInvite,
   ensurePublicProject,
+  findUserIdByEmail,
   getProjectMember,
   isProjectMember,
+  listInvitesForEmail,
   listNotificationsForUser,
   listProjectsForUser,
   markAllNotificationsRead,
@@ -393,5 +398,192 @@ describe('notifications helpers', () => {
       notifUpdateAllError: { message: 'boom' },
     }) as never)
     await expect(markAllNotificationsRead('u')).rejects.toThrow('boom')
+  })
+})
+
+type InviteRow = {
+  project_key: string
+  email: string
+  role: 'admin' | 'member'
+  invited_by: string
+  created_at: string
+}
+
+type InviteMocks = {
+  inviteSingle?: { data: InviteRow | null; error: { message: string } | null }
+  inviteList?: { data: InviteRow[] | null; error: { message: string } | null }
+  inviteInsertResult?: { data: InviteRow | null; error: { code?: string; message: string } | null }
+  inviteDeleteError?: { message: string } | null
+  memberInsertError?: { code?: string; message: string } | null
+}
+
+function inviteSupabase(m: InviteMocks = {}) {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'project_invites') {
+        return {
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve(m.inviteInsertResult ?? { data: null, error: null })),
+            })),
+          })),
+          select: vi.fn(() => {
+            const chain = {
+              eq: vi.fn(() => chain),
+              order: vi.fn(() => chain),
+              maybeSingle: vi.fn(() => Promise.resolve(m.inviteSingle ?? { data: null, error: null })),
+              then: (r: (v: unknown) => unknown) =>
+                Promise.resolve(m.inviteList ?? { data: [], error: null }).then(r),
+            }
+            return chain
+          }),
+          delete: vi.fn(() => {
+            const chain = {
+              eq: vi.fn(() => chain),
+              then: (r: (v: unknown) => unknown) =>
+                Promise.resolve({ error: m.inviteDeleteError ?? null }).then(r),
+            }
+            return chain
+          }),
+        }
+      }
+      if (table === 'project_members') {
+        return { insert: vi.fn(() => Promise.resolve({ error: m.memberInsertError ?? null })) }
+      }
+      throw new Error(`Unmocked table ${table}`)
+    }),
+  }
+}
+
+describe('invite helpers', () => {
+  const INVITE: InviteRow = { project_key: 'p', email: 'x@y.z', role: 'member', invited_by: 'inviter-1', created_at: 't' }
+
+  it('createInvite: success / already_invited / other error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteInsertResult: { data: INVITE, error: null },
+    }) as never)
+    expect((await createInvite({ projectKey: 'p', email: 'X@Y.Z', role: 'member', invitedBy: 'inviter-1' })).email).toBe('x@y.z')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteInsertResult: { data: null, error: { code: '23505', message: 'dup' } },
+    }) as never)
+    await expect(createInvite({ projectKey: 'p', email: 'x@y.z', role: 'member', invitedBy: 'i' })).rejects.toThrow('already_invited')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteInsertResult: { data: null, error: { code: '50000', message: 'boom' } },
+    }) as never)
+    await expect(createInvite({ projectKey: 'p', email: 'x@y.z', role: 'member', invitedBy: 'i' })).rejects.toThrow('boom')
+  })
+
+  it('listInvitesForEmail: success / null fallback / error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteList: { data: [INVITE], error: null },
+    }) as never)
+    expect((await listInvitesForEmail('X@Y.Z')).map((i) => i.projectKey)).toEqual(['p'])
+
+    // defensive `data || []` fallback
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteList: { data: null, error: null },
+    }) as never)
+    expect(await listInvitesForEmail('x@y.z')).toEqual([])
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteList: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(listInvitesForEmail('x@y.z')).rejects.toThrow('boom')
+  })
+
+  it('acceptInvite: not_found / happy / membership 23505 tolerated / other error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: null, error: null } }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('not_found')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: INVITE, error: null } }) as never)
+    expect(await acceptInvite('u', 'x@y.z', 'p')).toBe('inviter-1')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: INVITE, error: null },
+      memberInsertError: { code: '23505', message: 'dup' },
+    }) as never)
+    expect(await acceptInvite('u', 'x@y.z', 'p')).toBe('inviter-1')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: INVITE, error: null },
+      memberInsertError: { code: '50000', message: 'boom' },
+    }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('boom')
+  })
+
+  it('declineInvite: not_found / happy', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: null, error: null } }) as never)
+    await expect(declineInvite('x@y.z', 'p')).rejects.toThrow('not_found')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: INVITE, error: null } }) as never)
+    expect(await declineInvite('x@y.z', 'p')).toBe('inviter-1')
+  })
+
+  it('getInvite lookup error / deleteInvite error bubble through accept', async () => {
+    // getInvite error path
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: null, error: { message: 'lookup boom' } },
+    }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('lookup boom')
+
+    // deleteInvite error path (invite found, member insert ok, delete fails)
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: INVITE, error: null },
+      inviteDeleteError: { message: 'delete boom' },
+    }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('delete boom')
+  })
+})
+
+describe('findUserIdByEmail', () => {
+  const origFetch = globalThis.fetch
+  const origUrl = process.env.SUPABASE_URL
+  const origKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  beforeEach(() => {
+    process.env.SUPABASE_URL = 'https://supa.example'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key'
+  })
+
+  afterEach(() => {
+    globalThis.fetch = origFetch
+    process.env.SUPABASE_URL = origUrl
+    process.env.SUPABASE_SERVICE_ROLE_KEY = origKey
+  })
+
+  it('returns null when service role key is missing', async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns null when SUPABASE_URL is missing', async () => {
+    delete process.env.SUPABASE_URL
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns null when admin endpoint returns non-OK', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('nope', { status: 500 })) as never
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns the matching user id when found', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
+      users: [{ id: 'u-1', email: 'X@Y.Z' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } })) as never
+    expect(await findUserIdByEmail('x@y.z')).toBe('u-1')
+  })
+
+  it('returns null when fetch throws', async () => {
+    globalThis.fetch = vi.fn(async () => { throw new Error('net') }) as never
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns null when response shape is unexpected', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('{}', {
+      status: 200, headers: { 'content-type': 'application/json' },
+    })) as never
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
   })
 })

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from './supabase.js'
+import { getServiceSupabase, getSupabase } from './supabase.js'
 import { fromLegacyStatus, toLegacyStatus, type ImplementationStatus, type ReviewStatus } from './status.js'
 
 type CommentRow = {
@@ -769,6 +769,88 @@ export async function saveOperationKey(shareId: string, agentId: string, idempot
       feedback_event_id: feedbackEventId,
     }] as never)
 
+  if (error) throw new Error(error.message)
+}
+
+export type NotificationKind = 'invite.received' | 'invite.accepted' | 'invite.declined'
+
+type NotificationRow = {
+  id: string
+  user_id: string
+  kind: NotificationKind
+  payload: Record<string, unknown>
+  read_at: string | null
+  created_at: string
+}
+
+function mapNotification(row: NotificationRow) {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    kind: row.kind,
+    payload: row.payload || {},
+    readAt: row.read_at,
+    createdAt: row.created_at,
+  }
+}
+
+// Notifications uses the service-role client because the table has RLS
+// (`auth.uid() = user_id`) enabled for safe per-user realtime subscriptions.
+// The backend has no user JWT in its supabase client, so anon-key queries
+// would always see zero rows / fail to insert. Service role bypasses RLS;
+// these helpers enforce the user_id scope themselves.
+export async function createNotification(input: {
+  userId: string
+  kind: NotificationKind
+  payload?: Record<string, unknown>
+}) {
+  const supabase = getServiceSupabase()
+  const { data, error } = await supabase
+    .from('notifications')
+    .insert([{ user_id: input.userId, kind: input.kind, payload: input.payload ?? {} }] as never)
+    .select('id, user_id, kind, payload, read_at, created_at')
+    .single()
+  if (error) throw new Error(error.message)
+  return mapNotification(data as NotificationRow)
+}
+
+export async function listNotificationsForUser(
+  userId: string,
+  opts: { unreadOnly?: boolean; limit?: number } = {},
+) {
+  const supabase = getServiceSupabase()
+  let query = supabase
+    .from('notifications')
+    .select('id, user_id, kind, payload, read_at, created_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(opts.limit ?? 50)
+  if (opts.unreadOnly) query = query.is('read_at', null)
+  const { data, error } = await query
+  if (error) throw new Error(error.message)
+  return (data || []).map((row) => mapNotification(row as NotificationRow))
+}
+
+export async function markNotificationRead(notificationId: string, userId: string): Promise<boolean> {
+  const supabase = getServiceSupabase()
+  const { data, error } = await supabase
+    .from('notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('id', notificationId)
+    .eq('user_id', userId)
+    .is('read_at', null)
+    .select('id')
+  if (error) throw new Error(error.message)
+  return Array.isArray(data) && data.length > 0
+}
+
+export async function markAllNotificationsRead(userId: string) {
+  const supabase = getServiceSupabase()
+  const { error } = await supabase
+    .from('notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('user_id', userId)
+    .is('read_at', null)
   if (error) throw new Error(error.message)
 }
 

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -854,3 +854,130 @@ export async function markAllNotificationsRead(userId: string) {
   if (error) throw new Error(error.message)
 }
 
+type InviteRow = {
+  project_key: string
+  email: string
+  role: 'admin' | 'member'
+  invited_by: string
+  created_at: string
+}
+
+function mapInvite(row: InviteRow) {
+  return {
+    projectKey: row.project_key,
+    email: row.email,
+    role: row.role,
+    invitedBy: row.invited_by,
+    createdAt: row.created_at,
+  }
+}
+
+export async function createInvite(input: {
+  projectKey: string
+  email: string
+  role: 'admin' | 'member'
+  invitedBy: string
+}) {
+  const supabase = getSupabase()
+  const email = input.email.toLowerCase().trim()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .insert([{
+      project_key: input.projectKey,
+      email,
+      role: input.role,
+      invited_by: input.invitedBy,
+    }] as never)
+    .select('project_key, email, role, invited_by, created_at')
+    .single()
+  if (error) {
+    if (error.code === '23505') throw new Error('already_invited')
+    throw new Error(error.message)
+  }
+  return mapInvite(data as InviteRow)
+}
+
+export async function listInvitesForEmail(email: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .select('project_key, email, role, invited_by, created_at')
+    .eq('email', email.toLowerCase().trim())
+    .order('created_at', { ascending: false })
+  if (error) throw new Error(error.message)
+  return (data || []).map((row) => mapInvite(row as InviteRow))
+}
+
+async function getInvite(email: string, projectKey: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .select('project_key, email, role, invited_by, created_at')
+    .eq('email', email.toLowerCase().trim())
+    .eq('project_key', projectKey)
+    .maybeSingle()
+  if (error) throw new Error(error.message)
+  return data ? mapInvite(data as InviteRow) : null
+}
+
+async function deleteInvite(email: string, projectKey: string) {
+  const supabase = getSupabase()
+  const { error } = await supabase
+    .from('project_invites')
+    .delete()
+    .eq('email', email.toLowerCase().trim())
+    .eq('project_key', projectKey)
+  if (error) throw new Error(error.message)
+}
+
+/**
+ * Atomic invite acceptance: verify the invite exists for this email, insert
+ * the project_members row (idempotent via 23505), delete the invite. Returns
+ * the inviter's user_id so the caller can emit an `invite.accepted` notif.
+ */
+export async function acceptInvite(userId: string, email: string, projectKey: string): Promise<string> {
+  const invite = await getInvite(email, projectKey)
+  if (!invite) throw new Error('not_found')
+
+  const supabase = getSupabase()
+  const { error: insertError } = await supabase
+    .from('project_members')
+    .insert([{ project_key: projectKey, user_id: userId, role: invite.role }] as never)
+  if (insertError && insertError.code !== '23505') throw new Error(insertError.message)
+
+  await deleteInvite(email, projectKey)
+  return invite.invitedBy
+}
+
+export async function declineInvite(email: string, projectKey: string): Promise<string> {
+  const invite = await getInvite(email, projectKey)
+  if (!invite) throw new Error('not_found')
+  await deleteInvite(email, projectKey)
+  return invite.invitedBy
+}
+
+/**
+ * Look up the auth.users id for an email. Uses the service role admin API if
+ * a SUPABASE_SERVICE_ROLE_KEY is configured; otherwise returns null. The null
+ * fallback is intentional — the invite still gets created, just no realtime
+ * notif fires for the invitee (they'll see it on next login via GET /invites).
+ */
+export async function findUserIdByEmail(email: string): Promise<string | null> {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!serviceKey) return null
+  const url = process.env.SUPABASE_URL
+  if (!url) return null
+  try {
+    const res = await fetch(`${url}/auth/v1/admin/users?email=${encodeURIComponent(email)}`, {
+      headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as { users?: Array<{ id?: string; email?: string }> }
+    const users = Array.isArray(body.users) ? body.users : []
+    const match = users.find((u) => u.email?.toLowerCase() === email.toLowerCase())
+    return match?.id ?? null
+  } catch {
+    return null
+  }
+}
+

--- a/api/_lib/supabase.test.ts
+++ b/api/_lib/supabase.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: vi.fn() })),
+}))
+
+import { createClient } from '@supabase/supabase-js'
+import { getServiceSupabase, getSupabase } from './supabase.js'
+
+const origUrl = process.env.SUPABASE_URL
+const origKey = process.env.SUPABASE_KEY
+const origServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+beforeEach(() => {
+  vi.mocked(createClient).mockClear()
+  process.env.SUPABASE_URL = 'https://supa.example'
+  process.env.SUPABASE_KEY = 'anon-key'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key'
+})
+
+afterEach(() => {
+  process.env.SUPABASE_URL = origUrl
+  process.env.SUPABASE_KEY = origKey
+  process.env.SUPABASE_SERVICE_ROLE_KEY = origServiceKey
+})
+
+describe('getSupabase', () => {
+  it('builds an anon-key client', () => {
+    getSupabase()
+    expect(createClient).toHaveBeenCalledWith('https://supa.example', 'anon-key')
+  })
+
+  it('throws when SUPABASE_URL is missing', () => {
+    delete process.env.SUPABASE_URL
+    expect(() => getSupabase()).toThrow(/missing Supabase credentials/)
+  })
+
+  it('throws when SUPABASE_KEY is missing', () => {
+    delete process.env.SUPABASE_KEY
+    expect(() => getSupabase()).toThrow(/missing Supabase credentials/)
+  })
+})
+
+describe('getServiceSupabase', () => {
+  it('builds a service-role client with persistSession disabled', () => {
+    getServiceSupabase()
+    expect(createClient).toHaveBeenCalledWith(
+      'https://supa.example',
+      'svc-key',
+      { auth: { persistSession: false, autoRefreshToken: false } },
+    )
+  })
+
+  it('throws when SUPABASE_SERVICE_ROLE_KEY is missing', () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    expect(() => getServiceSupabase()).toThrow(/missing SUPABASE_SERVICE_ROLE_KEY/)
+  })
+
+  it('throws when SUPABASE_URL is missing', () => {
+    delete process.env.SUPABASE_URL
+    expect(() => getServiceSupabase()).toThrow(/missing SUPABASE_SERVICE_ROLE_KEY/)
+  })
+})

--- a/api/_lib/supabase.test.ts
+++ b/api/_lib/supabase.test.ts
@@ -53,11 +53,11 @@ describe('getServiceSupabase', () => {
 
   it('throws when SUPABASE_SERVICE_ROLE_KEY is missing', () => {
     delete process.env.SUPABASE_SERVICE_ROLE_KEY
-    expect(() => getServiceSupabase()).toThrow(/missing SUPABASE_SERVICE_ROLE_KEY/)
+    expect(() => getServiceSupabase()).toThrow(/missing Supabase credentials/)
   })
 
   it('throws when SUPABASE_URL is missing', () => {
     delete process.env.SUPABASE_URL
-    expect(() => getServiceSupabase()).toThrow(/missing SUPABASE_SERVICE_ROLE_KEY/)
+    expect(() => getServiceSupabase()).toThrow(/missing Supabase credentials/)
   })
 })

--- a/api/_lib/supabase.ts
+++ b/api/_lib/supabase.ts
@@ -21,7 +21,7 @@ export function getServiceSupabase(): SupabaseClient {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
   if (!supabaseUrl || !serviceKey) {
-    throw new Error('Server misconfigured: missing SUPABASE_SERVICE_ROLE_KEY')
+    throw new Error('Server misconfigured: missing Supabase credentials')
   }
 
   return createClient(supabaseUrl, serviceKey, {

--- a/api/_lib/supabase.ts
+++ b/api/_lib/supabase.ts
@@ -11,3 +11,21 @@ export function getSupabase(): SupabaseClient {
   return createClient(supabaseUrl, supabaseKey)
 }
 
+/**
+ * Service-role client. Bypasses RLS, so use it only for backend writes/reads
+ * on RLS-protected tables (currently: `notifications`). Frontend code must
+ * never call this. SUPABASE_SERVICE_ROLE_KEY is required.
+ */
+export function getServiceSupabase(): SupabaseClient {
+  const supabaseUrl = process.env.SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceKey) {
+    throw new Error('Server misconfigured: missing SUPABASE_SERVICE_ROLE_KEY')
+  }
+
+  return createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+}
+

--- a/api/v1/invites/accept.test.ts
+++ b/api/v1/invites/accept.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({
+  acceptInvite: vi.fn(),
+  createNotification: vi.fn(),
+}))
+
+import handler from './accept.js'
+import { requireUser } from '../../_lib/auth.js'
+import { acceptInvite, createNotification } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(acceptInvite).mockReset()
+  vi.mocked(createNotification).mockReset()
+})
+
+describe('api/v1/invites/accept', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('tolerates absent body (req.body ?? {} fallback)', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('non-POST + unauthed', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('validates body + not_found + happy path + 500', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    let res = mockRes()
+    await call({ method: 'POST', body: {}, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(acceptInvite).mockRejectedValueOnce(new Error('not_found'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(acceptInvite).mockResolvedValueOnce('inviter-1')
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'inviter-1', kind: 'invite.accepted',
+    }))
+
+    // notif emit fails → accept still returns 200 (fanout is fire-and-forget)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(acceptInvite).mockResolvedValueOnce('inviter-1')
+    vi.mocked(createNotification).mockRejectedValueOnce(new Error('notif down'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    vi.mocked(acceptInvite).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+
+    // non-Error throw → 500
+    vi.mocked(acceptInvite).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+})

--- a/api/v1/invites/accept.ts
+++ b/api/v1/invites/accept.ts
@@ -1,0 +1,36 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { acceptInvite, createNotification } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const body = (req.body ?? {}) as { projectKey?: unknown }
+  const projectKey = typeof body.projectKey === 'string' ? body.projectKey.trim() : ''
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectKey')
+
+  try {
+    const inviterId = await acceptInvite(user.userId, user.email, projectKey)
+    // Notif fanout failure can't undo membership; log + continue.
+    try {
+      await createNotification({
+        userId: inviterId,
+        kind: 'invite.accepted',
+        payload: { projectKey, acceptedBy: user.userId, email: user.email },
+      })
+    } catch (notifError) {
+      console.warn('invite.accepted notif failed:', notifError)
+    }
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json({ projectKey })
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : undefined
+    if (msg === 'not_found') return jsonError(req, res, 404, 'Invite not found')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/invites/decline.test.ts
+++ b/api/v1/invites/decline.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({
+  declineInvite: vi.fn(),
+  createNotification: vi.fn(),
+}))
+
+import handler from './decline.js'
+import { requireUser } from '../../_lib/auth.js'
+import { createNotification, declineInvite } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(declineInvite).mockReset()
+  vi.mocked(createNotification).mockReset()
+})
+
+describe('api/v1/invites/decline', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('tolerates absent body (req.body ?? {} fallback)', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('non-POST + unauthed + validation + not_found + happy + 500', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    res = mockRes()
+    await call({ method: 'POST', body: {}, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(declineInvite).mockRejectedValueOnce(new Error('not_found'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(declineInvite).mockResolvedValueOnce('inviter-1')
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'inviter-1', kind: 'invite.declined',
+    }))
+
+    // notif emit fails → decline still returns 200 (fanout is fire-and-forget)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(declineInvite).mockResolvedValueOnce('inviter-1')
+    vi.mocked(createNotification).mockRejectedValueOnce(new Error('notif down'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    vi.mocked(declineInvite).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+
+    // non-Error throw → 500
+    vi.mocked(declineInvite).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+})

--- a/api/v1/invites/decline.ts
+++ b/api/v1/invites/decline.ts
@@ -1,0 +1,36 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { createNotification, declineInvite } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const body = (req.body ?? {}) as { projectKey?: unknown }
+  const projectKey = typeof body.projectKey === 'string' ? body.projectKey.trim() : ''
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectKey')
+
+  try {
+    const inviterId = await declineInvite(user.email, projectKey)
+    // Notif fanout failure can't undo decline; log + continue.
+    try {
+      await createNotification({
+        userId: inviterId,
+        kind: 'invite.declined',
+        payload: { projectKey, declinedBy: user.userId, email: user.email },
+      })
+    } catch (notifError) {
+      console.warn('invite.declined notif failed:', notifError)
+    }
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json({ projectKey })
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : undefined
+    if (msg === 'not_found') return jsonError(req, res, 404, 'Invite not found')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/invites/index.test.ts
+++ b/api/v1/invites/index.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({ listInvitesForEmail: vi.fn() }))
+
+import handler from './index.js'
+import { requireUser } from '../../_lib/auth.js'
+import { listInvitesForEmail } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(listInvitesForEmail).mockReset()
+})
+
+describe('api/v1/invites', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('returns 500 on non-Error throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(listInvitesForEmail).mockImplementationOnce(() => { throw 'string-not-error' })
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+
+  it('non-GET 405; unauthed 401; happy path lists invites; 500 on throw', async () => {
+    let res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(listInvitesForEmail).mockResolvedValueOnce([{ projectKey: 'p' }] as never)
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(listInvitesForEmail).toHaveBeenCalledWith('a@b.c')
+
+    vi.mocked(listInvitesForEmail).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/invites/index.ts
+++ b/api/v1/invites/index.ts
@@ -1,0 +1,20 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { listInvitesForEmail } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  try {
+    const invites = await listInvitesForEmail(user.email)
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json(invites)
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/notifications/[notificationId]/read.test.ts
+++ b/api/v1/notifications/[notificationId]/read.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({ markNotificationRead: vi.fn() }))
+
+import handler from './read.js'
+import { requireUser } from '../../../_lib/auth.js'
+import { markNotificationRead } from '../../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(markNotificationRead).mockReset()
+})
+
+describe('api/v1/notifications/[notificationId]/read', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('falls back to "Unexpected error" on non-Error throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(markNotificationRead).mockImplementationOnce(() => { throw 'string-not-error' })
+    const res = mockRes()
+    await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+  })
+
+  it('non-POST 405; unauthed 401; missing id; happy / not_found / 500', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(markNotificationRead).mockResolvedValueOnce(true)
+    res = mockRes()
+    await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(markNotificationRead).toHaveBeenCalledWith('n', 'u')
+
+    vi.mocked(markNotificationRead).mockResolvedValueOnce(false)
+    res = mockRes()
+    await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(markNotificationRead).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/notifications/[notificationId]/read.test.ts
+++ b/api/v1/notifications/[notificationId]/read.test.ts
@@ -33,13 +33,13 @@ describe('api/v1/notifications/[notificationId]/read', () => {
     expect(res.statusCode).toBe(204)
   })
 
-  it('falls back to "Unexpected error" on non-Error throws', async () => {
+  it('returns 500 on non-Error throws', async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
     vi.mocked(markNotificationRead).mockImplementationOnce(() => { throw 'string-not-error' })
     const res = mockRes()
     await call({ method: 'POST', query: { notificationId: 'n' }, headers: {} }, res)
     expect(res.statusCode).toBe(500)
-    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
   })
 
   it('non-POST 405; unauthed 401; missing id; happy / not_found / 500', async () => {

--- a/api/v1/notifications/[notificationId]/read.ts
+++ b/api/v1/notifications/[notificationId]/read.ts
@@ -18,6 +18,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     setCors(req, res, ['POST', 'OPTIONS'])
     return res.status(200).json({ id: notificationId, read: true })
   } catch (error) {
-    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
   }
 }

--- a/api/v1/notifications/[notificationId]/read.ts
+++ b/api/v1/notifications/[notificationId]/read.ts
@@ -1,0 +1,23 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../../_lib/auth.js'
+import { markNotificationRead } from '../../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const notificationId = getStringQuery(req.query.notificationId)
+  if (!notificationId) return jsonError(req, res, 400, 'Missing notificationId')
+
+  try {
+    const updated = await markNotificationRead(notificationId, user.userId)
+    if (!updated) return jsonError(req, res, 404, 'Notification not found')
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json({ id: notificationId, read: true })
+  } catch (error) {
+    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+  }
+}

--- a/api/v1/notifications/index.test.ts
+++ b/api/v1/notifications/index.test.ts
@@ -33,13 +33,13 @@ describe('api/v1/notifications', () => {
     expect(res.statusCode).toBe(204)
   })
 
-  it('falls back to "Unexpected error" on non-Error throws', async () => {
+  it('returns 500 on non-Error throws', async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 'u-1', email: 'a@b.c' })
     vi.mocked(listNotificationsForUser).mockImplementationOnce(() => { throw 'string-not-error' })
     const res = mockRes()
     await call({ method: 'GET', query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(500)
-    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
   })
 
   it('non-GET 405; unauthed 401; happy path + unreadOnly flag; 500 on throw', async () => {

--- a/api/v1/notifications/index.test.ts
+++ b/api/v1/notifications/index.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({ listNotificationsForUser: vi.fn() }))
+
+import handler from './index.js'
+import { requireUser } from '../../_lib/auth.js'
+import { listNotificationsForUser } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(listNotificationsForUser).mockReset()
+})
+
+describe('api/v1/notifications', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('falls back to "Unexpected error" on non-Error throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u-1', email: 'a@b.c' })
+    vi.mocked(listNotificationsForUser).mockImplementationOnce(() => { throw 'string-not-error' })
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+  })
+
+  it('non-GET 405; unauthed 401; happy path + unreadOnly flag; 500 on throw', async () => {
+    let res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u-1', email: 'a@b.c' })
+    vi.mocked(listNotificationsForUser).mockResolvedValueOnce([{ id: 'n1' }] as never)
+    res = mockRes()
+    await call({ method: 'GET', query: { unreadOnly: 'true' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(listNotificationsForUser).toHaveBeenCalledWith('u-1', { unreadOnly: true })
+
+    vi.mocked(listNotificationsForUser).mockResolvedValueOnce([] as never)
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(listNotificationsForUser).toHaveBeenLastCalledWith('u-1', { unreadOnly: false })
+
+    vi.mocked(listNotificationsForUser).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/notifications/index.ts
+++ b/api/v1/notifications/index.ts
@@ -16,6 +16,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     setCors(req, res, ['GET', 'OPTIONS'])
     return res.status(200).json(notifications)
   } catch (error) {
-    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
   }
 }

--- a/api/v1/notifications/index.ts
+++ b/api/v1/notifications/index.ts
@@ -1,0 +1,21 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { listNotificationsForUser } from '../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const unreadOnly = getStringQuery(req.query.unreadOnly) === 'true'
+
+  try {
+    const notifications = await listNotificationsForUser(user.userId, { unreadOnly })
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json(notifications)
+  } catch (error) {
+    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+  }
+}

--- a/api/v1/notifications/read-all.test.ts
+++ b/api/v1/notifications/read-all.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({ markAllNotificationsRead: vi.fn() }))
+
+import handler from './read-all.js'
+import { requireUser } from '../../_lib/auth.js'
+import { markAllNotificationsRead } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(markAllNotificationsRead).mockReset()
+})
+
+describe('api/v1/notifications/read-all', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('falls back to "Unexpected error" on non-Error throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(markAllNotificationsRead).mockImplementationOnce(() => { throw 'string-not-error' })
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+  })
+
+  it('non-POST 405; unauthed 401; happy + 500', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(markAllNotificationsRead).mockResolvedValueOnce(undefined as never)
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(markAllNotificationsRead).toHaveBeenCalledWith('u')
+
+    vi.mocked(markAllNotificationsRead).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/notifications/read-all.test.ts
+++ b/api/v1/notifications/read-all.test.ts
@@ -33,13 +33,13 @@ describe('api/v1/notifications/read-all', () => {
     expect(res.statusCode).toBe(204)
   })
 
-  it('falls back to "Unexpected error" on non-Error throws', async () => {
+  it('returns 500 on non-Error throws', async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
     vi.mocked(markAllNotificationsRead).mockImplementationOnce(() => { throw 'string-not-error' })
     const res = mockRes()
     await call({ method: 'POST', query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(500)
-    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
   })
 
   it('non-POST 405; unauthed 401; happy + 500', async () => {

--- a/api/v1/notifications/read-all.ts
+++ b/api/v1/notifications/read-all.ts
@@ -14,6 +14,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     setCors(req, res, ['POST', 'OPTIONS'])
     return res.status(200).json({ ok: true })
   } catch (error) {
-    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
   }
 }

--- a/api/v1/notifications/read-all.ts
+++ b/api/v1/notifications/read-all.ts
@@ -1,0 +1,19 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { markAllNotificationsRead } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  try {
+    await markAllNotificationsRead(user.userId)
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json({ ok: true })
+  } catch (error) {
+    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+  }
+}

--- a/api/v1/projects/[projectId]/invites.test.ts
+++ b/api/v1/projects/[projectId]/invites.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({
+  createInvite: vi.fn(),
+  createNotification: vi.fn(),
+  findUserIdByEmail: vi.fn(),
+  getProjectMember: vi.fn(),
+}))
+
+import handler from './invites.js'
+import { requireUser } from '../../../_lib/auth.js'
+import { createInvite, createNotification, findUserIdByEmail, getProjectMember } from '../../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(getProjectMember).mockReset()
+  vi.mocked(createInvite).mockReset()
+  vi.mocked(findUserIdByEmail).mockReset()
+  vi.mocked(createNotification).mockReset()
+})
+
+describe('api/v1/projects/[projectId]/invites', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('tolerates absent body / non-string email', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    // no body at all → 400 Invalid email (req.body ?? {} path)
+    let res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // non-string email → 400
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 123 }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects non-POST + unauthenticated', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('validates projectKey + email + admin role + already_invited + happy path', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    // missing projectKey
+    let res = mockRes()
+    await call({ method: 'POST', query: {}, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // bad email
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'nope' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // non-member
+    vi.mocked(getProjectMember).mockResolvedValueOnce(null)
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    // member but not admin
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'member' })
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    // already_invited
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockRejectedValueOnce(new Error('already_invited'))
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(409)
+
+    // happy path: invitee exists → notification fired
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
+    vi.mocked(findUserIdByEmail).mockResolvedValueOnce('invitee-1')
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z', role: 'admin' }, headers: {} }, res)
+    expect(res.statusCode).toBe(201)
+    expect(createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'invitee-1', kind: 'invite.received',
+    }))
+
+    // happy path: invitee has no account → notification skipped
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
+    vi.mocked(findUserIdByEmail).mockResolvedValueOnce(null)
+    vi.mocked(createNotification).mockClear()
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(201)
+    expect(createNotification).not.toHaveBeenCalled()
+
+    // notif emit fails → invite still returns 201 (fanout is fire-and-forget)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
+    vi.mocked(findUserIdByEmail).mockResolvedValueOnce('invitee-1')
+    vi.mocked(createNotification).mockRejectedValueOnce(new Error('notif down'))
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(201)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    // generic 500
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockRejectedValueOnce(new Error('db down'))
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+
+    // non-Error throw → 500
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+})

--- a/api/v1/projects/[projectId]/invites.ts
+++ b/api/v1/projects/[projectId]/invites.ts
@@ -1,0 +1,61 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../../_lib/auth.js'
+import {
+  createInvite,
+  createNotification,
+  findUserIdByEmail,
+  getProjectMember,
+} from '../../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  // Route param is `projectId` to match the sibling dir (Vercel rejects two
+  // different dynamic-segment names at the same path level). The value is
+  // still a project public_key — we use that semantic name internally.
+  const projectKey = getStringQuery(req.query.projectId)
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectId')
+
+  const body = (req.body ?? {}) as { email?: unknown; role?: unknown }
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
+  const role = body.role === 'admin' ? 'admin' : 'member'
+  if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+    return jsonError(req, res, 400, 'Invalid email')
+  }
+
+  try {
+    const membership = await getProjectMember(user.userId, projectKey)
+    if (!membership) return jsonError(req, res, 403, 'Forbidden')
+    if (membership.role !== 'admin') return jsonError(req, res, 403, 'Admin role required')
+
+    const invite = await createInvite({ projectKey, email, role, invitedBy: user.userId })
+
+    // Notif emit is fire-and-forget: invite row is already persisted, and the
+    // invitee will still see it on next GET /invites even if realtime fanout
+    // fails (e.g. notifications table missing, transient DB error).
+    try {
+      const inviteeUserId = await findUserIdByEmail(email)
+      if (inviteeUserId) {
+        await createNotification({
+          userId: inviteeUserId,
+          kind: 'invite.received',
+          payload: { projectKey, email, role, invitedBy: user.userId },
+        })
+      }
+    } catch (notifError) {
+      console.warn('invite.received notif failed:', notifError)
+    }
+
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(201).json(invite)
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : undefined
+    if (msg === 'already_invited') return jsonError(req, res, 409, 'Already invited')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -67,6 +67,16 @@ export function App() {
   return <AuthenticatedApp accessToken={session.access_token} user={user} onSignOut={signOut} />
 }
 
+// TODO(ui-notifications): add a bell icon to the topbar. On mount, GET
+// /api/v1/notifications and subscribe live:
+//   supabase.channel('notifications')
+//     .on('postgres_changes',
+//         { event: 'INSERT', schema: 'public', table: 'notifications',
+//           filter: `user_id=eq.${user.id}` },
+//         (p) => setNotifications(n => [p.new, ...n]))
+//     .subscribe()
+// Show unread count; POST /api/v1/notifications/:id/read on click; offer
+// "Mark all read" → POST /api/v1/notifications/read-all.
 function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: string; user: import('@supabase/supabase-js').User; onSignOut: () => void }) {
   const { projects, loading: projectsLoading, error: projectsError, createProject } = useProjects(API_BASE, accessToken)
   const [selectedProject, setSelectedProject] = useState<string>('')

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -77,6 +77,11 @@ export function App() {
 //     .subscribe()
 // Show unread count; POST /api/v1/notifications/:id/read on click; offer
 // "Mark all read" → POST /api/v1/notifications/read-all.
+// Invite acceptance UI: list GET /api/v1/invites in a panel with
+// Accept (POST /api/v1/invites/accept { projectKey }) and
+// Decline (POST /api/v1/invites/decline { projectKey }) buttons.
+// Admin-side invite send: POST /api/v1/projects/:projectKey/invites
+// { email, role } (admin role required).
 function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: string; user: import('@supabase/supabase-js').User; onSignOut: () => void }) {
   const { projects, loading: projectsLoading, error: projectsError, createProject } = useProjects(API_BASE, accessToken)
   const [selectedProject, setSelectedProject] = useState<string>('')

--- a/db/migrations/0002_wild_black_bird.sql
+++ b/db/migrations/0002_wild_black_bird.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "notifications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"kind" text NOT NULL,
+	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"read_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "notifications_kind_check" CHECK ("notifications"."kind" in ('invite.received', 'invite.accepted', 'invite.declined'))
+);
+--> statement-breakpoint
+CREATE INDEX "notifications_user_created_idx" ON "notifications" USING btree ("user_id","created_at" DESC NULLS LAST);--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_auth_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "notifications_select_own" ON "notifications" FOR SELECT USING (auth.uid() = user_id);--> statement-breakpoint
+ALTER PUBLICATION supabase_realtime ADD TABLE "notifications";

--- a/db/migrations/meta/0002_snapshot.json
+++ b/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1102 @@
+{
+  "id": "3d7f732e-a64a-464e-992e-06473eb2b386",
+  "prevId": "d3faf753-9cf9-4399-87e1-99c8d7524f21",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_presence_share_seen_idx": {
+          "name": "agent_presence_share_seen_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_presence_share_id_feedback_shares_id_fk": {
+          "name": "agent_presence_share_id_feedback_shares_id_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_presence_share_id_agent_id_pk": {
+          "name": "agent_presence_share_id_agent_id_pk",
+          "columns": [
+            "share_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "implementation_status": {
+          "name": "implementation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unassigned'"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_project_created_idx": {
+          "name": "comments_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_project_url_idx": {
+          "name": "comments_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_project_status_idx": {
+          "name": "comments_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "implementation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_events": {
+      "name": "feedback_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feedback_events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_events_share_id_idx": {
+          "name": "feedback_events_share_id_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_events_share_id_feedback_shares_id_fk": {
+          "name": "feedback_events_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_events",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_events_comment_id_comments_id_fk": {
+          "name": "feedback_events_comment_id_comments_id_fk",
+          "tableFrom": "feedback_events",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_operation_keys": {
+      "name": "feedback_operation_keys",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_event_id": {
+          "name": "feedback_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_operation_keys_share_id_feedback_shares_id_fk": {
+          "name": "feedback_operation_keys_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_operation_keys_feedback_event_id_feedback_events_id_fk": {
+          "name": "feedback_operation_keys_feedback_event_id_feedback_events_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "tableTo": "feedback_events",
+          "columnsFrom": [
+            "feedback_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_operation_keys_share_id_agent_id_idempotency_key_pk": {
+          "name": "feedback_operation_keys_share_id_agent_id_idempotency_key_pk",
+          "columns": [
+            "share_id",
+            "agent_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_share_items": {
+      "name": "feedback_share_items",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_share_items_share_id_feedback_shares_id_fk": {
+          "name": "feedback_share_items_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_share_items",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_share_items_comment_id_comments_id_fk": {
+          "name": "feedback_share_items_comment_id_comments_id_fk",
+          "tableFrom": "feedback_share_items",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_share_items_share_id_comment_id_pk": {
+          "name": "feedback_share_items_share_id_comment_id_pk",
+          "columns": [
+            "share_id",
+            "comment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_shares": {
+      "name": "feedback_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_page_url": {
+          "name": "scope_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_shares_one_project_scope_per_project": {
+          "name": "feedback_shares_one_project_scope_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "scope_type = 'project' and revoked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_shares_project_id_projects_public_key_fk": {
+          "name": "feedback_shares_project_id_projects_public_key_fk",
+          "tableFrom": "feedback_shares",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_shares_slug_unique": {
+          "name": "feedback_shares_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feedback_shares_scope_type_check": {
+          "name": "feedback_shares_scope_type_check",
+          "value": "\"feedback_shares\".\"scope_type\" in ('page', 'selection', 'project')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_kind_check": {
+          "name": "notifications_kind_check",
+          "value": "\"notifications\".\"kind\" in ('invite.received', 'invite.accepted', 'invite.declined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_invites": {
+      "name": "project_invites",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invites_email_idx": {
+          "name": "project_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invites_project_key_projects_public_key_fk": {
+          "name": "project_invites_project_key_projects_public_key_fk",
+          "tableFrom": "project_invites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_invites_project_key_email_pk": {
+          "name": "project_invites_project_key_email_pk",
+          "columns": [
+            "project_key",
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_invites_role_check": {
+          "name": "project_invites_role_check",
+          "value": "\"project_invites\".\"role\" in ('admin', 'member')"
+        },
+        "project_invites_email_lower_check": {
+          "name": "project_invites_email_lower_check",
+          "value": "\"project_invites\".\"email\" = lower(\"project_invites\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_key_projects_public_key_fk": {
+          "name": "project_members_project_key_projects_public_key_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_key_user_id_pk": {
+          "name": "project_members_project_key_user_id_pk",
+          "columns": [
+            "project_key",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_members_role_check": {
+          "name": "project_members_role_check",
+          "value": "\"project_members\".\"role\" in ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_repo_configs": {
+      "name": "project_repo_configs",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_command": {
+          "name": "dev_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command": {
+          "name": "build_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instructions": {
+          "name": "agent_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_repo_configs_project_key_projects_public_key_fk": {
+          "name": "project_repo_configs_project_key_projects_public_key_fk",
+          "tableFrom": "project_repo_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claimable": {
+          "name": "claimable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1779348294740,
       "tag": "0001_fluffy_nuke",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1779692374320,
+      "tag": "0002_wild_black_bird",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -188,6 +188,29 @@ export const agentPresence = pgTable(
   }),
 )
 
+// In-app notification feed. user_id references auth.users(id); the FK is
+// added by hand in the migration SQL (same pattern as projectMembers).
+// RLS + supabase_realtime publication also configured by hand in that
+// migration so the dashboard can subscribe with the anon key.
+export const notifications = pgTable(
+  'notifications',
+  {
+    id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+    userId: uuid('user_id').notNull(),
+    kind: text('kind').notNull(),
+    payload: jsonb('payload').notNull().default(sql`'{}'::jsonb`),
+    readAt: timestamp('read_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    userCreatedIdx: index('notifications_user_created_idx').on(t.userId, t.createdAt.desc()),
+    kindCheck: check(
+      'notifications_kind_check',
+      sql`${t.kind} in ('invite.received', 'invite.accepted', 'invite.declined')`,
+    ),
+  }),
+)
+
 export const feedbackOperationKeys = pgTable(
   'feedback_operation_keys',
   {


### PR DESCRIPTION
> Stacked on #114.

> ~1100 of the changed lines are an auto-generated Drizzle migration snapshot — safe to skip during review.

- Add a notifications feed: each user has their own inbox of in-app messages.
- Wire up Supabase realtime so the dashboard can subscribe and see new notifications pop in without a refresh.
- Lock the table down so each user only ever sees their own notifications, even if someone tries to listen to the channel directly.
- Endpoints to fetch your notifications, mark one as read, or mark them all read at once.
- Backend uses a service-role client for this table specifically (it's the one table with row-level security on); rest of the API unchanged.
- A `TODO(ui-notifications)` in the dashboard points to where the bell icon + realtime subscription should land in the UI PR.