### PR TITLE
Dashboard: name-to-key project creation with live availability

### DIFF
--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -12,12 +12,16 @@ import {
   ensurePublicProject,
   findUserIdByEmail,
   getProjectMember,
+  isProjectKeyAvailable,
   isProjectMember,
+  isValidProjectKey,
   listInvitesForEmail,
   listNotificationsForUser,
   listProjectsForUser,
   markAllNotificationsRead,
   markNotificationRead,
+  slugifyProjectKey,
+  suggestAvailableProjectKey,
 } from './store.js'
 
 type ProjectRow = {
@@ -179,6 +183,8 @@ type MembershipMocks = {
   projectsIn?: { data: ProjectRow[] | null; error: { message: string } | null }
   projectsUpdate?: { data: ProjectRow[] | null; error: { message: string } | null }
   projectsSingle?: { data: ProjectRow | null; error: { message: string } | null }
+  projectInsert?: { data: ProjectRow | null; error: { code?: string; message: string } | null }
+  repoInsert?: { error: { code?: string; message: string } | null }
 }
 
 function membershipSupabase(m: MembershipMocks = {}) {
@@ -209,6 +215,11 @@ function membershipSupabase(m: MembershipMocks = {}) {
           eq: vi.fn(() => ({
             eq: vi.fn(() => ({ select: vi.fn(() => Promise.resolve(m.projectsUpdate ?? { data: [], error: null })) })),
           })),
+        })),
+        // projects insert → .select().single(); repo-config insert → awaited directly
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({ single: vi.fn(() => Promise.resolve(m.projectInsert ?? { data: null, error: null })) })),
+          then: (r: (v: unknown) => unknown) => Promise.resolve(m.repoInsert ?? { error: null }).then(r),
         })),
       }
     }),
@@ -297,6 +308,106 @@ describe('membership helpers + claim', () => {
       projectsUpdate: { data: null, error: { message: 'db boom' } },
     }) as never)
     await expect(claimProject('u', 'pk')).rejects.toThrow('db boom')
+  })
+
+  it('claimProject create-and-claim: creates a new project when none exists and a name is given', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+      projectInsert: { data: PROJECT_ROW, error: null },
+    }) as never)
+    expect((await claimProject('u', 'pk', 'Acme')).publicKey).toBe('pk')
+  })
+
+  it('claimProject create-and-claim: maps insert 23505 to already_claimed, propagates other errors', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+      projectInsert: { data: null, error: { code: '23505', message: 'dup' } },
+    }) as never)
+    await expect(claimProject('u', 'pk', 'Acme')).rejects.toThrow('already_claimed')
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+      projectInsert: { data: null, error: { code: '50000', message: 'boom' } },
+    }) as never)
+    await expect(claimProject('u', 'pk', 'Acme')).rejects.toThrow('boom')
+  })
+
+  it('claimProject create-and-claim: surfaces repo-config errors but ignores 23505', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+      projectInsert: { data: PROJECT_ROW, error: null },
+      repoInsert: { error: { code: '50000', message: 'repo boom' } },
+    }) as never)
+    await expect(claimProject('u', 'pk', 'Acme')).rejects.toThrow('repo boom')
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsUpdate: { data: [], error: null },
+      projectsSingle: { data: null, error: null },
+      projectInsert: { data: PROJECT_ROW, error: null },
+      repoInsert: { error: { code: '23505', message: 'dup' } },
+    }) as never)
+    expect((await claimProject('u', 'pk', 'Acme')).publicKey).toBe('pk')
+  })
+})
+
+describe('project key helpers', () => {
+  it('slugifyProjectKey lowercases, hyphenates, and trims edges', () => {
+    expect(slugifyProjectKey('Acme Marketing Site!')).toBe('acme-marketing-site')
+    expect(slugifyProjectKey('  --Hello-- ')).toBe('hello')
+  })
+
+  it('isValidProjectKey enforces charset, length, and hyphen rules', () => {
+    expect(isValidProjectKey('acme-site')).toBe(true)
+    expect(isValidProjectKey('a')).toBe(true)
+    expect(isValidProjectKey('')).toBe(false)
+    expect(isValidProjectKey('-acme')).toBe(false)
+    expect(isValidProjectKey('acme--site')).toBe(false)
+    expect(isValidProjectKey('Acme')).toBe(false)
+    expect(isValidProjectKey('a'.repeat(64))).toBe(false)
+  })
+
+  it('isProjectKeyAvailable reflects whether a row exists', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsSingle: { data: null, error: null },
+    }) as never)
+    expect(await isProjectKeyAvailable('free')).toBe(true)
+
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsSingle: { data: PROJECT_ROW, error: null },
+    }) as never)
+    expect(await isProjectKeyAvailable('taken')).toBe(false)
+  })
+
+  it('suggestAvailableProjectKey returns the base when free', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsSingle: { data: null, error: null },
+    }) as never)
+    expect(await suggestAvailableProjectKey('acme')).toBe('acme')
+  })
+
+  it('suggestAvailableProjectKey appends a suffix when the base is taken', async () => {
+    // base lookup hits a row → taken; first suffixed candidate lookup finds nothing → free
+    const single = vi.fn()
+      .mockResolvedValueOnce({ data: PROJECT_ROW, error: null })
+      .mockResolvedValue({ data: null, error: null })
+    vi.mocked(getSupabase).mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: single })) })),
+      })),
+    } as never)
+    const suggestion = await suggestAvailableProjectKey('acme')
+    expect(suggestion).toMatch(/^acme-[a-z0-9]{1,4}$/)
+  })
+
+  it('suggestAvailableProjectKey throws when no free key is found', async () => {
+    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+      projectsSingle: { data: PROJECT_ROW, error: null },
+    }) as never)
+    await expect(suggestAvailableProjectKey('acme')).rejects.toThrow('no_available_key')
   })
 })
 

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -203,14 +203,22 @@ export async function isProjectMember(userId: string, projectKey: string): Promi
 }
 
 /**
- * Atomically take ownership of an unclaimed project. Conditional UPDATE
- * gates the race: only the first caller flips `claimable=false`, the rest
- * see zero rows and get `already_claimed`. Membership INSERT after the flip
- * is idempotent — a duplicate (23505) just means we already own it.
+ * Take ownership of a project. Two ways in:
+ *  - Existing unclaimed project (widget-made): a conditional UPDATE flips
+ *    `claimable=false`. Only the first caller wins the race; the rest see zero
+ *    rows and either `already_claimed` (row exists) or fall through to create.
+ *  - Brand-new project (dashboard create flow): when no row exists and a `name`
+ *    is supplied, create the project (claimable=false) + seed its repo config,
+ *    then add the caller as admin. A 23505 on insert means we lost the race.
+ *
+ * Without a `name`, a missing project is `not_found` (the paste-existing-key
+ * path). The membership INSERT is idempotent — a duplicate (23505) just means
+ * we already own it.
  */
 export async function claimProject(
   userId: string,
   projectKey: string,
+  name?: string,
 ): Promise<ReturnType<typeof mapProject>> {
   const supabase = getSupabase()
 
@@ -223,10 +231,15 @@ export async function claimProject(
 
   if (updateError) throw new Error(updateError.message)
 
+  let claimed: ReturnType<typeof mapProject>
+
   if (!updatedRows || updatedRows.length === 0) {
     const existing = await getProject(projectKey)
-    if (!existing) throw new Error('not_found')
-    throw new Error('already_claimed')
+    if (existing) throw new Error('already_claimed')
+    if (!name) throw new Error('not_found')
+    claimed = await createClaimedProject(projectKey, name)
+  } else {
+    claimed = mapProject(updatedRows[0] as ProjectRow)
   }
 
   const { error: memberError } = await supabase
@@ -237,7 +250,71 @@ export async function claimProject(
     throw new Error(memberError.message)
   }
 
-  return mapProject(updatedRows[0] as ProjectRow)
+  return claimed
+}
+
+/**
+ * Insert a dashboard-created project (slug mirrors the public key, as in
+ * `ensurePublicProject`) plus its default repo config. A 23505 on the project
+ * insert means a concurrent claim won the key — surface as `already_claimed`.
+ */
+async function createClaimedProject(projectKey: string, name: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('projects')
+    .insert([{
+      public_key: projectKey,
+      slug: projectKey,
+      name,
+      allowed_origins: [],
+      claimable: false,
+    }] as never)
+    .select('public_key, slug, name, created_at, updated_at')
+    .single()
+
+  if (error) {
+    if (error.code === '23505') throw new Error('already_claimed')
+    throw new Error(error.message)
+  }
+
+  const { error: repoError } = await supabase
+    .from('project_repo_configs')
+    .insert([{ project_key: projectKey, default_branch: 'main' }] as never)
+
+  if (repoError && repoError.code !== '23505') {
+    throw new Error(repoError.message)
+  }
+
+  return mapProject(data as ProjectRow)
+}
+
+/** Slugify a display name into a candidate project key (matches the dashboard's rule). */
+export function slugifyProjectKey(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+}
+
+/** A project key is 1–63 chars of lowercase alphanumerics and single internal hyphens. */
+export function isValidProjectKey(key: string): boolean {
+  return key.length >= 1 && key.length <= 63 && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(key)
+}
+
+/** True when no project row already owns this key (free to create). */
+export async function isProjectKeyAvailable(projectKey: string): Promise<boolean> {
+  return (await getProject(projectKey)) === null
+}
+
+/**
+ * Return `base` if free, else `base-<suffix>` with a short random suffix,
+ * probing until one is available. Throws `no_available_key` if it can't find
+ * a free key within a bounded number of attempts.
+ */
+export async function suggestAvailableProjectKey(base: string): Promise<string> {
+  if (await isProjectKeyAvailable(base)) return base
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const candidate = `${base}-${Math.random().toString(36).slice(2, 6)}`
+    if (await isProjectKeyAvailable(candidate)) return candidate
+  }
+  throw new Error('no_available_key')
 }
 
 export async function getProject(projectKey: string) {

--- a/api/v1/projects/availability.test.ts
+++ b/api/v1/projects/availability.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({
+  isValidProjectKey: vi.fn(),
+  suggestAvailableProjectKey: vi.fn(),
+}))
+
+import handler from './availability.js'
+import { requireUser } from '../../_lib/auth.js'
+import { isValidProjectKey, suggestAvailableProjectKey } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(isValidProjectKey).mockReset()
+  vi.mocked(suggestAvailableProjectKey).mockReset()
+})
+
+describe('api/v1/projects/availability', () => {
+  it('handles preflight OPTIONS and rejects non-GET', async () => {
+    let res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' })
+      return null
+    })
+    const res = mockRes()
+    await call({ method: 'GET', query: { key: 'acme' }, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('rejects an invalid (or missing) key with 400', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(isValidProjectKey).mockReturnValue(false)
+
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toMatchObject({ error: 'Invalid project key' })
+  })
+
+  it('reports availability=true when the suggestion equals the key', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(isValidProjectKey).mockReturnValue(true)
+    vi.mocked(suggestAvailableProjectKey).mockResolvedValue('acme')
+
+    const res = mockRes()
+    await call({ method: 'GET', query: { key: ' ACME ' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    // key is trimmed + lowercased before lookup
+    expect(suggestAvailableProjectKey).toHaveBeenCalledWith('acme')
+    expect(res.body).toEqual({ key: 'acme', available: true, suggestion: 'acme' })
+  })
+
+  it('reports availability=false with a suggested alternative', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(isValidProjectKey).mockReturnValue(true)
+    vi.mocked(suggestAvailableProjectKey).mockResolvedValue('acme-x7k2')
+
+    const res = mockRes()
+    await call({ method: 'GET', query: { key: 'acme' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ key: 'acme', available: false, suggestion: 'acme-x7k2' })
+  })
+
+  it('returns 500 when suggestion lookup throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(isValidProjectKey).mockReturnValue(true)
+    vi.mocked(suggestAvailableProjectKey).mockRejectedValue(new Error('db down'))
+
+    const res = mockRes()
+    await call({ method: 'GET', query: { key: 'acme' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ error: 'Internal server error' })
+  })
+})

--- a/api/v1/projects/availability.ts
+++ b/api/v1/projects/availability.ts
@@ -1,0 +1,23 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../_lib/auth.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+import { isValidProjectKey, suggestAvailableProjectKey } from '../../_lib/store.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  const key = (getStringQuery(req.query.key) ?? '').trim().toLowerCase()
+  if (!isValidProjectKey(key)) return jsonError(req, res, 400, 'Invalid project key')
+
+  try {
+    const suggestion = await suggestAvailableProjectKey(key)
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json({ key, available: suggestion === key, suggestion })
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/projects/claim.test.ts
+++ b/api/v1/projects/claim.test.ts
@@ -74,7 +74,20 @@ describe('api/v1/projects/claim', () => {
     res = mockRes()
     await call({ method: 'POST', body: { projectKey: 'k' }, query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(200)
-    expect(claimProject).toHaveBeenCalledWith('u', 'k')
+    expect(claimProject).toHaveBeenCalledWith('u', 'k', undefined)
+
+    // name is trimmed and forwarded for the create-and-claim path
+    vi.mocked(claimProject).mockResolvedValueOnce({ publicKey: 'k' } as never)
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'k', name: '  Acme  ' }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(claimProject).toHaveBeenLastCalledWith('u', 'k', 'Acme')
+
+    // over-long name → 400 before claimProject runs
+    res = mockRes()
+    await call({ method: 'POST', body: { projectKey: 'k', name: 'x'.repeat(81) }, query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toMatchObject({ error: 'Project name too long' })
 
     vi.mocked(claimProject).mockRejectedValueOnce(new Error('not_found'))
     res = mockRes()

--- a/api/v1/projects/claim.ts
+++ b/api/v1/projects/claim.ts
@@ -9,12 +9,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const user = await requireUser(req, res)
   if (!user) return
 
-  const body = (req.body ?? {}) as { projectKey?: unknown }
+  const body = (req.body ?? {}) as { projectKey?: unknown; name?: unknown }
   const projectKey = typeof body.projectKey === 'string' ? body.projectKey.trim() : ''
   if (!projectKey) return jsonError(req, res, 400, 'Missing projectKey')
+  const rawName = typeof body.name === 'string' ? body.name.trim() : ''
+  if (rawName.length > 80) return jsonError(req, res, 400, 'Project name too long')
+  const name = rawName || undefined
 
   try {
-    const project = await claimProject(user.userId, projectKey)
+    const project = await claimProject(user.userId, projectKey, name)
     setCors(req, res, ['POST', 'OPTIONS'])
     return res.status(200).json(project)
   } catch (error) {

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -83,7 +83,7 @@ export function App() {
 // Admin-side invite send: POST /api/v1/projects/:projectKey/invites
 // { email, role } (admin role required).
 function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: string; user: import('@supabase/supabase-js').User; onSignOut: () => void }) {
-  const { projects, loading: projectsLoading, error: projectsError, createProject } = useProjects(API_BASE, accessToken)
+  const { projects, loading: projectsLoading, error: projectsError, claimProject, checkAvailability } = useProjects(API_BASE, accessToken)
   const [selectedProject, setSelectedProject] = useState<string>('')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const [selectedCommentId, setSelectedCommentId] = useState<string>('')
@@ -324,15 +324,11 @@ function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: strin
     }
   }, [agentSession, copyPrompt, selectedAgentMeta])
 
-  // TODO(ui-claim-flow): swap this create flow for a claim flow. Prompt the
-  // user for a projectKey (paste from widget install snippet) and call
-  // POST /v1/projects/claim. New projects now come into being via the widget
-  // hitting public endpoints (ensurePublicProject); the dashboard only claims.
-  const handleAddProject = useCallback(async (name: string) => {
+  const handleAddProject = useCallback(async (projectKey: string, name: string) => {
     setAddProjectError(null)
     setAddProjectBusy(true)
     try {
-      const project = await createProject(name)
+      const project = await claimProject(projectKey, name)
       setSelectedProject(project.publicKey)
       setStatusFilter('all')
       setSelectedCommentId('')
@@ -342,7 +338,7 @@ function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: strin
     } finally {
       setAddProjectBusy(false)
     }
-  }, [createProject])
+  }, [claimProject])
 
   // Onboarding gate: show the welcome screen when this account has no
   // projects and hasn't been onboarded before. Once they click the CTA we
@@ -365,6 +361,7 @@ function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: strin
           <AddProjectPopover
             onAdd={handleAddProject}
             onClose={() => setAddProjectOpen(false)}
+            checkAvailability={checkAvailability}
             busy={addProjectBusy}
             error={addProjectError}
           />
@@ -388,6 +385,7 @@ function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: strin
         addProjectOpen={addProjectOpen}
         setAddProjectOpen={setAddProjectOpen}
         onAddProject={handleAddProject}
+        onCheckAvailability={checkAvailability}
         addProjectBusy={addProjectBusy}
         addProjectError={addProjectError}
         onOpenCmd={() => setCmdOpen(true)}

--- a/apps/dashboard/api.ts
+++ b/apps/dashboard/api.ts
@@ -126,21 +126,35 @@ export function listProjects(apiBase: string, accessToken: string) {
   })
 }
 
-// TODO(ui-claim-flow): the POST /v1/projects endpoint has been removed.
-// Replace this with a claim flow that calls POST /v1/projects/claim with a
-// projectKey the user enters (or pastes from the widget install). New projects
-// now materialize via the widget's ensurePublicProject path on first comment;
-// the dashboard's role is to claim ownership of an unclaimed (claimable=true)
-// project. Until this is rewired, the dashboard's "Create new project" button
-// will 405.
-export function createProject(apiBase: string, accessToken: string, name: string) {
-  return requestJson<Project>(`${apiBase}/v1/projects`, {
+export interface ProjectKeyAvailability {
+  key: string
+  available: boolean
+  suggestion: string
+}
+
+// Check whether a candidate project key is free, and get a suggested
+// alternative (slug + short suffix) when it isn't.
+export function checkProjectKeyAvailability(apiBase: string, accessToken: string, key: string) {
+  return requestJson<ProjectKeyAvailability>(
+    `${apiBase}/v1/projects/availability?key=${encodeURIComponent(key)}`,
+    {
+      headers: {
+        ...authHeaders(accessToken),
+      },
+    },
+  )
+}
+
+// Claim a project key as the current user, creating the project with the given
+// name if it doesn't exist yet. Replaces the removed POST /v1/projects.
+export function claimProject(apiBase: string, accessToken: string, projectKey: string, name: string) {
+  return requestJson<Project>(`${apiBase}/v1/projects/claim`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       ...authHeaders(accessToken),
     },
-    body: JSON.stringify({ name }),
+    body: JSON.stringify({ projectKey, name }),
   })
 }
 

--- a/apps/dashboard/components/AddProjectPopover.tsx
+++ b/apps/dashboard/components/AddProjectPopover.tsx
@@ -1,16 +1,28 @@
 import { useEffect, useRef, useState } from 'react'
-import { cn } from '../lib/utils'
+import type { ProjectKeyAvailability } from '../api'
+import { cn, isValidProjectKey, slugify } from '../lib/utils'
+import { CheckIcon, XIcon } from './icons'
+import { Spinner } from './primitives'
 
 interface AddProjectPopoverProps {
-  onAdd: (name: string) => void
+  onAdd: (projectKey: string, name: string) => void
   onClose: () => void
+  checkAvailability: (key: string) => Promise<ProjectKeyAvailability>
   busy?: boolean
   error?: string | null
 }
 
-export function AddProjectPopover({ onAdd, onClose, busy, error }: AddProjectPopoverProps) {
+type KeyStatus = 'idle' | 'invalid' | 'checking' | 'available' | 'taken'
+
+export function AddProjectPopover({ onAdd, onClose, checkAvailability, busy, error }: AddProjectPopoverProps) {
   const [name, setName] = useState('')
+  const [key, setKey] = useState('')
+  const [keyEdited, setKeyEdited] = useState(false)
+  const [status, setStatus] = useState<KeyStatus>('idle')
+  const [suggestion, setSuggestion] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
+  // Tracks the latest key we kicked off a check for, so stale responses are ignored.
+  const latestKey = useRef('')
 
   useEffect(() => {
     requestAnimationFrame(() => inputRef.current?.focus())
@@ -22,7 +34,43 @@ export function AddProjectPopover({ onAdd, onClose, busy, error }: AddProjectPop
     return () => document.removeEventListener('keydown', handleKey)
   }, [onClose])
 
-  const canSubmit = !!name.trim() && !busy
+  // Until the user edits the key by hand, keep it in sync with the name.
+  useEffect(() => {
+    if (!keyEdited) setKey(slugify(name))
+  }, [name, keyEdited])
+
+  // Debounced availability check whenever the key changes.
+  useEffect(() => {
+    if (!key) {
+      setStatus('idle')
+      return
+    }
+    if (!isValidProjectKey(key)) {
+      setStatus('invalid')
+      return
+    }
+    setStatus('checking')
+    latestKey.current = key
+    const timer = setTimeout(async () => {
+      try {
+        const result = await checkAvailability(key)
+        if (latestKey.current !== key) return
+        setSuggestion(result.suggestion)
+        setStatus(result.available ? 'available' : 'taken')
+      } catch {
+        if (latestKey.current !== key) return
+        setStatus('idle')
+      }
+    }, 400)
+    return () => clearTimeout(timer)
+  }, [key, checkAvailability])
+
+  const canSubmit = !!name.trim() && status === 'available' && !busy
+
+  function applySuggestion() {
+    setKeyEdited(true)
+    setKey(suggestion)
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex justify-center pt-[18vh] px-4" role="dialog" aria-modal="true" aria-labelledby="add-project-title">
@@ -38,14 +86,14 @@ export function AddProjectPopover({ onAdd, onClose, busy, error }: AddProjectPop
             Create a project
           </h2>
           <p className="mt-1 text-[12px] text-muted-foreground leading-relaxed">
-            Name your product or app. We'll give you a public key after you save — paste the snippet into the host app to start collecting feedback.
+            Name your product or app — we'll suggest a public key from the name. Paste the snippet with that key into the host app to start collecting feedback.
           </p>
         </div>
 
         <form
           onSubmit={(e) => {
             e.preventDefault()
-            if (canSubmit) onAdd(name.trim())
+            if (canSubmit) onAdd(key, name.trim())
           }}
           className="px-5 pb-5"
         >
@@ -61,6 +109,44 @@ export function AddProjectPopover({ onAdd, onClose, busy, error }: AddProjectPop
             autoComplete="off"
             spellCheck={false}
           />
+
+          <label htmlFor="project-key" className="block mt-3 mb-1 text-[11px] font-medium text-muted-foreground">
+            Public key
+          </label>
+          <div className="relative">
+            <input
+              id="project-key"
+              type="text"
+              value={key}
+              onChange={(e) => { setKeyEdited(true); setKey(e.target.value) }}
+              placeholder="acme-marketing-site"
+              disabled={busy}
+              aria-label="Project public key"
+              className="w-full pl-3 pr-9 py-2.5 rounded-md border border-border bg-background text-sm font-mono text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-colors disabled:opacity-50"
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center" aria-hidden="true">
+              {status === 'checking' && <Spinner size={14} strokeWidth={3} />}
+              {status === 'available' && <span className="text-status-accepted flex"><CheckIcon size={15} /></span>}
+              {(status === 'taken' || status === 'invalid') && <span className="text-status-rejected flex"><XIcon size={15} /></span>}
+            </span>
+          </div>
+
+          <div className="mt-1.5 min-h-[16px] text-[11px]" aria-live="polite">
+            {status === 'invalid' && (
+              <span className="text-status-rejected">Use lowercase letters, numbers, and single hyphens.</span>
+            )}
+            {status === 'taken' && (
+              <span className="text-status-rejected">
+                Taken — try{' '}
+                <button type="button" onClick={applySuggestion} className="font-mono underline hover:text-foreground">
+                  {suggestion}
+                </button>
+              </span>
+            )}
+          </div>
+
           {error && (
             <p className="mt-2 text-[11px] text-status-rejected" role="alert" aria-live="polite">
               {error}

--- a/apps/dashboard/components/Header.tsx
+++ b/apps/dashboard/components/Header.tsx
@@ -1,6 +1,6 @@
 import type { User } from '@supabase/supabase-js'
 import { cn } from '../lib/utils'
-import type { Project } from '../api'
+import type { Project, ProjectKeyAvailability } from '../api'
 import type { StatusFilter } from '../lib/types'
 import { MoonIcon, PlusIcon, SearchIcon, SunIcon } from './icons'
 import { Spinner } from './primitives'
@@ -19,7 +19,8 @@ interface HeaderProps {
   setSelectedCommentId: (id: string) => void
   addProjectOpen: boolean
   setAddProjectOpen: (open: boolean | ((v: boolean) => boolean)) => void
-  onAddProject: (name: string) => void
+  onAddProject: (projectKey: string, name: string) => void
+  onCheckAvailability: (key: string) => Promise<ProjectKeyAvailability>
   addProjectBusy: boolean
   addProjectError: string | null
   onOpenCmd: () => void
@@ -42,6 +43,7 @@ export function Header({
   addProjectOpen,
   setAddProjectOpen,
   onAddProject,
+  onCheckAvailability,
   addProjectBusy,
   addProjectError,
   onOpenCmd,
@@ -130,6 +132,7 @@ export function Header({
           <AddProjectPopover
             onAdd={onAddProject}
             onClose={() => setAddProjectOpen(false)}
+            checkAvailability={onCheckAvailability}
             busy={addProjectBusy}
             error={addProjectError}
           />

--- a/apps/dashboard/hooks/useProjects.ts
+++ b/apps/dashboard/hooks/useProjects.ts
@@ -1,13 +1,21 @@
 import { useCallback, useEffect, useState } from 'react'
-import { createProject as apiCreateProject, listProjects, type Project } from '../api'
+import {
+  checkProjectKeyAvailability as apiCheckAvailability,
+  claimProject as apiClaimProject,
+  listProjects,
+  type Project,
+  type ProjectKeyAvailability,
+} from '../api'
 import { getMockProjects, mocksEnabled } from '../lib/mocks'
+import { slugify } from '../lib/utils'
 
 export interface UseProjectsResult {
   projects: Project[]
   loading: boolean
   error: string | null
   refresh: () => Promise<void>
-  createProject: (name: string) => Promise<Project>
+  claimProject: (projectKey: string, name: string) => Promise<Project>
+  checkAvailability: (key: string) => Promise<ProjectKeyAvailability>
 }
 
 export function useProjects(apiBase: string, accessToken: string): UseProjectsResult {
@@ -37,12 +45,18 @@ export function useProjects(apiBase: string, accessToken: string): UseProjectsRe
     refresh()
   }, [refresh])
 
-  const createProject = useCallback(async (name: string) => {
+  const checkAvailability = useCallback(async (key: string): Promise<ProjectKeyAvailability> => {
     if (mocksEnabled) {
-      const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+      return { key, available: true, suggestion: key }
+    }
+    return apiCheckAvailability(apiBase, accessToken, key)
+  }, [apiBase, accessToken])
+
+  const claimProject = useCallback(async (projectKey: string, name: string) => {
+    if (mocksEnabled) {
       const project: Project = {
-        publicKey: `proj_${slug || 'untitled'}`,
-        slug: slug || 'untitled',
+        publicKey: projectKey,
+        slug: slugify(name) || projectKey,
         name,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
@@ -50,10 +64,10 @@ export function useProjects(apiBase: string, accessToken: string): UseProjectsRe
       setProjects((prev) => [...prev, project])
       return project
     }
-    const project = await apiCreateProject(apiBase, accessToken, name)
+    const project = await apiClaimProject(apiBase, accessToken, projectKey, name)
     setProjects((prev) => [...prev, project])
     return project
   }, [apiBase, accessToken])
 
-  return { projects, loading, error, refresh, createProject }
+  return { projects, loading, error, refresh, claimProject, checkAvailability }
 }

--- a/apps/dashboard/lib/utils.ts
+++ b/apps/dashboard/lib/utils.ts
@@ -4,3 +4,17 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Turn a display name into a candidate project key. Mirrors the server's
+ * `slugifyProjectKey` so the suggested key matches what the API will accept.
+ */
+export function slugify(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+}
+
+/** Client mirror of the server's `isValidProjectKey`: 1–63 chars, lowercase
+ * alphanumerics, single internal hyphens. */
+export function isValidProjectKey(key: string): boolean {
+  return key.length >= 1 && key.length <= 63 && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(key)
+}


### PR DESCRIPTION
- Rework the create-project dialog so you name the project and get an auto-derived, editable public key.
- Check the key's availability as you type, with an inline spinner that resolves to a green tick or red cross and a one-click suggested alternative when the key is taken.
- Claim the chosen key on submit — creating the project under that name — instead of calling the removed create endpoint.
- Thread the availability check through the header and welcome-screen entry points.

> Stacked on #120 — review/merge that first; this PR's base will retarget to trunk once it lands.