### PR TITLE
Invite teammates to a project

### DIFF
--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -1,14 +1,19 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('./supabase.js', () => ({ getSupabase: vi.fn(), getServiceSupabase: vi.fn() }))
 
 import { getServiceSupabase, getSupabase } from './supabase.js'
 import {
+  acceptInvite,
   claimProject,
+  createInvite,
   createNotification,
+  declineInvite,
   ensurePublicProject,
+  findUserIdByEmail,
   getProjectMember,
   isProjectMember,
+  listInvitesForEmail,
   listNotificationsForUser,
   listProjectsForUser,
   markAllNotificationsRead,
@@ -393,5 +398,192 @@ describe('notifications helpers', () => {
       notifUpdateAllError: { message: 'boom' },
     }) as never)
     await expect(markAllNotificationsRead('u')).rejects.toThrow('boom')
+  })
+})
+
+type InviteRow = {
+  project_key: string
+  email: string
+  role: 'admin' | 'member'
+  invited_by: string
+  created_at: string
+}
+
+type InviteMocks = {
+  inviteSingle?: { data: InviteRow | null; error: { message: string } | null }
+  inviteList?: { data: InviteRow[] | null; error: { message: string } | null }
+  inviteInsertResult?: { data: InviteRow | null; error: { code?: string; message: string } | null }
+  inviteDeleteError?: { message: string } | null
+  memberInsertError?: { code?: string; message: string } | null
+}
+
+function inviteSupabase(m: InviteMocks = {}) {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'project_invites') {
+        return {
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve(m.inviteInsertResult ?? { data: null, error: null })),
+            })),
+          })),
+          select: vi.fn(() => {
+            const chain = {
+              eq: vi.fn(() => chain),
+              order: vi.fn(() => chain),
+              maybeSingle: vi.fn(() => Promise.resolve(m.inviteSingle ?? { data: null, error: null })),
+              then: (r: (v: unknown) => unknown) =>
+                Promise.resolve(m.inviteList ?? { data: [], error: null }).then(r),
+            }
+            return chain
+          }),
+          delete: vi.fn(() => {
+            const chain = {
+              eq: vi.fn(() => chain),
+              then: (r: (v: unknown) => unknown) =>
+                Promise.resolve({ error: m.inviteDeleteError ?? null }).then(r),
+            }
+            return chain
+          }),
+        }
+      }
+      if (table === 'project_members') {
+        return { insert: vi.fn(() => Promise.resolve({ error: m.memberInsertError ?? null })) }
+      }
+      throw new Error(`Unmocked table ${table}`)
+    }),
+  }
+}
+
+describe('invite helpers', () => {
+  const INVITE: InviteRow = { project_key: 'p', email: 'x@y.z', role: 'member', invited_by: 'inviter-1', created_at: 't' }
+
+  it('createInvite: success / already_invited / other error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteInsertResult: { data: INVITE, error: null },
+    }) as never)
+    expect((await createInvite({ projectKey: 'p', email: 'X@Y.Z', role: 'member', invitedBy: 'inviter-1' })).email).toBe('x@y.z')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteInsertResult: { data: null, error: { code: '23505', message: 'dup' } },
+    }) as never)
+    await expect(createInvite({ projectKey: 'p', email: 'x@y.z', role: 'member', invitedBy: 'i' })).rejects.toThrow('already_invited')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteInsertResult: { data: null, error: { code: '50000', message: 'boom' } },
+    }) as never)
+    await expect(createInvite({ projectKey: 'p', email: 'x@y.z', role: 'member', invitedBy: 'i' })).rejects.toThrow('boom')
+  })
+
+  it('listInvitesForEmail: success / null fallback / error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteList: { data: [INVITE], error: null },
+    }) as never)
+    expect((await listInvitesForEmail('X@Y.Z')).map((i) => i.projectKey)).toEqual(['p'])
+
+    // defensive `data || []` fallback
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteList: { data: null, error: null },
+    }) as never)
+    expect(await listInvitesForEmail('x@y.z')).toEqual([])
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteList: { data: null, error: { message: 'boom' } },
+    }) as never)
+    await expect(listInvitesForEmail('x@y.z')).rejects.toThrow('boom')
+  })
+
+  it('acceptInvite: not_found / happy / membership 23505 tolerated / other error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: null, error: null } }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('not_found')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: INVITE, error: null } }) as never)
+    expect(await acceptInvite('u', 'x@y.z', 'p')).toBe('inviter-1')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: INVITE, error: null },
+      memberInsertError: { code: '23505', message: 'dup' },
+    }) as never)
+    expect(await acceptInvite('u', 'x@y.z', 'p')).toBe('inviter-1')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: INVITE, error: null },
+      memberInsertError: { code: '50000', message: 'boom' },
+    }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('boom')
+  })
+
+  it('declineInvite: not_found / happy', async () => {
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: null, error: null } }) as never)
+    await expect(declineInvite('x@y.z', 'p')).rejects.toThrow('not_found')
+
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: INVITE, error: null } }) as never)
+    expect(await declineInvite('x@y.z', 'p')).toBe('inviter-1')
+  })
+
+  it('getInvite lookup error / deleteInvite error bubble through accept', async () => {
+    // getInvite error path
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: null, error: { message: 'lookup boom' } },
+    }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('lookup boom')
+
+    // deleteInvite error path (invite found, member insert ok, delete fails)
+    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+      inviteSingle: { data: INVITE, error: null },
+      inviteDeleteError: { message: 'delete boom' },
+    }) as never)
+    await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('delete boom')
+  })
+})
+
+describe('findUserIdByEmail', () => {
+  const origFetch = globalThis.fetch
+  const origUrl = process.env.SUPABASE_URL
+  const origKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  beforeEach(() => {
+    process.env.SUPABASE_URL = 'https://supa.example'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key'
+  })
+
+  afterEach(() => {
+    globalThis.fetch = origFetch
+    process.env.SUPABASE_URL = origUrl
+    process.env.SUPABASE_SERVICE_ROLE_KEY = origKey
+  })
+
+  it('returns null when service role key is missing', async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns null when SUPABASE_URL is missing', async () => {
+    delete process.env.SUPABASE_URL
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns null when admin endpoint returns non-OK', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('nope', { status: 500 })) as never
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns the matching user id when found', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
+      users: [{ id: 'u-1', email: 'X@Y.Z' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } })) as never
+    expect(await findUserIdByEmail('x@y.z')).toBe('u-1')
+  })
+
+  it('returns null when fetch throws', async () => {
+    globalThis.fetch = vi.fn(async () => { throw new Error('net') }) as never
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+
+  it('returns null when response shape is unexpected', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('{}', {
+      status: 200, headers: { 'content-type': 'application/json' },
+    })) as never
+    expect(await findUserIdByEmail('x@y.z')).toBeNull()
   })
 })

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -854,3 +854,130 @@ export async function markAllNotificationsRead(userId: string) {
   if (error) throw new Error(error.message)
 }
 
+type InviteRow = {
+  project_key: string
+  email: string
+  role: 'admin' | 'member'
+  invited_by: string
+  created_at: string
+}
+
+function mapInvite(row: InviteRow) {
+  return {
+    projectKey: row.project_key,
+    email: row.email,
+    role: row.role,
+    invitedBy: row.invited_by,
+    createdAt: row.created_at,
+  }
+}
+
+export async function createInvite(input: {
+  projectKey: string
+  email: string
+  role: 'admin' | 'member'
+  invitedBy: string
+}) {
+  const supabase = getSupabase()
+  const email = input.email.toLowerCase().trim()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .insert([{
+      project_key: input.projectKey,
+      email,
+      role: input.role,
+      invited_by: input.invitedBy,
+    }] as never)
+    .select('project_key, email, role, invited_by, created_at')
+    .single()
+  if (error) {
+    if (error.code === '23505') throw new Error('already_invited')
+    throw new Error(error.message)
+  }
+  return mapInvite(data as InviteRow)
+}
+
+export async function listInvitesForEmail(email: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .select('project_key, email, role, invited_by, created_at')
+    .eq('email', email.toLowerCase().trim())
+    .order('created_at', { ascending: false })
+  if (error) throw new Error(error.message)
+  return (data || []).map((row) => mapInvite(row as InviteRow))
+}
+
+async function getInvite(email: string, projectKey: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .select('project_key, email, role, invited_by, created_at')
+    .eq('email', email.toLowerCase().trim())
+    .eq('project_key', projectKey)
+    .maybeSingle()
+  if (error) throw new Error(error.message)
+  return data ? mapInvite(data as InviteRow) : null
+}
+
+async function deleteInvite(email: string, projectKey: string) {
+  const supabase = getSupabase()
+  const { error } = await supabase
+    .from('project_invites')
+    .delete()
+    .eq('email', email.toLowerCase().trim())
+    .eq('project_key', projectKey)
+  if (error) throw new Error(error.message)
+}
+
+/**
+ * Atomic invite acceptance: verify the invite exists for this email, insert
+ * the project_members row (idempotent via 23505), delete the invite. Returns
+ * the inviter's user_id so the caller can emit an `invite.accepted` notif.
+ */
+export async function acceptInvite(userId: string, email: string, projectKey: string): Promise<string> {
+  const invite = await getInvite(email, projectKey)
+  if (!invite) throw new Error('not_found')
+
+  const supabase = getSupabase()
+  const { error: insertError } = await supabase
+    .from('project_members')
+    .insert([{ project_key: projectKey, user_id: userId, role: invite.role }] as never)
+  if (insertError && insertError.code !== '23505') throw new Error(insertError.message)
+
+  await deleteInvite(email, projectKey)
+  return invite.invitedBy
+}
+
+export async function declineInvite(email: string, projectKey: string): Promise<string> {
+  const invite = await getInvite(email, projectKey)
+  if (!invite) throw new Error('not_found')
+  await deleteInvite(email, projectKey)
+  return invite.invitedBy
+}
+
+/**
+ * Look up the auth.users id for an email. Uses the service role admin API if
+ * a SUPABASE_SERVICE_ROLE_KEY is configured; otherwise returns null. The null
+ * fallback is intentional — the invite still gets created, just no realtime
+ * notif fires for the invitee (they'll see it on next login via GET /invites).
+ */
+export async function findUserIdByEmail(email: string): Promise<string | null> {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!serviceKey) return null
+  const url = process.env.SUPABASE_URL
+  if (!url) return null
+  try {
+    const res = await fetch(`${url}/auth/v1/admin/users?email=${encodeURIComponent(email)}`, {
+      headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as { users?: Array<{ id?: string; email?: string }> }
+    const users = Array.isArray(body.users) ? body.users : []
+    const match = users.find((u) => u.email?.toLowerCase() === email.toLowerCase())
+    return match?.id ?? null
+  } catch {
+    return null
+  }
+}
+

--- a/api/v1/invites/accept.test.ts
+++ b/api/v1/invites/accept.test.ts
@@ -92,11 +92,11 @@ describe('api/v1/invites/accept', () => {
     await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(500)
 
-    // non-Error throw → "Unexpected error" fallback
+    // non-Error throw → 500
     vi.mocked(acceptInvite).mockImplementationOnce(() => { throw 'string-not-error' })
     res = mockRes()
     await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(500)
-    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
   })
 })

--- a/api/v1/invites/accept.test.ts
+++ b/api/v1/invites/accept.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({
+  acceptInvite: vi.fn(),
+  createNotification: vi.fn(),
+}))
+
+import handler from './accept.js'
+import { requireUser } from '../../_lib/auth.js'
+import { acceptInvite, createNotification } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(acceptInvite).mockReset()
+  vi.mocked(createNotification).mockReset()
+})
+
+describe('api/v1/invites/accept', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('tolerates absent body (req.body ?? {} fallback)', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('non-POST + unauthed', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('validates body + not_found + happy path + 500', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    let res = mockRes()
+    await call({ method: 'POST', body: {}, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(acceptInvite).mockRejectedValueOnce(new Error('not_found'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(acceptInvite).mockResolvedValueOnce('inviter-1')
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'inviter-1', kind: 'invite.accepted',
+    }))
+
+    // notif emit fails → accept still returns 200 (fanout is fire-and-forget)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(acceptInvite).mockResolvedValueOnce('inviter-1')
+    vi.mocked(createNotification).mockRejectedValueOnce(new Error('notif down'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    vi.mocked(acceptInvite).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+
+    // non-Error throw → "Unexpected error" fallback
+    vi.mocked(acceptInvite).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+  })
+})

--- a/api/v1/invites/accept.ts
+++ b/api/v1/invites/accept.ts
@@ -1,0 +1,35 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { acceptInvite, createNotification } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const body = (req.body ?? {}) as { projectKey?: unknown }
+  const projectKey = typeof body.projectKey === 'string' ? body.projectKey.trim() : ''
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectKey')
+
+  try {
+    const inviterId = await acceptInvite(user.userId, user.email, projectKey)
+    // Notif fanout failure can't undo membership; log + continue.
+    try {
+      await createNotification({
+        userId: inviterId,
+        kind: 'invite.accepted',
+        payload: { projectKey, acceptedBy: user.userId, email: user.email },
+      })
+    } catch (notifError) {
+      console.warn('invite.accepted notif failed:', notifError)
+    }
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json({ projectKey })
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unexpected error'
+    if (msg === 'not_found') return jsonError(req, res, 404, 'Invite not found')
+    return jsonError(req, res, 500, msg)
+  }
+}

--- a/api/v1/invites/accept.ts
+++ b/api/v1/invites/accept.ts
@@ -28,8 +28,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     setCors(req, res, ['POST', 'OPTIONS'])
     return res.status(200).json({ projectKey })
   } catch (error) {
-    const msg = error instanceof Error ? error.message : 'Unexpected error'
+    const msg = error instanceof Error ? error.message : undefined
     if (msg === 'not_found') return jsonError(req, res, 404, 'Invite not found')
-    return jsonError(req, res, 500, msg)
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
   }
 }

--- a/api/v1/invites/decline.test.ts
+++ b/api/v1/invites/decline.test.ts
@@ -90,11 +90,11 @@ describe('api/v1/invites/decline', () => {
     await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(500)
 
-    // non-Error throw → "Unexpected error" fallback
+    // non-Error throw → 500
     vi.mocked(declineInvite).mockImplementationOnce(() => { throw 'string-not-error' })
     res = mockRes()
     await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(500)
-    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
   })
 })

--- a/api/v1/invites/decline.test.ts
+++ b/api/v1/invites/decline.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({
+  declineInvite: vi.fn(),
+  createNotification: vi.fn(),
+}))
+
+import handler from './decline.js'
+import { requireUser } from '../../_lib/auth.js'
+import { createNotification, declineInvite } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(declineInvite).mockReset()
+  vi.mocked(createNotification).mockReset()
+})
+
+describe('api/v1/invites/decline', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('tolerates absent body (req.body ?? {} fallback)', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('non-POST + unauthed + validation + not_found + happy + 500', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    res = mockRes()
+    await call({ method: 'POST', body: {}, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(declineInvite).mockRejectedValueOnce(new Error('not_found'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    vi.mocked(declineInvite).mockResolvedValueOnce('inviter-1')
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'inviter-1', kind: 'invite.declined',
+    }))
+
+    // notif emit fails → decline still returns 200 (fanout is fire-and-forget)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(declineInvite).mockResolvedValueOnce('inviter-1')
+    vi.mocked(createNotification).mockRejectedValueOnce(new Error('notif down'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    vi.mocked(declineInvite).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+
+    // non-Error throw → "Unexpected error" fallback
+    vi.mocked(declineInvite).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'p' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+  })
+})

--- a/api/v1/invites/decline.ts
+++ b/api/v1/invites/decline.ts
@@ -1,0 +1,35 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { createNotification, declineInvite } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const body = (req.body ?? {}) as { projectKey?: unknown }
+  const projectKey = typeof body.projectKey === 'string' ? body.projectKey.trim() : ''
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectKey')
+
+  try {
+    const inviterId = await declineInvite(user.email, projectKey)
+    // Notif fanout failure can't undo decline; log + continue.
+    try {
+      await createNotification({
+        userId: inviterId,
+        kind: 'invite.declined',
+        payload: { projectKey, declinedBy: user.userId, email: user.email },
+      })
+    } catch (notifError) {
+      console.warn('invite.declined notif failed:', notifError)
+    }
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(200).json({ projectKey })
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unexpected error'
+    if (msg === 'not_found') return jsonError(req, res, 404, 'Invite not found')
+    return jsonError(req, res, 500, msg)
+  }
+}

--- a/api/v1/invites/decline.ts
+++ b/api/v1/invites/decline.ts
@@ -28,8 +28,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     setCors(req, res, ['POST', 'OPTIONS'])
     return res.status(200).json({ projectKey })
   } catch (error) {
-    const msg = error instanceof Error ? error.message : 'Unexpected error'
+    const msg = error instanceof Error ? error.message : undefined
     if (msg === 'not_found') return jsonError(req, res, 404, 'Invite not found')
-    return jsonError(req, res, 500, msg)
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
   }
 }

--- a/api/v1/invites/index.test.ts
+++ b/api/v1/invites/index.test.ts
@@ -33,13 +33,13 @@ describe('api/v1/invites', () => {
     expect(res.statusCode).toBe(204)
   })
 
-  it('falls back to "Unexpected error" on non-Error throws', async () => {
+  it('returns 500 on non-Error throws', async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
     vi.mocked(listInvitesForEmail).mockImplementationOnce(() => { throw 'string-not-error' })
     const res = mockRes()
     await call({ method: 'GET', query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(500)
-    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
   })
 
   it('non-GET 405; unauthed 401; happy path lists invites; 500 on throw', async () => {

--- a/api/v1/invites/index.test.ts
+++ b/api/v1/invites/index.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({ listInvitesForEmail: vi.fn() }))
+
+import handler from './index.js'
+import { requireUser } from '../../_lib/auth.js'
+import { listInvitesForEmail } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(listInvitesForEmail).mockReset()
+})
+
+describe('api/v1/invites', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('falls back to "Unexpected error" on non-Error throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(listInvitesForEmail).mockImplementationOnce(() => { throw 'string-not-error' })
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+  })
+
+  it('non-GET 405; unauthed 401; happy path lists invites; 500 on throw', async () => {
+    let res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(listInvitesForEmail).mockResolvedValueOnce([{ projectKey: 'p' }] as never)
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(listInvitesForEmail).toHaveBeenCalledWith('a@b.c')
+
+    vi.mocked(listInvitesForEmail).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/invites/index.ts
+++ b/api/v1/invites/index.ts
@@ -14,6 +14,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     setCors(req, res, ['GET', 'OPTIONS'])
     return res.status(200).json(invites)
   } catch (error) {
-    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
   }
 }

--- a/api/v1/invites/index.ts
+++ b/api/v1/invites/index.ts
@@ -1,0 +1,19 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { listInvitesForEmail } from '../../_lib/store.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  try {
+    const invites = await listInvitesForEmail(user.email)
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json(invites)
+  } catch (error) {
+    return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
+  }
+}

--- a/api/v1/projects/[projectId]/invites.test.ts
+++ b/api/v1/projects/[projectId]/invites.test.ts
@@ -140,12 +140,12 @@ describe('api/v1/projects/[projectId]/invites', () => {
     await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
     expect(res.statusCode).toBe(500)
 
-    // non-Error throw → "Unexpected error" fallback
+    // non-Error throw → 500
     vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
     vi.mocked(createInvite).mockImplementationOnce(() => { throw 'string-not-error' })
     res = mockRes()
     await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
     expect(res.statusCode).toBe(500)
-    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
   })
 })

--- a/api/v1/projects/[projectId]/invites.test.ts
+++ b/api/v1/projects/[projectId]/invites.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({
+  createInvite: vi.fn(),
+  createNotification: vi.fn(),
+  findUserIdByEmail: vi.fn(),
+  getProjectMember: vi.fn(),
+}))
+
+import handler from './invites.js'
+import { requireUser } from '../../../_lib/auth.js'
+import { createInvite, createNotification, findUserIdByEmail, getProjectMember } from '../../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(getProjectMember).mockReset()
+  vi.mocked(createInvite).mockReset()
+  vi.mocked(findUserIdByEmail).mockReset()
+  vi.mocked(createNotification).mockReset()
+})
+
+describe('api/v1/projects/[projectId]/invites', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('tolerates absent body / non-string email', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    // no body at all → 400 Invalid email (req.body ?? {} path)
+    let res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // non-string email → 400
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 123 }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects non-POST + unauthenticated', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('validates projectKey + email + admin role + already_invited + happy path', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    // missing projectKey
+    let res = mockRes()
+    await call({ method: 'POST', query: {}, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // bad email
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'nope' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // non-member
+    vi.mocked(getProjectMember).mockResolvedValueOnce(null)
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    // member but not admin
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'member' })
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    // already_invited
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockRejectedValueOnce(new Error('already_invited'))
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(409)
+
+    // happy path: invitee exists → notification fired
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
+    vi.mocked(findUserIdByEmail).mockResolvedValueOnce('invitee-1')
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z', role: 'admin' }, headers: {} }, res)
+    expect(res.statusCode).toBe(201)
+    expect(createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'invitee-1', kind: 'invite.received',
+    }))
+
+    // happy path: invitee has no account → notification skipped
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
+    vi.mocked(findUserIdByEmail).mockResolvedValueOnce(null)
+    vi.mocked(createNotification).mockClear()
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(201)
+    expect(createNotification).not.toHaveBeenCalled()
+
+    // notif emit fails → invite still returns 201 (fanout is fire-and-forget)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
+    vi.mocked(findUserIdByEmail).mockResolvedValueOnce('invitee-1')
+    vi.mocked(createNotification).mockRejectedValueOnce(new Error('notif down'))
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(201)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+
+    // generic 500
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockRejectedValueOnce(new Error('db down'))
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+
+    // non-Error throw → "Unexpected error" fallback
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(createInvite).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Unexpected error' })
+  })
+})

--- a/api/v1/projects/[projectId]/invites.ts
+++ b/api/v1/projects/[projectId]/invites.ts
@@ -53,8 +53,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     setCors(req, res, ['POST', 'OPTIONS'])
     return res.status(201).json(invite)
   } catch (error) {
-    const msg = error instanceof Error ? error.message : 'Unexpected error'
+    const msg = error instanceof Error ? error.message : undefined
     if (msg === 'already_invited') return jsonError(req, res, 409, 'Already invited')
-    return jsonError(req, res, 500, msg)
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
   }
 }

--- a/api/v1/projects/[projectId]/invites.ts
+++ b/api/v1/projects/[projectId]/invites.ts
@@ -1,0 +1,60 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../../_lib/auth.js'
+import {
+  createInvite,
+  createNotification,
+  findUserIdByEmail,
+  getProjectMember,
+} from '../../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
+  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  // Route param is `projectId` to match the sibling dir (Vercel rejects two
+  // different dynamic-segment names at the same path level). The value is
+  // still a project public_key — we use that semantic name internally.
+  const projectKey = getStringQuery(req.query.projectId)
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectId')
+
+  const body = (req.body ?? {}) as { email?: unknown; role?: unknown }
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
+  const role = body.role === 'admin' ? 'admin' : 'member'
+  if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+    return jsonError(req, res, 400, 'Invalid email')
+  }
+
+  try {
+    const membership = await getProjectMember(user.userId, projectKey)
+    if (!membership) return jsonError(req, res, 403, 'Forbidden')
+    if (membership.role !== 'admin') return jsonError(req, res, 403, 'Admin role required')
+
+    const invite = await createInvite({ projectKey, email, role, invitedBy: user.userId })
+
+    // Notif emit is fire-and-forget: invite row is already persisted, and the
+    // invitee will still see it on next GET /invites even if realtime fanout
+    // fails (e.g. notifications table missing, transient DB error).
+    try {
+      const inviteeUserId = await findUserIdByEmail(email)
+      if (inviteeUserId) {
+        await createNotification({
+          userId: inviteeUserId,
+          kind: 'invite.received',
+          payload: { projectKey, email, role, invitedBy: user.userId },
+        })
+      }
+    } catch (notifError) {
+      console.warn('invite.received notif failed:', notifError)
+    }
+
+    setCors(req, res, ['POST', 'OPTIONS'])
+    return res.status(201).json(invite)
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unexpected error'
+    if (msg === 'already_invited') return jsonError(req, res, 409, 'Already invited')
+    return jsonError(req, res, 500, msg)
+  }
+}

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -77,6 +77,11 @@ export function App() {
 //     .subscribe()
 // Show unread count; POST /api/v1/notifications/:id/read on click; offer
 // "Mark all read" → POST /api/v1/notifications/read-all.
+// Invite acceptance UI: list GET /api/v1/invites in a panel with
+// Accept (POST /api/v1/invites/accept { projectKey }) and
+// Decline (POST /api/v1/invites/decline { projectKey }) buttons.
+// Admin-side invite send: POST /api/v1/projects/:projectKey/invites
+// { email, role } (admin role required).
 function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: string; user: import('@supabase/supabase-js').User; onSignOut: () => void }) {
   const { projects, loading: projectsLoading, error: projectsError, createProject } = useProjects(API_BASE, accessToken)
   const [selectedProject, setSelectedProject] = useState<string>('')


### PR DESCRIPTION
> Stacked on #115.

- Admins can invite someone by email. If they already have an account, they get a live in-app notification right away.
- Invitees see their pending invites and can accept or decline. Accepting drops them into the project as a member.
- The inviter gets a notification back when an invite is accepted or declined.
- A failing notification never blocks the underlying action — fanout is fire-and-forget, so accepting always succeeds even if the notification step hiccups.
- TODO in the dashboard for the invite list and the admin invite-send UI.