### PR TITLE
Claim flow: create projects on claim + project-key availability

### DIFF
--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -12,12 +12,16 @@ import {
   ensurePublicProject,
   findUserIdByEmail,
   getProjectMember,
+  isProjectKeyAvailable,
   isProjectMember,
+  isValidProjectKey,
   listInvitesForEmail,
   listNotificationsForUser,
   listProjectsForUser,
   markAllNotificationsRead,
   markNotificationRead,
+  slugifyProjectKey,
+  suggestAvailableProjectKey,
 } from './store.js'
 
 type ProjectRow = {
@@ -179,6 +183,8 @@ type MembershipMocks = {
   projectsIn?: { data: ProjectRow[] | null; error: { message: string } | null }
   projectsUpdate?: { data: ProjectRow[] | null; error: { message: string } | null }
   projectsSingle?: { data: ProjectRow | null; error: { message: string } | null }
+  projectInsert?: { data: ProjectRow | null; error: { code?: string; message: string } | null }
+  repoInsert?: { error: { code?: string; message: string } | null }
 }
 
 function membershipSupabase(m: MembershipMocks = {}) {
@@ -209,6 +215,11 @@ function membershipSupabase(m: MembershipMocks = {}) {
           eq: vi.fn(() => ({
             eq: vi.fn(() => ({ select: vi.fn(() => Promise.resolve(m.projectsUpdate ?? { data: [], error: null })) })),
           })),
+        })),
+        // projects insert → .select().single(); repo-config insert → awaited directly
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({ single: vi.fn(() => Promise.resolve(m.projectInsert ?? { data: null, error: null })) })),
+          then: (r: (v: unknown) => unknown) => Promise.resolve(m.repoInsert ?? { error: null }).then(r),
         })),
       }
     }),
@@ -297,6 +308,106 @@ describe('membership helpers + claim', () => {
       projectsUpdate: { data: null, error: { message: 'db boom' } },
     }) as never)
     await expect(claimProject('u', 'pk')).rejects.toThrow('db boom')
+  })
+
+  it('claimProject create-and-claim: creates a new project when none exists and a name is given', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+      projectInsert: { data: PROJECT_ROW, error: null },
+    }) as never)
+    expect((await claimProject('u', 'pk', 'Acme')).publicKey).toBe('pk')
+  })
+
+  it('claimProject create-and-claim: maps insert 23505 to already_claimed, propagates other errors', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+      projectInsert: { data: null, error: { code: '23505', message: 'dup' } },
+    }) as never)
+    await expect(claimProject('u', 'pk', 'Acme')).rejects.toThrow('already_claimed')
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+      projectInsert: { data: null, error: { code: '50000', message: 'boom' } },
+    }) as never)
+    await expect(claimProject('u', 'pk', 'Acme')).rejects.toThrow('boom')
+  })
+
+  it('claimProject create-and-claim: surfaces repo-config errors but ignores 23505', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+      projectInsert: { data: PROJECT_ROW, error: null },
+      repoInsert: { error: { code: '50000', message: 'repo boom' } },
+    }) as never)
+    await expect(claimProject('u', 'pk', 'Acme')).rejects.toThrow('repo boom')
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+      projectInsert: { data: PROJECT_ROW, error: null },
+      repoInsert: { error: { code: '23505', message: 'dup' } },
+    }) as never)
+    expect((await claimProject('u', 'pk', 'Acme')).publicKey).toBe('pk')
+  })
+})
+
+describe('project key helpers', () => {
+  it('slugifyProjectKey lowercases, hyphenates, and trims edges', () => {
+    expect(slugifyProjectKey('Acme Marketing Site!')).toBe('acme-marketing-site')
+    expect(slugifyProjectKey('  --Hello-- ')).toBe('hello')
+  })
+
+  it('isValidProjectKey enforces charset, length, and hyphen rules', () => {
+    expect(isValidProjectKey('acme-site')).toBe(true)
+    expect(isValidProjectKey('a')).toBe(true)
+    expect(isValidProjectKey('')).toBe(false)
+    expect(isValidProjectKey('-acme')).toBe(false)
+    expect(isValidProjectKey('acme--site')).toBe(false)
+    expect(isValidProjectKey('Acme')).toBe(false)
+    expect(isValidProjectKey('a'.repeat(64))).toBe(false)
+  })
+
+  it('isProjectKeyAvailable reflects whether a row exists', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsSingle: { data: null, error: null },
+    }) as never)
+    expect(await isProjectKeyAvailable('free')).toBe(true)
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsSingle: { data: PROJECT_ROW, error: null },
+    }) as never)
+    expect(await isProjectKeyAvailable('taken')).toBe(false)
+  })
+
+  it('suggestAvailableProjectKey returns the base when free', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsSingle: { data: null, error: null },
+    }) as never)
+    expect(await suggestAvailableProjectKey('acme')).toBe('acme')
+  })
+
+  it('suggestAvailableProjectKey appends a suffix when the base is taken', async () => {
+    // base lookup hits a row → taken; first suffixed candidate lookup finds nothing → free
+    const single = vi.fn()
+      .mockResolvedValueOnce({ data: PROJECT_ROW, error: null })
+      .mockResolvedValue({ data: null, error: null })
+    vi.mocked(getSupabase).mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: single })) })),
+      })),
+    } as never)
+    const suggestion = await suggestAvailableProjectKey('acme')
+    expect(suggestion).toMatch(/^acme-[a-z0-9]{1,4}$/)
+  })
+
+  it('suggestAvailableProjectKey throws when no free key is found', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsSingle: { data: PROJECT_ROW, error: null },
+    }) as never)
+    await expect(suggestAvailableProjectKey('acme')).rejects.toThrow('no_available_key')
   })
 })
 

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -203,14 +203,22 @@ export async function isProjectMember(userId: string, projectKey: string): Promi
 }
 
 /**
- * Atomically take ownership of an unclaimed project. Conditional UPDATE
- * gates the race: only the first caller flips `claimable=false`, the rest
- * see zero rows and get `already_claimed`. Membership INSERT after the flip
- * is idempotent — a duplicate (23505) just means we already own it.
+ * Take ownership of a project. Two ways in:
+ *  - Existing unclaimed project (widget-made): a conditional UPDATE flips
+ *    `claimable=false`. Only the first caller wins the race; the rest see zero
+ *    rows and either `already_claimed` (row exists) or fall through to create.
+ *  - Brand-new project (dashboard create flow): when no row exists and a `name`
+ *    is supplied, create the project (claimable=false) + seed its repo config,
+ *    then add the caller as admin. A 23505 on insert means we lost the race.
+ *
+ * Without a `name`, a missing project is `not_found` (the paste-existing-key
+ * path). The membership INSERT is idempotent — a duplicate (23505) just means
+ * we already own it.
  */
 export async function claimProject(
   userId: string,
   projectKey: string,
+  name?: string,
 ): Promise<ReturnType<typeof mapProject>> {
   const supabase = getSupabase()
 
@@ -223,10 +231,15 @@ export async function claimProject(
 
   if (updateError) throw new Error(updateError.message)
 
+  let claimed: ReturnType<typeof mapProject>
+
   if (!updatedRows || updatedRows.length === 0) {
     const existing = await getProject(projectKey)
-    if (!existing) throw new Error('not_found')
-    throw new Error('already_claimed')
+    if (existing) throw new Error('already_claimed')
+    if (!name) throw new Error('not_found')
+    claimed = await createClaimedProject(projectKey, name)
+  } else {
+    claimed = mapProject(updatedRows[0] as ProjectRow)
   }
 
   const { error: memberError } = await supabase
@@ -237,7 +250,71 @@ export async function claimProject(
     throw new Error(memberError.message)
   }
 
-  return mapProject(updatedRows[0] as ProjectRow)
+  return claimed
+}
+
+/**
+ * Insert a dashboard-created project (slug mirrors the public key, as in
+ * `ensurePublicProject`) plus its default repo config. A 23505 on the project
+ * insert means a concurrent claim won the key — surface as `already_claimed`.
+ */
+async function createClaimedProject(projectKey: string, name: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('projects')
+    .insert([{
+      public_key: projectKey,
+      slug: projectKey,
+      name,
+      allowed_origins: [],
+      claimable: false,
+    }] as never)
+    .select('public_key, slug, name, created_at, updated_at')
+    .single()
+
+  if (error) {
+    if (error.code === '23505') throw new Error('already_claimed')
+    throw new Error(error.message)
+  }
+
+  const { error: repoError } = await supabase
+    .from('project_repo_configs')
+    .insert([{ project_key: projectKey, default_branch: 'main' }] as never)
+
+  if (repoError && repoError.code !== '23505') {
+    throw new Error(repoError.message)
+  }
+
+  return mapProject(data as ProjectRow)
+}
+
+/** Slugify a display name into a candidate project key (matches the dashboard's rule). */
+export function slugifyProjectKey(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+}
+
+/** A project key is 1–63 chars of lowercase alphanumerics and single internal hyphens. */
+export function isValidProjectKey(key: string): boolean {
+  return key.length >= 1 && key.length <= 63 && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(key)
+}
+
+/** True when no project row already owns this key (free to create). */
+export async function isProjectKeyAvailable(projectKey: string): Promise<boolean> {
+  return (await getProject(projectKey)) === null
+}
+
+/**
+ * Return `base` if free, else `base-<suffix>` with a short random suffix,
+ * probing until one is available. Throws `no_available_key` if it can't find
+ * a free key within a bounded number of attempts.
+ */
+export async function suggestAvailableProjectKey(base: string): Promise<string> {
+  if (await isProjectKeyAvailable(base)) return base
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const candidate = `${base}-${Math.random().toString(36).slice(2, 6)}`
+    if (await isProjectKeyAvailable(candidate)) return candidate
+  }
+  throw new Error('no_available_key')
 }
 
 export async function getProject(projectKey: string) {

--- a/api/v1/projects/availability.test.ts
+++ b/api/v1/projects/availability.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({
+  isValidProjectKey: vi.fn(),
+  suggestAvailableProjectKey: vi.fn(),
+}))
+
+import handler from './availability.js'
+import { requireUser } from '../../_lib/auth.js'
+import { isValidProjectKey, suggestAvailableProjectKey } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(isValidProjectKey).mockReset()
+  vi.mocked(suggestAvailableProjectKey).mockReset()
+})
+
+describe('api/v1/projects/availability', () => {
+  it('handles preflight OPTIONS and rejects non-GET', async () => {
+    let res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' })
+      return null
+    })
+    const res = mockRes()
+    await call({ method: 'GET', query: { key: 'acme' }, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('rejects an invalid (or missing) key with 400', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(isValidProjectKey).mockReturnValue(false)
+
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toMatchObject({ error: 'Invalid project key' })
+  })
+
+  it('reports availability=true when the suggestion equals the key', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(isValidProjectKey).mockReturnValue(true)
+    vi.mocked(suggestAvailableProjectKey).mockResolvedValue('acme')
+
+    const res = mockRes()
+    await call({ method: 'GET', query: { key: ' ACME ' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    // key is trimmed + lowercased before lookup
+    expect(suggestAvailableProjectKey).toHaveBeenCalledWith('acme')
+    expect(res.body).toEqual({ key: 'acme', available: true, suggestion: 'acme' })
+  })
+
+  it('reports availability=false with a suggested alternative', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(isValidProjectKey).mockReturnValue(true)
+    vi.mocked(suggestAvailableProjectKey).mockResolvedValue('acme-x7k2')
+
+    const res = mockRes()
+    await call({ method: 'GET', query: { key: 'acme' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ key: 'acme', available: false, suggestion: 'acme-x7k2' })
+  })
+
+  it('returns 500 when suggestion lookup throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(isValidProjectKey).mockReturnValue(true)
+    vi.mocked(suggestAvailableProjectKey).mockRejectedValue(new Error('db down'))
+
+    const res = mockRes()
+    await call({ method: 'GET', query: { key: 'acme' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+})

--- a/api/v1/projects/availability.ts
+++ b/api/v1/projects/availability.ts
@@ -1,0 +1,23 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+import { isValidProjectKey, suggestAvailableProjectKey } from '../../_lib/store.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const key = (getStringQuery(req.query.key) ?? '').trim().toLowerCase()
+  if (!isValidProjectKey(key)) return jsonError(req, res, 400, 'Invalid project key')
+
+  try {
+    const suggestion = await suggestAvailableProjectKey(key)
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json({ key, available: suggestion === key, suggestion })
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/projects/claim.test.ts
+++ b/api/v1/projects/claim.test.ts
@@ -74,7 +74,20 @@ describe('api/v1/projects/claim', () => {
     res = mockRes()
     await call({ method: 'POST', body: { projectKey: 'k' }, query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(200)
-    expect(claimProject).toHaveBeenCalledWith('u', 'k')
+    expect(claimProject).toHaveBeenCalledWith('u', 'k', undefined)
+
+    // name is trimmed and forwarded for the create-and-claim path
+    vi.mocked(claimProject).mockResolvedValueOnce({ publicKey: 'k' } as never)
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'k', name: '  Acme  ' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(claimProject).toHaveBeenLastCalledWith('u', 'k', 'Acme')
+
+    // over-long name → 400 before claimProject runs
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'k', name: 'x'.repeat(81) }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toMatchObject({ error: 'Project name too long' })
 
     vi.mocked(claimProject).mockRejectedValueOnce(new Error('not_found'))
     res = mockRes()

--- a/api/v1/projects/claim.ts
+++ b/api/v1/projects/claim.ts
@@ -9,12 +9,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const user = await requireUser(req, res)
   if (!user) return
 
-  const body = (req.body ?? {}) as { projectKey?: unknown }
+  const body = (req.body ?? {}) as { projectKey?: unknown; name?: unknown }
   const projectKey = typeof body.projectKey === 'string' ? body.projectKey.trim() : ''
   if (!projectKey) return jsonError(req, res, 400, 'Missing projectKey')
+  const rawName = typeof body.name === 'string' ? body.name.trim() : ''
+  if (rawName.length > 80) return jsonError(req, res, 400, 'Project name too long')
+  const name = rawName || undefined
 
   try {
-    const project = await claimProject(user.userId, projectKey)
+    const project = await claimProject(user.userId, projectKey, name)
     setCors(req, res, ['POST', 'OPTIONS'])
     return res.status(200).json(project)
   } catch (error) {


### PR DESCRIPTION
- Extend the project claim endpoint to create a brand-new project — and make the caller its admin — when the key doesn't exist yet and a name is supplied, while keeping the existing path for claiming a project the widget already made.
- Add an availability endpoint that says whether a project key is free and suggests an open alternative (the slug plus a short suffix) when it's taken.
- Add helpers to turn a display name into a candidate key, validate key format, and check whether a key is available.
- Cover the new create-and-claim path, the availability endpoint, and the helpers with tests.