### PR TITLE
fix(widget): tooltip flip, scroll re-anchor, pill hysteresis, dead-UI removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ coverage/
 .vercel
 *.tgz
 pr/
+
+# Claude Code skill artifacts (local-only, per-developer)
+.superpowers/
+skills-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,18 +15,3 @@ Supabase client (`@supabase/supabase-js`) stays the runtime query layer. Do **no
 ## Diff coverage
 
 After any code change, MUST invoke `diff-coverage` skill before handing work back. Both line and branch diff coverage vs `trunk` required at 100%.
-
-## Repo identity
-
-This local folder is `feedback-widget`, but `origin` points at `github.com/thedesignproject/CRRT`. **They are the same repo.** The `tomasTDP/branding-widget` remote (alias `branding`) is **deprecated** — never push or reference it.
-
-## Deploying to Vercel
-
-Only commits whose author is `alsoalter85` (Alessandro) trigger Vercel builds — direct contributor permission for other users costs extra. Alessandro maintains a standing "kick Vercel" PR (originally **#113**, branch prefix `attaccante/vercel-deployment-trigger-*`) and a systemd timer that adds an empty commit as him every 15 min whenever the latest commit on that branch is not his.
-
-**After merging a feature PR into `trunk`, to deploy:**
-1. Open the standing "Trigger Vercel" PR and rebase/update it onto `trunk`.
-2. Wait ≤15 min for Alessandro's automation to push a fresh empty commit.
-3. Approve and merge that PR — Vercel deploys.
-
-**Never close PR #113** (or its current successor). It is the standing PR the automation depends on.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,18 @@ Supabase client (`@supabase/supabase-js`) stays the runtime query layer. Do **no
 ## Diff coverage
 
 After any code change, MUST invoke `diff-coverage` skill before handing work back. Both line and branch diff coverage vs `trunk` required at 100%.
+
+## Repo identity
+
+This local folder is `feedback-widget`, but `origin` points at `github.com/thedesignproject/CRRT`. **They are the same repo.** The `tomasTDP/branding-widget` remote (alias `branding`) is **deprecated** — never push or reference it.
+
+## Deploying to Vercel
+
+Only commits whose author is `alsoalter85` (Alessandro) trigger Vercel builds — direct contributor permission for other users costs extra. Alessandro maintains a standing "kick Vercel" PR (originally **#113**, branch prefix `attaccante/vercel-deployment-trigger-*`) and a systemd timer that adds an empty commit as him every 15 min whenever the latest commit on that branch is not his.
+
+**After merging a feature PR into `trunk`, to deploy:**
+1. Open the standing "Trigger Vercel" PR and rebase/update it onto `trunk`.
+2. Wait ≤15 min for Alessandro's automation to push a fresh empty commit.
+3. Approve and merge that PR — Vercel deploys.
+
+**Never close PR #113** (or its current successor). It is the standing PR the automation depends on.

--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -1877,6 +1877,28 @@ describe('<FeedbackWidget />', () => {
       const carrotSpan = pillWrapper.querySelector<HTMLElement>('span[style*="width: 28"]')
       expect(carrotSpan).not.toBeNull()
     })
+
+    it('second mouseLeave while timer is pending clears the prior timer and resets', async () => {
+      mockFetch()
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+      const pillWrapper = await waitFor(() => {
+        const el = Array.from(document.querySelectorAll<HTMLDivElement>('[data-fw]'))
+          .find((el) => /cursor:\s*grab/.test(el.getAttribute('style') ?? ''))
+        if (!el) throw new Error('pill wrapper not found')
+        return el
+      })
+
+      // Enter so pillHover=true, then leave twice before the 120ms timer fires.
+      // The second leave must hit the clearTimeout branch in onPillLeave (L126).
+      fireEvent.mouseEnter(pillWrapper)
+      fireEvent.mouseLeave(pillWrapper)
+      fireEvent.mouseLeave(pillWrapper)
+
+      // After 200ms both leaves have had time to resolve; pillHover should be false.
+      await new Promise((r) => setTimeout(r, 200))
+      const carrotSpan = pillWrapper.querySelector<HTMLElement>('span[style*="width: 28"]')
+      expect(carrotSpan).toBeNull()
+    })
   })
 
   describe('onPillPointerDown (lines 466-469)', () => {

--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -114,6 +114,34 @@ async function enterCommentingMode() {
   return { textarea, getSendButton, targetNode }
 }
 
+// Opens inline edit on the sidebar card whose body contains `bodyText`,
+// via the 3-dot menu → Edit (the click-body-to-edit path was removed
+// since the whole card click is reserved for scroll-to-pin).
+async function openCardEditByBody(bodyText: string) {
+  await waitFor(() => {
+    if (!document.body.textContent?.includes(bodyText)) throw new Error('comment not loaded')
+  })
+  const card = Array.from(
+    document.querySelectorAll<HTMLDivElement>('[data-fw] .fw-sidebar-card'),
+  ).find((c) => c.textContent?.includes(bodyText))
+  if (!card) throw new Error('card not found')
+  const moreBtn = card.querySelector<HTMLButtonElement>('button[title="More"]')
+  if (!moreBtn) throw new Error('More button not found')
+  await act(async () => { fireEvent.click(moreBtn) })
+  const editMenuItem = await waitFor(() => {
+    const btn = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-fw] button'))
+      .find((b) => b.textContent?.trim() === 'Edit')
+    if (!btn) throw new Error('Edit menu item not found')
+    return btn
+  })
+  await act(async () => { fireEvent.click(editMenuItem) })
+  return await waitFor(() => {
+    const ta = card.querySelector<HTMLTextAreaElement>('textarea')
+    if (!ta) throw new Error('edit textarea not mounted')
+    return ta
+  })
+}
+
 describe('<FeedbackWidget />', () => {
   beforeEach(() => {
     vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
@@ -368,33 +396,11 @@ describe('<FeedbackWidget />', () => {
       }
     }
 
-    it('clicking a card body switches to inline edit mode and Save updates the comment text', async () => {
+    it('opening Edit from the 3-dot menu switches to inline edit mode and Save updates the comment text', async () => {
       mockFetch(undefined, commentsResponse([seedComment()]))
       render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
 
-      // Wait for the comment to land in the DOM, then locate the inner text
-      // div by its cursor:text style — that's the inline-edit trigger.
-      await waitFor(() => {
-        if (!document.body.textContent?.includes('sidebar entry')) {
-          throw new Error('comment body not rendered yet')
-        }
-      })
-      const bodyDiv = Array.from(
-        document.querySelectorAll<HTMLDivElement>('[data-fw] div'),
-      ).find(
-        (el) =>
-          /cursor:\s*text/.test(el.getAttribute('style') ?? '') &&
-          el.textContent === 'sidebar entry',
-      )
-      expect(bodyDiv).toBeDefined()
-
-      fireEvent.click(bodyDiv!)
-
-      const editArea = await waitFor(() => {
-        const ta = document.querySelector<HTMLTextAreaElement>('[data-fw] textarea')
-        if (!ta) throw new Error('edit textarea not mounted yet')
-        return ta
-      })
+      const editArea = await openCardEditByBody('sidebar entry')
 
       const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-fw] button'))
       const cancel = buttons.find((b) => b.textContent === 'Cancel')
@@ -420,20 +426,7 @@ describe('<FeedbackWidget />', () => {
       const calls = mockFetch(undefined, commentsResponse([seedComment()]))
       render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
 
-      await waitFor(() => {
-        if (!document.body.textContent?.includes('sidebar entry')) {
-          throw new Error('comment body not rendered yet')
-        }
-      })
-      const bodyDiv = Array.from(
-        document.querySelectorAll<HTMLDivElement>('[data-fw] div'),
-      ).find(
-        (el) =>
-          /cursor:\s*text/.test(el.getAttribute('style') ?? '') &&
-          el.textContent === 'sidebar entry',
-      )
-      expect(bodyDiv).toBeDefined()
-      fireEvent.click(bodyDiv!)
+      await openCardEditByBody('sidebar entry')
 
       const cancel = await waitFor(() => {
         const btn = Array.from(
@@ -527,6 +520,73 @@ describe('<FeedbackWidget />', () => {
         // Author shows as 'Ada' inside the tooltip layer alongside the body.
         expect(document.body.textContent).toContain('Ada')
       })
+    })
+
+    // Helper to read the tooltip wrapper next to a hovered pin. The tooltip is
+    // the sibling div with position:fixed and pointerEvents:none.
+    async function hoverPinAndGetTooltip() {
+      const pin = await waitFor(() => {
+        const el = document.querySelector<HTMLDivElement>('[data-fw-pin]')
+        if (!el) throw new Error('pin not rendered')
+        return el
+      })
+      fireEvent.mouseEnter(pin)
+      return await waitFor(() => {
+        const wrappers = Array.from(document.querySelectorAll<HTMLDivElement>('[data-fw] div'))
+        const tooltip = wrappers.find((el) =>
+          /pointer-events:\s*none/.test(el.getAttribute('style') ?? '') &&
+          /position:\s*fixed/.test(el.getAttribute('style') ?? ''),
+        )
+        if (!tooltip) throw new Error('tooltip wrapper not rendered')
+        return tooltip
+      })
+    }
+
+    // Force happy-dom (which reports scrollWidth/Height = 0 by default) to use
+    // realistic page dimensions so pinPos.left/top maps from x%/y% as expected.
+    function stubPageSize(width = 1024, height = 768) {
+      Object.defineProperty(document.documentElement, 'scrollWidth', { value: width, configurable: true })
+      Object.defineProperty(document.documentElement, 'scrollHeight', { value: height, configurable: true })
+      Object.defineProperty(window, 'innerWidth', { value: width, configurable: true })
+      Object.defineProperty(window, 'innerHeight', { value: height, configurable: true })
+    }
+
+    it('pin hover tooltip flips horizontally when pin is near the right viewport edge', async () => {
+      // pinPos.left ≈ 0.9 * 1024 = 921; 921 + 280 + 8 > 1024 → flipH=true.
+      stubPageSize()
+      mockFetch(undefined, commentsResponse([seedComment({ x: 90, y: 50, body: 'right edge tip' })]))
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+      const tooltip = await hoverPinAndGetTooltip()
+      // Wrapper is shifted left so the right edge anchors near the pin.
+      expect(parseFloat(tooltip.style.left)).toBeLessThan(900)
+      expect(tooltip.style.transform).toBe('translateY(-100%)')
+      // Bottom-right anchor → transformOrigin '100% 100%'.
+      const inner = tooltip.firstElementChild as HTMLElement
+      expect(inner.style.transformOrigin).toBe('100% 100%')
+    })
+
+    it('pin hover tooltip flips vertically when pin is near the top viewport edge', async () => {
+      // pinPos.top ≈ 0.05 * 768 = 38; 38 - 11 - 140 < 8 → flipV=true.
+      stubPageSize()
+      mockFetch(undefined, commentsResponse([seedComment({ x: 20, y: 5, body: 'top edge tip' })]))
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+      const tooltip = await hoverPinAndGetTooltip()
+      // Wrapper sits below the pin; translateY reset to 0.
+      expect(tooltip.style.transform).toBe('translateY(0)')
+      // Top-left anchor → transformOrigin '0% 0%'.
+      const inner = tooltip.firstElementChild as HTMLElement
+      expect(inner.style.transformOrigin).toBe('0% 0%')
+    })
+
+    it('pin hover tooltip flips both axes when pin is in the top-right corner', async () => {
+      stubPageSize()
+      mockFetch(undefined, commentsResponse([seedComment({ x: 90, y: 5, body: 'corner tip' })]))
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+      const tooltip = await hoverPinAndGetTooltip()
+      expect(tooltip.style.transform).toBe('translateY(0)')
+      const inner = tooltip.firstElementChild as HTMLElement
+      // Top-right anchor → transformOrigin '100% 0%'.
+      expect(inner.style.transformOrigin).toBe('100% 0%')
     })
 
     it('numbers pins descending so the newest comment is #N for N comments', async () => {
@@ -1418,27 +1478,6 @@ describe('<FeedbackWidget />', () => {
       })
     })
 
-    it('reply button stopPropagation does not trigger card click (line 1390)', async () => {
-      mockFetch(undefined, commentsResponse([seedComment()]))
-      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
-
-      const replyBtn = await waitFor(() => {
-        const btn = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-fw] button'))
-          .find((b) => b.textContent?.trim() === 'Reply')
-        if (!btn) throw new Error('Reply button not found')
-        return btn
-      })
-      // Hover to cover onMouseEnter/Leave (lines 1403-1404).
-      fireEvent.mouseEnter(replyBtn)
-      fireEvent.mouseLeave(replyBtn)
-
-      // Click should not throw and should NOT open pin detail (stopPropagation).
-      await act(async () => { fireEvent.click(replyBtn) })
-      // No pin detail popover should be open.
-      const meta = Array.from(document.querySelectorAll<HTMLDivElement>('[data-fw] div'))
-        .find((el) => /#1\s*·/.test(el.textContent ?? ''))
-      expect(meta).toBeUndefined()
-    })
   })
 
   describe('sidebar card inline edit via keyboard (lines 1336-1338, 1349)', () => {
@@ -1454,19 +1493,7 @@ describe('<FeedbackWidget />', () => {
       mockFetch(undefined, commentsResponse([seedComment()]))
       render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
 
-      await waitFor(() => {
-        if (!document.body.textContent?.includes('inline edit body')) throw new Error('not rendered')
-      })
-      const bodyDiv = Array.from(document.querySelectorAll<HTMLDivElement>('[data-fw] div'))
-        .find((el) => /cursor:\s*text/.test(el.getAttribute('style') ?? '') && el.textContent === 'inline edit body')
-      expect(bodyDiv).toBeDefined()
-      fireEvent.click(bodyDiv!)
-
-      const ta = await waitFor(() => {
-        const el = document.querySelector<HTMLTextAreaElement>('[data-fw] textarea')
-        if (!el) throw new Error('textarea not found')
-        return el
-      })
+      const ta = await openCardEditByBody('inline edit body')
 
       // onFocus/onBlur cover lines 1348-1349.
       fireEvent.focus(ta)
@@ -1488,19 +1515,7 @@ describe('<FeedbackWidget />', () => {
       mockFetch(undefined, commentsResponse([seedComment()]))
       render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
 
-      await waitFor(() => {
-        if (!document.body.textContent?.includes('inline edit body')) throw new Error('not rendered')
-      })
-      const bodyDiv = Array.from(document.querySelectorAll<HTMLDivElement>('[data-fw] div'))
-        .find((el) => /cursor:\s*text/.test(el.getAttribute('style') ?? '') && el.textContent === 'inline edit body')
-      expect(bodyDiv).toBeDefined()
-      fireEvent.click(bodyDiv!)
-
-      const ta = await waitFor(() => {
-        const el = document.querySelector<HTMLTextAreaElement>('[data-fw] textarea')
-        if (!el) throw new Error('textarea not found')
-        return el
-      })
+      const ta = await openCardEditByBody('inline edit body')
 
       await act(async () => {
         fireEvent.change(ta, { target: { value: 'do not save' } })
@@ -1739,24 +1754,13 @@ describe('<FeedbackWidget />', () => {
     })
   })
 
-  describe('emoji and react button hover handlers (lines 802-803, 813-818, 833-834)', () => {
-    it('hovering emoji and react buttons in the commenting popover does not throw', async () => {
+  describe('composer Send button hover', () => {
+    it('hovering the Send button in the commenting popover does not throw', async () => {
       mockFetch()
       render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
       const { textarea } = await enterCommentingMode()
       fireEvent.change(textarea, { target: { value: 'test hover' } })
 
-      const addEmojiBtn = document.querySelector<HTMLButtonElement>('[aria-label="Add emoji"]')
-      expect(addEmojiBtn).not.toBeNull()
-      fireEvent.mouseEnter(addEmojiBtn!)
-      fireEvent.mouseLeave(addEmojiBtn!)
-
-      const reactBtn = document.querySelector<HTMLButtonElement>('[aria-label="React"]')
-      expect(reactBtn).not.toBeNull()
-      fireEvent.mouseEnter(reactBtn!)
-      fireEvent.mouseLeave(reactBtn!)
-
-      // The Send button hover (lines 859-860).
       const sendBtn = document.querySelector<HTMLButtonElement>('[aria-label="Send"]')
       expect(sendBtn).not.toBeNull()
       fireEvent.mouseEnter(sendBtn!)
@@ -1849,6 +1853,29 @@ describe('<FeedbackWidget />', () => {
       fireEvent.mouseLeave(pillWrapper)
       // No error thrown — the drag handle visibility changes.
       expect(pillWrapper).toBeDefined()
+    })
+
+    it('re-entering the pill before the unhover delay fires cancels the pending leave', async () => {
+      mockFetch()
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+      const pillWrapper = await waitFor(() => {
+        const el = Array.from(document.querySelectorAll<HTMLDivElement>('[data-fw]'))
+          .find((el) => /cursor:\s*grab/.test(el.getAttribute('style') ?? ''))
+        if (!el) throw new Error('pill wrapper not found')
+        return el
+      })
+
+      // Enter → leave schedules a 120ms timeout; re-entering before it fires
+      // must hit the clearTimeout branch in onPillEnter and keep pillHover true.
+      fireEvent.mouseEnter(pillWrapper)
+      fireEvent.mouseLeave(pillWrapper)
+      fireEvent.mouseEnter(pillWrapper)
+
+      // Wait past the original delay; pillHover should still be true.
+      await new Promise((r) => setTimeout(r, 200))
+      // Icon span at width 28 is the pillHover=true signal (46 when collapsed).
+      const carrotSpan = pillWrapper.querySelector<HTMLElement>('span[style*="width: 28"]')
+      expect(carrotSpan).not.toBeNull()
     })
   })
 
@@ -2364,19 +2391,8 @@ describe('<FeedbackWidget />', () => {
       return { id: 'edit1', projectId: 'proj', pageUrl, x: 20, y: 30, selector: 'body', body: 'edit kbd test', authorName: 'Ada', reviewStatus: 'open', createdAt: '2026-04-22T00:00:00Z', ...overrides }
     }
 
-    async function openEditMode() {
-      await waitFor(() => {
-        if (!document.body.textContent?.includes('edit kbd test')) throw new Error('not loaded')
-      })
-      const bodyDiv = Array.from(document.querySelectorAll<HTMLElement>('[data-fw] div'))
-        .find((el) => /cursor:\s*text/.test(el.getAttribute('style') ?? '') && el.textContent === 'edit kbd test')
-      if (!bodyDiv) throw new Error('body div not found')
-      fireEvent.click(bodyDiv)
-      return waitFor(() => {
-        const ta = document.querySelector<HTMLTextAreaElement>('[data-fw] textarea')
-        if (!ta) throw new Error('edit textarea not mounted')
-        return ta
-      })
+    function openEditMode() {
+      return openCardEditByBody('edit kbd test')
     }
 
     it('Cmd+Enter in edit textarea saves the edit (L1353 metaKey branch)', async () => {
@@ -2549,21 +2565,7 @@ describe('<FeedbackWidget />', () => {
       mockFetch(undefined, commentsResponse([seedComment()]))
       render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
 
-      await waitFor(() => {
-        if (!document.body.textContent?.includes('gap test')) throw new Error('comment not rendered')
-      })
-      const bodyDiv = Array.from(
-        document.querySelectorAll<HTMLDivElement>('[data-fw] div'),
-      ).find((el) =>
-        /cursor:\s*text/.test(el.getAttribute('style') ?? '') && el.textContent === 'gap test',
-      )
-      fireEvent.click(bodyDiv!)
-
-      const editArea = await waitFor(() => {
-        const ta = document.querySelector<HTMLTextAreaElement>('[data-fw] textarea')
-        if (!ta) throw new Error('edit textarea not mounted')
-        return ta
-      })
+      const editArea = await openCardEditByBody('gap test')
       fireEvent.change(editArea, { target: { value: '   ' } })
       const save = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-fw] button'))
         .find((b) => b.textContent === 'Save')
@@ -2582,21 +2584,7 @@ describe('<FeedbackWidget />', () => {
       ]))
       render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
 
-      await waitFor(() => {
-        if (!document.body.textContent?.includes('edit me')) throw new Error('seed not rendered')
-      })
-      const targetDiv = Array.from(
-        document.querySelectorAll<HTMLDivElement>('[data-fw] div'),
-      ).find((el) =>
-        /cursor:\s*text/.test(el.getAttribute('style') ?? '') && el.textContent === 'edit me',
-      )
-      fireEvent.click(targetDiv!)
-
-      const editArea = await waitFor(() => {
-        const ta = document.querySelector<HTMLTextAreaElement>('[data-fw] textarea')
-        if (!ta) throw new Error('edit textarea not mounted')
-        return ta
-      })
+      const editArea = await openCardEditByBody('edit me')
       fireEvent.change(editArea, { target: { value: 'edited' } })
       const save = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-fw] button'))
         .find((b) => b.textContent === 'Save')

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -111,6 +111,27 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
   const [draggedPos, setDraggedPos] = useState<{ x: number; y: number } | null>(null)
   const [pillHover, setPillHover] = useState(false)
   const dragging = useRef(false)
+  // Drag handle visually extends below the pill but sits outside its bounding
+  // box, so sliding the cursor onto it fires mouseleave on the wrapper and
+  // oscillates the expand/collapse animation. Small unhover delay absorbs it.
+  const pillLeaveTimer = useRef<number | null>(null)
+  const onPillEnter = useCallback(() => {
+    if (pillLeaveTimer.current) {
+      window.clearTimeout(pillLeaveTimer.current)
+      pillLeaveTimer.current = null
+    }
+    setPillHover(true)
+  }, [])
+  const onPillLeave = useCallback(() => {
+    if (pillLeaveTimer.current) window.clearTimeout(pillLeaveTimer.current)
+    pillLeaveTimer.current = window.setTimeout(() => {
+      pillLeaveTimer.current = null
+      setPillHover(false)
+    }, 120)
+  }, [])
+  useEffect(() => () => {
+    if (pillLeaveTimer.current) window.clearTimeout(pillLeaveTimer.current)
+  }, [])
 
   // Pins/popovers use position:fixed, so their viewport coords must be recomputed
   // on scroll (and on resize / body reflow, which shift the page-percent mapping).
@@ -141,7 +162,10 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
       })
     }
     window.addEventListener('resize', onResize)
-    window.addEventListener('scroll', bump, { passive: true })
+    // Capture phase + document target catches scroll on any nested scrollable
+    // container (dashboards with internal overflow:auto panels). Bubble-phase
+    // listeners on window miss those because scroll events don't bubble.
+    document.addEventListener('scroll', bump, { passive: true, capture: true })
 
     const ro = new ResizeObserver(bump)
     ro.observe(document.body)
@@ -149,7 +173,7 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
     return () => {
       cancelAnimationFrame(raf)
       window.removeEventListener('resize', onResize)
-      window.removeEventListener('scroll', bump)
+      document.removeEventListener('scroll', bump, { capture: true })
       ro.disconnect()
     }
   }, [])
@@ -614,8 +638,8 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
   }, [filteredComments])
   const commentCount = filteredComments.length
 
-  // Only sync on scroll when a viewport-anchored popover is open or commenting.
-  // Persisted pins/tooltip are absolute (page-anchored), so scroll moves them natively.
+  // Sync on scroll when anything position:fixed is visible — popovers, the
+  // commenting flow, or persisted pins. Gating keeps idle pages cheap.
   needsPositionSyncRef.current = selectedPin !== null || mode !== 'idle' || !!target || (pinsVisible && filteredComments.length > 0)
 
   const pathDisplay = (window.location.pathname || '/').slice(0, 28) || '/'
@@ -784,7 +808,7 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
               </div>
             )}
 
-            {/* Footer toolbar: avatar + emoji + cancel + send */}
+            {/* Footer toolbar: avatar + cancel + send */}
             <div style={{
               display: 'flex',
               alignItems: 'center',
@@ -812,29 +836,6 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
                     {avatarInitial}
                   </button>
                 )}
-                <button
-                  aria-label="Add emoji"
-                  style={{ width: 28, height: 28, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'none', border: 'none', cursor: 'pointer', borderRadius: 6, color: '#6B6560' }}
-                  onMouseEnter={(e) => (e.currentTarget.style.color = '#FFFFFF')}
-                  onMouseLeave={(e) => (e.currentTarget.style.color = '#6B6560')}
-                >
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                    <circle cx="12" cy="12" r="10" />
-                    <path d="M8 14s1.5 2 4 2 4-2 4-2" />
-                    <line x1="9" y1="9" x2="9.01" y2="9" />
-                    <line x1="15" y1="9" x2="15.01" y2="9" />
-                  </svg>
-                </button>
-                <button
-                  aria-label="React"
-                  style={{ width: 28, height: 28, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'none', border: 'none', cursor: 'pointer', borderRadius: 6, color: '#6B6560' }}
-                  onMouseEnter={(e) => (e.currentTarget.style.color = '#FFFFFF')}
-                  onMouseLeave={(e) => (e.currentTarget.style.color = '#6B6560')}
-                >
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-                  </svg>
-                </button>
               </div>
 
               <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
@@ -958,30 +959,49 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
               <PinMarker outline={isSelected} hovered={isHovered} number={pinNumber} resolved={isResolved} />
             </div>
 
-            {/* Hover tooltip — dark CRRT glass */}
-            {isHovered && (
+            {/* Hover tooltip — dark CRRT glass. Flips toward whichever side has
+                room so it never clips against the viewport edge. */}
+            {isHovered && (() => {
+              const TOOLTIP_W = 280
+              const TOOLTIP_H_EST = 140
+              const MARGIN = 8
+              const PIN_W = 28
+              const flipH = pinPos.left + TOOLTIP_W + MARGIN > window.innerWidth
+              const flipV = pinPos.top - 11 - TOOLTIP_H_EST < MARGIN
+              const wrapperLeft = flipH
+                ? Math.max(MARGIN, pinPos.left + PIN_W - TOOLTIP_W)
+                : pinPos.left
+              const wrapperTop = flipV ? pinPos.top + 25 : pinPos.top - 11
+              const wrapperTransform = flipV ? 'translateY(0)' : 'translateY(-100%)'
+              const tailRadius = flipV
+                ? (flipH ? '14px 0 14px 14px' : '0 14px 14px 14px')
+                : (flipH ? '14px 14px 0 14px' : '14px 14px 14px 0')
+              const tailOrigin = flipV
+                ? (flipH ? '100% 0%' : '0% 0%')
+                : (flipH ? '100% 100%' : '0% 100%')
+              return (
               <div
                 style={{
                   position: 'fixed',
-                  left: pinPos.left,
-                  top: pinPos.top - 11,
+                  left: wrapperLeft,
+                  top: wrapperTop,
                   zIndex: 2147483643,
                   pointerEvents: 'none',
-                  transform: 'translateY(-100%)',
+                  transform: wrapperTransform,
                 }}
               >
                 <div style={{
-                  width: 280,
+                  width: TOOLTIP_W,
                   background: 'rgba(18, 18, 18, 0.96)',
                   backdropFilter: 'blur(20px)',
                   WebkitBackdropFilter: 'blur(20px)',
-                  borderRadius: '14px 14px 14px 0',
+                  borderRadius: tailRadius,
                   padding: 14,
                   boxShadow: '0 12px 32px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3)',
                   border: '1px solid rgba(255, 255, 255, 0.08)',
                   fontFamily: "'Inter', -apple-system, BlinkMacSystemFont, sans-serif",
                   animation: 'fw-tooltip-liquid 0.5s cubic-bezier(0.16, 1, 0.3, 1) both',
-                  transformOrigin: '0% 100%',
+                  transformOrigin: tailOrigin,
                   display: 'flex',
                   alignItems: 'flex-start',
                   gap: 10,
@@ -1006,7 +1026,8 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
                   </div>
                 </div>
               </div>
-            )}
+              )
+            })()}
 
             {/* Pin detail popover */}
             {isSelected && (() => {
@@ -1430,12 +1451,10 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
                   ) : (
                     <>
                       <div
-                        onClick={(e) => { e.stopPropagation(); setEditingId(c.id); setEditText(c.body) }}
                         style={{
                           fontSize: 13.5,
                           lineHeight: 1.5,
                           color: isResolved ? '#6B6560' : '#E8E5DF',
-                          cursor: 'text',
                           marginLeft: 32,
                           wordBreak: 'break-word',
                         }}
@@ -1459,26 +1478,6 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
                           }}
                         />
                       )}
-                      {/* Reply link (visual only — affordance, no thread logic yet) */}
-                      <button
-                        onClick={(e) => e.stopPropagation()}
-                        style={{
-                          marginTop: 8,
-                          marginLeft: 32,
-                          padding: 0,
-                          fontSize: 12,
-                          color: '#6B6560',
-                          background: 'transparent',
-                          border: 'none',
-                          cursor: 'pointer',
-                          fontFamily: 'inherit',
-                          transition: 'color 150ms ease',
-                        }}
-                        onMouseEnter={(e) => (e.currentTarget.style.color = '#FFFFFF')}
-                        onMouseLeave={(e) => (e.currentTarget.style.color = '#6B6560')}
-                      >
-                        Reply
-                      </button>
                     </>
                   )}
 
@@ -1597,8 +1596,8 @@ export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: F
         ref={pillRef}
         {...{ [WIDGET_ATTR]: '' }}
         onPointerDown={onPillPointerDown}
-        onMouseEnter={() => setPillHover(true)}
-        onMouseLeave={() => setPillHover(false)}
+        onMouseEnter={onPillEnter}
+        onMouseLeave={onPillLeave}
         style={{
           position: 'fixed',
           // draggedPos stores right/bottom offsets (see onMove handler). This


### PR DESCRIPTION
## Summary

Batches six widget UI issues reported by Tomas. All changes live in the embedded widget (`src/components/FeedbackWidget/index.tsx`) plus tests; sent together because they share the same component and benefit from a single review pass.

### Behaviour fixes

- **Pin hover tooltip clips at viewport edges.** Tooltip was hardcoded above-and-right of the pin with no edge detection. Added flip logic so it pivots to whichever quadrant has room, with a viewport clamp for the corner case. Tail corner + `transformOrigin` follow the chosen quadrant so the popover still "points" at the pin.
- **Pins follow the viewport on scroll instead of staying with their anchored element.** Scroll listener was on `window`, but scroll events don't bubble — host pages with internal `overflow:auto` containers (dashboards, embedded apps) never reached it, so `getElementFixedPos` was never recomputed. Switched to a capture-phase listener on `document` so any nested scroll triggers re-anchoring.
- **Launcher pill flickers / "flips" on hover.** The drag-handle dots are positioned `bottom: -12` outside the wrapper's bounding box, so sliding the cursor down onto them fires `mouseleave` on the wrapper and oscillates the expand/collapse animation. Added a 120 ms unhover debounce that absorbs the re-entries.

### Dead UI removed

- **Emoji + heart buttons** in the composer were visual-only with no handlers — removed. Reactions can come back as a real feature when scoped.
- **Sidebar Reply button** had no handler and no threading model behind it — removed. Replies will need parent_id, thread UI, and notifications; not in this PR's scope.
- **Click-body-to-edit on sidebar cards** was stealing the card's scroll-to-pin click (clicking the body text entered inline edit instead of navigating). The card already routes the click to `setSelectedPin + highlightElement` (smooth scroll + glow). Removed the body click handler so the card has a single click model: **card → navigate, ⋯ → act**. Edit remains in the 3-dot menu.

### Tests

- Failing tests updated to use the 3-dot menu → Edit path via a new `openCardEditByBody` helper.
- Tests for removed buttons (emoji/heart/reply) deleted.
- Three new tests exercise the tooltip flip branches (right-edge, top-edge, top-right corner).
- New test covers the pill hover-debounce (re-enter cancels pending leave).

Line + branch diff coverage vs trunk: **100%**.

## Test plan

- [ ] Drop a pin near the right edge of the page — hover preview should flip leftward and stay inside the viewport.
- [ ] Drop a pin near the top of the page — hover preview should drop below the pin.
- [ ] Scroll a host page with an internal scrollable container — pins should stay glued to the elements they were placed on, not follow the viewport.
- [ ] Hover the launcher near the gray ring / drag-handle dots — no flicker or "flip" should occur.
- [ ] Open the composer — emoji and heart icons should be gone; only the avatar + Cancel + Send remain.
- [ ] Open the sidebar — Reply links should be gone; clicking anywhere on a card scrolls to and highlights the pinned element; the 3-dot menu still has Edit/Delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)