### PR TITLE
Project settings API: rename, members, and invite management

### DIFF
--- a/api/_lib/store.settings.test.ts
+++ b/api/_lib/store.settings.test.ts
@@ -40,6 +40,13 @@ function supabaseWith(tableResults: Record<string, Result[]>) {
   }
 }
 
+// `removeProjectMember` delegates to the `remove_project_member` DB function,
+// so its stub mocks `.rpc` (resolving to the function's text result) rather than
+// the `from` query chain the other helpers use.
+function supabaseRpc(result: Result) {
+  return { rpc: vi.fn(() => Promise.resolve(result)) }
+}
+
 beforeEach(() => {
   vi.mocked(getSupabase).mockReset()
 })
@@ -102,61 +109,23 @@ describe('listProjectMembers', () => {
 
 describe('removeProjectMember', () => {
   it('returns false when the member is not in the project', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
-      project_members: [{ data: [{ user_id: 'other', role: 'admin' }], error: null }],
-    }) as never)
-    expect(await removeProjectMember('p', 'gone')).toBe(false)
-  })
-
-  it('returns false when the table yields no rows', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
-      project_members: [{ data: null, error: null }],
-    }) as never)
+    vi.mocked(getSupabase).mockReturnValue(supabaseRpc({ data: 'not_found', error: null }) as never)
     expect(await removeProjectMember('p', 'gone')).toBe(false)
   })
 
   it('refuses to remove the last admin', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
-      project_members: [{ data: [{ user_id: 'a', role: 'admin' }, { user_id: 'b', role: 'member' }], error: null }],
-    }) as never)
+    vi.mocked(getSupabase).mockReturnValue(supabaseRpc({ data: 'last_admin', error: null }) as never)
     await expect(removeProjectMember('p', 'a')).rejects.toThrow('last_admin')
   })
 
-  it('removes a member when another admin remains', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
-      project_members: [
-        { data: [{ user_id: 'a', role: 'admin' }, { user_id: 'b', role: 'admin' }], error: null },
-        { data: null, error: null },
-      ],
-    }) as never)
+  it('removes a member when the guard passes', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseRpc({ data: 'removed', error: null }) as never)
     expect(await removeProjectMember('p', 'a')).toBe(true)
   })
 
-  it('removes a non-admin member', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
-      project_members: [
-        { data: [{ user_id: 'a', role: 'admin' }, { user_id: 'b', role: 'member' }], error: null },
-        { data: null, error: null },
-      ],
-    }) as never)
-    expect(await removeProjectMember('p', 'b')).toBe(true)
-  })
-
-  it('throws when the lookup query errors', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
-      project_members: [{ data: null, error: { message: 'boom' } }],
-    }) as never)
+  it('throws when the rpc errors', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseRpc({ data: null, error: { message: 'boom' } }) as never)
     await expect(removeProjectMember('p', 'a')).rejects.toThrow('boom')
-  })
-
-  it('throws when the delete query errors', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
-      project_members: [
-        { data: [{ user_id: 'a', role: 'admin' }, { user_id: 'b', role: 'admin' }], error: null },
-        { data: null, error: { message: 'del boom' } },
-      ],
-    }) as never)
-    await expect(removeProjectMember('p', 'a')).rejects.toThrow('del boom')
   })
 })
 

--- a/api/_lib/store.settings.test.ts
+++ b/api/_lib/store.settings.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./supabase.js', () => ({ getSupabase: vi.fn(), getServiceSupabase: vi.fn() }))
+
+import { getSupabase } from './supabase.js'
+import {
+  deleteProjectInvite,
+  getUserEmailsByIds,
+  listProjectInvites,
+  listProjectMembers,
+  removeProjectMember,
+  updateProjectName,
+} from './store.js'
+
+type Result = { data: unknown; error: { code?: string; message: string } | null }
+
+// A chainable Supabase stub: every builder method returns the same object, and
+// awaiting it (or calling .single/.maybeSingle) resolves to `result`.
+function chain(result: Result) {
+  const p: Record<string, unknown> = {}
+  const self = () => p
+  for (const m of ['select', 'update', 'delete', 'insert', 'eq', 'order', 'is', 'in']) p[m] = self
+  p.maybeSingle = () => Promise.resolve(result)
+  p.single = () => Promise.resolve(result)
+  p.then = (resolve: (v: Result) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject)
+  return p
+}
+
+// `from(table)` returns the next queued result for that table, each wrapped in
+// a fresh chain — so a function that queries the same table twice gets two.
+function supabaseWith(tableResults: Record<string, Result[]>) {
+  const queues: Record<string, Result[]> = {}
+  for (const [k, v] of Object.entries(tableResults)) queues[k] = [...v]
+  return {
+    from: vi.fn((table: string) => {
+      const q = queues[table]
+      return chain(q && q.length ? (q.shift() as Result) : { data: null, error: null })
+    }),
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(getSupabase).mockReset()
+})
+
+describe('updateProjectName', () => {
+  it('returns the renamed project', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      projects: [{ data: [{ public_key: 'p', slug: 'p', name: 'New', created_at: 't', updated_at: 't' }], error: null }],
+    }) as never)
+    const out = await updateProjectName('p', 'New')
+    expect(out).toMatchObject({ publicKey: 'p', name: 'New' })
+  })
+
+  it('returns null when no row matched', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      projects: [{ data: [], error: null }],
+    }) as never)
+    expect(await updateProjectName('missing', 'New')).toBeNull()
+  })
+
+  it('throws on db error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      projects: [{ data: null, error: { message: 'boom' } }],
+    }) as never)
+    await expect(updateProjectName('p', 'New')).rejects.toThrow('boom')
+  })
+})
+
+describe('listProjectMembers', () => {
+  const origKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  afterEach(() => {
+    if (origKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = origKey
+  })
+
+  it('maps rows with null emails when no service key is configured', async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_members: [{ data: [{ user_id: 'u1', role: 'admin', created_at: 't' }], error: null }],
+    }) as never)
+    const out = await listProjectMembers('p')
+    expect(out).toEqual([{ userId: 'u1', email: null, role: 'admin', createdAt: 't' }])
+  })
+
+  it('returns an empty roster when the table yields no rows', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_members: [{ data: null, error: null }],
+    }) as never)
+    expect(await listProjectMembers('p')).toEqual([])
+  })
+
+  it('throws on db error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_members: [{ data: null, error: { message: 'boom' } }],
+    }) as never)
+    await expect(listProjectMembers('p')).rejects.toThrow('boom')
+  })
+})
+
+describe('removeProjectMember', () => {
+  it('returns false when the member is not in the project', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_members: [{ data: [{ user_id: 'other', role: 'admin' }], error: null }],
+    }) as never)
+    expect(await removeProjectMember('p', 'gone')).toBe(false)
+  })
+
+  it('returns false when the table yields no rows', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_members: [{ data: null, error: null }],
+    }) as never)
+    expect(await removeProjectMember('p', 'gone')).toBe(false)
+  })
+
+  it('refuses to remove the last admin', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_members: [{ data: [{ user_id: 'a', role: 'admin' }, { user_id: 'b', role: 'member' }], error: null }],
+    }) as never)
+    await expect(removeProjectMember('p', 'a')).rejects.toThrow('last_admin')
+  })
+
+  it('removes a member when another admin remains', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_members: [
+        { data: [{ user_id: 'a', role: 'admin' }, { user_id: 'b', role: 'admin' }], error: null },
+        { data: null, error: null },
+      ],
+    }) as never)
+    expect(await removeProjectMember('p', 'a')).toBe(true)
+  })
+
+  it('removes a non-admin member', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_members: [
+        { data: [{ user_id: 'a', role: 'admin' }, { user_id: 'b', role: 'member' }], error: null },
+        { data: null, error: null },
+      ],
+    }) as never)
+    expect(await removeProjectMember('p', 'b')).toBe(true)
+  })
+
+  it('throws when the lookup query errors', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_members: [{ data: null, error: { message: 'boom' } }],
+    }) as never)
+    await expect(removeProjectMember('p', 'a')).rejects.toThrow('boom')
+  })
+
+  it('throws when the delete query errors', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_members: [
+        { data: [{ user_id: 'a', role: 'admin' }, { user_id: 'b', role: 'admin' }], error: null },
+        { data: null, error: { message: 'del boom' } },
+      ],
+    }) as never)
+    await expect(removeProjectMember('p', 'a')).rejects.toThrow('del boom')
+  })
+})
+
+describe('getUserEmailsByIds', () => {
+  const origFetch = globalThis.fetch
+  const origUrl = process.env.SUPABASE_URL
+  const origKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  beforeEach(() => {
+    process.env.SUPABASE_URL = 'https://supa.example'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc-key'
+  })
+
+  afterEach(() => {
+    globalThis.fetch = origFetch
+    process.env.SUPABASE_URL = origUrl
+    process.env.SUPABASE_SERVICE_ROLE_KEY = origKey
+  })
+
+  it('returns an empty map for no ids', async () => {
+    expect(await getUserEmailsByIds([])).toEqual({})
+  })
+
+  it('returns an empty map when service config is missing', async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    expect(await getUserEmailsByIds(['u1'])).toEqual({})
+  })
+
+  it('resolves emails, dedupes ids, and skips failures', async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (url.endsWith('/ok')) {
+        return new Response(JSON.stringify({ email: 'a@b.c' }), {
+          status: 200, headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url.endsWith('/noemail')) {
+        return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      if (url.endsWith('/boom')) throw new Error('net')
+      return new Response('nope', { status: 500 }) // /bad
+    }) as never
+    const out = await getUserEmailsByIds(['ok', 'ok', 'bad', 'noemail', 'boom'])
+    expect(out).toEqual({ ok: 'a@b.c' })
+  })
+})
+
+describe('listProjectInvites', () => {
+  it('returns mapped invites', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_invites: [{ data: [{ project_key: 'p', email: 'x@y.z', role: 'member', invited_by: 'u', created_at: 't' }], error: null }],
+    }) as never)
+    const out = await listProjectInvites('p')
+    expect(out).toEqual([{ projectKey: 'p', email: 'x@y.z', role: 'member', invitedBy: 'u', createdAt: 't' }])
+  })
+
+  it('returns an empty list when the table yields no rows', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_invites: [{ data: null, error: null }],
+    }) as never)
+    expect(await listProjectInvites('p')).toEqual([])
+  })
+
+  it('throws on db error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_invites: [{ data: null, error: { message: 'boom' } }],
+    }) as never)
+    await expect(listProjectInvites('p')).rejects.toThrow('boom')
+  })
+})
+
+describe('deleteProjectInvite', () => {
+  it('returns true when a row was deleted', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_invites: [{ data: [{ email: 'x@y.z' }], error: null }],
+    }) as never)
+    expect(await deleteProjectInvite('p', 'X@Y.Z')).toBe(true)
+  })
+
+  it('returns false when nothing matched', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_invites: [{ data: [], error: null }],
+    }) as never)
+    expect(await deleteProjectInvite('p', 'x@y.z')).toBe(false)
+  })
+
+  it('throws on db error', async () => {
+    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+      project_invites: [{ data: null, error: { message: 'boom' } }],
+    }) as never)
+    await expect(deleteProjectInvite('p', 'x@y.z')).rejects.toThrow('boom')
+  })
+})

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -236,29 +236,22 @@ export async function listProjectMembers(projectKey: string) {
  * Remove a member from a project. Refuses to remove the last remaining admin
  * (`last_admin`) so a project can never be orphaned. Returns false when the
  * member wasn't in the project so callers can map that to a 404.
+ *
+ * The count + delete run inside the `remove_project_member` DB function (see
+ * migration 0003) which locks the project's admin rows before counting — doing
+ * it here in two queries would race, letting concurrent admin removals both pass
+ * the guard and orphan the project.
  */
 export async function removeProjectMember(projectKey: string, userId: string): Promise<boolean> {
   const supabase = getSupabase()
-  const { data: members, error } = await supabase
-    .from('project_members')
-    .select('user_id, role')
-    .eq('project_key', projectKey)
+  const { data, error } = await supabase.rpc('remove_project_member', {
+    p_project_key: projectKey,
+    p_user_id: userId,
+  })
 
   if (error) throw new Error(error.message)
-  const rows = (members || []) as Array<{ user_id: string; role: 'admin' | 'member' }>
-  const target = rows.find((r) => r.user_id === userId)
-  if (!target) return false
-  if (target.role === 'admin' && rows.filter((r) => r.role === 'admin').length <= 1) {
-    throw new Error('last_admin')
-  }
-
-  const { error: deleteError } = await supabase
-    .from('project_members')
-    .delete()
-    .eq('project_key', projectKey)
-    .eq('user_id', userId)
-  if (deleteError) throw new Error(deleteError.message)
-  return true
+  if (data === 'last_admin') throw new Error('last_admin')
+  return data === 'removed'
 }
 
 /**

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -202,6 +202,96 @@ export async function isProjectMember(userId: string, projectKey: string): Promi
   return (await getProjectMember(userId, projectKey)) !== null
 }
 
+type ProjectMemberDetailRow = {
+  user_id: string
+  role: 'admin' | 'member'
+  created_at: string
+}
+
+/**
+ * List a project's members with their emails resolved. The membership table
+ * only stores user ids; emails come from the auth admin API (see
+ * `getUserEmailsByIds`), and degrade to null when the service key is absent.
+ */
+export async function listProjectMembers(projectKey: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_members')
+    .select('user_id, role, created_at')
+    .eq('project_key', projectKey)
+    .order('created_at', { ascending: true })
+
+  if (error) throw new Error(error.message)
+  const rows = (data || []) as ProjectMemberDetailRow[]
+  const emails = await getUserEmailsByIds(rows.map((r) => r.user_id))
+  return rows.map((r) => ({
+    userId: r.user_id,
+    email: emails[r.user_id] ?? null,
+    role: r.role,
+    createdAt: r.created_at,
+  }))
+}
+
+/**
+ * Remove a member from a project. Refuses to remove the last remaining admin
+ * (`last_admin`) so a project can never be orphaned. Returns false when the
+ * member wasn't in the project so callers can map that to a 404.
+ */
+export async function removeProjectMember(projectKey: string, userId: string): Promise<boolean> {
+  const supabase = getSupabase()
+  const { data: members, error } = await supabase
+    .from('project_members')
+    .select('user_id, role')
+    .eq('project_key', projectKey)
+
+  if (error) throw new Error(error.message)
+  const rows = (members || []) as Array<{ user_id: string; role: 'admin' | 'member' }>
+  const target = rows.find((r) => r.user_id === userId)
+  if (!target) return false
+  if (target.role === 'admin' && rows.filter((r) => r.role === 'admin').length <= 1) {
+    throw new Error('last_admin')
+  }
+
+  const { error: deleteError } = await supabase
+    .from('project_members')
+    .delete()
+    .eq('project_key', projectKey)
+    .eq('user_id', userId)
+  if (deleteError) throw new Error(deleteError.message)
+  return true
+}
+
+/**
+ * Resolve auth.users ids to emails via the service-role admin API. Mirrors
+ * `findUserIdByEmail`'s graceful fallback: returns an empty map (all emails
+ * null at the call site) when the service key / URL is missing or a lookup
+ * fails, rather than throwing.
+ */
+export async function getUserEmailsByIds(ids: string[]): Promise<Record<string, string | null>> {
+  const result: Record<string, string | null> = {}
+  const unique = Array.from(new Set(ids))
+  if (unique.length === 0) return result
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const url = process.env.SUPABASE_URL
+  if (!serviceKey || !url) return result
+
+  await Promise.all(
+    unique.map(async (id) => {
+      try {
+        const res = await fetch(`${url}/auth/v1/admin/users/${encodeURIComponent(id)}`, {
+          headers: { apikey: serviceKey, Authorization: `Bearer ${serviceKey}` },
+        })
+        if (!res.ok) return
+        const body = (await res.json()) as { email?: string }
+        if (body.email) result[id] = body.email
+      } catch {
+        /* leave unresolved; surfaces as null email */
+      }
+    }),
+  )
+  return result
+}
+
 /**
  * Take ownership of a project. Two ways in:
  *  - Existing unclaimed project (widget-made): a conditional UPDATE flips
@@ -327,6 +417,24 @@ export async function getProject(projectKey: string) {
 
   if (error) throw new Error(error.message)
   return data ? mapProject(data as ProjectRow) : null
+}
+
+/**
+ * Rename a project (display name only — public_key and slug are immutable).
+ * Returns the updated project, or null when no project matched the key so the
+ * caller can map that to a 404.
+ */
+export async function updateProjectName(projectKey: string, name: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('projects')
+    .update({ name, updated_at: new Date().toISOString() })
+    .eq('public_key', projectKey)
+    .select('public_key, slug, name, created_at, updated_at')
+
+  if (error) throw new Error(error.message)
+  if (!data || data.length === 0) return null
+  return mapProject(data[0] as ProjectRow)
 }
 
 export async function ensurePublicProject(publicKey: string) {
@@ -983,6 +1091,33 @@ export async function listInvitesForEmail(email: string) {
     .order('created_at', { ascending: false })
   if (error) throw new Error(error.message)
   return (data || []).map((row) => mapInvite(row as InviteRow))
+}
+
+export async function listProjectInvites(projectKey: string) {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .select('project_key, email, role, invited_by, created_at')
+    .eq('project_key', projectKey)
+    .order('created_at', { ascending: false })
+  if (error) throw new Error(error.message)
+  return (data || []).map((row) => mapInvite(row as InviteRow))
+}
+
+/**
+ * Cancel a pending invite. Returns false when no invite matched so the caller
+ * can map that to a 404.
+ */
+export async function deleteProjectInvite(projectKey: string, email: string): Promise<boolean> {
+  const supabase = getSupabase()
+  const { data, error } = await supabase
+    .from('project_invites')
+    .delete()
+    .eq('project_key', projectKey)
+    .eq('email', email.toLowerCase().trim())
+    .select('email')
+  if (error) throw new Error(error.message)
+  return Array.isArray(data) && data.length > 0
 }
 
 async function getInvite(email: string, projectKey: string) {

--- a/api/v1/projects/[projectId]/index.test.ts
+++ b/api/v1/projects/[projectId]/index.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({
+  getProjectMember: vi.fn(),
+  updateProjectName: vi.fn(),
+}))
+
+import handler from './index.js'
+import { requireUser } from '../../../_lib/auth.js'
+import { getProjectMember, updateProjectName } from '../../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(getProjectMember).mockReset()
+  vi.mocked(updateProjectName).mockReset()
+})
+
+describe('api/v1/projects/[projectId] PATCH (rename)', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('rejects non-PATCH + unauthenticated', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: 'x' }, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('validates projectKey + name', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    // missing projectKey
+    let res = mockRes()
+    await call({ method: 'PATCH', query: {}, body: { name: 'x' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // missing/blank name (also covers non-string body.name + absent body)
+    res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: '   ' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // too long
+    res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: 'a'.repeat(81) }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('enforces admin role', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    vi.mocked(getProjectMember).mockResolvedValueOnce(null)
+    let res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: 'New' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'member' })
+    res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: 'New' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('renames, 404s a missing project, and 500s on error', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
+
+    // success
+    vi.mocked(updateProjectName).mockResolvedValueOnce({ publicKey: 'p', name: 'New' } as never)
+    let res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: '  New  ' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(updateProjectName).toHaveBeenCalledWith('p', 'New')
+    expect(res.body).toMatchObject({ name: 'New' })
+
+    // not found
+    vi.mocked(updateProjectName).mockResolvedValueOnce(null)
+    res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: 'New' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    // error
+    vi.mocked(updateProjectName).mockRejectedValueOnce(new Error('db down'))
+    res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: 'New' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/projects/[projectId]/index.ts
+++ b/api/v1/projects/[projectId]/index.ts
@@ -1,0 +1,35 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../../_lib/auth.js'
+import { getProjectMember, updateProjectName } from '../../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['PATCH', 'OPTIONS'])) return
+  if (req.method !== 'PATCH') return methodNotAllowed(req, res, ['PATCH', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  // `projectId` is the project public_key (see sibling invites.ts note).
+  const projectKey = getStringQuery(req.query.projectId)
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectId')
+
+  const body = (req.body ?? {}) as { name?: unknown }
+  const name = typeof body.name === 'string' ? body.name.trim() : ''
+  if (!name) return jsonError(req, res, 400, 'Project name is required')
+  if (name.length > 80) return jsonError(req, res, 400, 'Project name must be 80 characters or fewer')
+
+  try {
+    const membership = await getProjectMember(user.userId, projectKey)
+    if (!membership) return jsonError(req, res, 403, 'Forbidden')
+    if (membership.role !== 'admin') return jsonError(req, res, 403, 'Admin role required')
+
+    const project = await updateProjectName(projectKey, name)
+    if (!project) return jsonError(req, res, 404, 'Project not found')
+
+    setCors(req, res, ['PATCH', 'OPTIONS'])
+    return res.status(200).json(project)
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/projects/[projectId]/invites.test.ts
+++ b/api/v1/projects/[projectId]/invites.test.ts
@@ -4,13 +4,22 @@ vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
 vi.mock('../../../_lib/store.js', () => ({
   createInvite: vi.fn(),
   createNotification: vi.fn(),
+  deleteProjectInvite: vi.fn(),
   findUserIdByEmail: vi.fn(),
   getProjectMember: vi.fn(),
+  listProjectInvites: vi.fn(),
 }))
 
 import handler from './invites.js'
 import { requireUser } from '../../../_lib/auth.js'
-import { createInvite, createNotification, findUserIdByEmail, getProjectMember } from '../../../_lib/store.js'
+import {
+  createInvite,
+  createNotification,
+  deleteProjectInvite,
+  findUserIdByEmail,
+  getProjectMember,
+  listProjectInvites,
+} from '../../../_lib/store.js'
 
 function mockRes() {
   return {
@@ -32,6 +41,8 @@ beforeEach(() => {
   vi.mocked(createInvite).mockReset()
   vi.mocked(findUserIdByEmail).mockReset()
   vi.mocked(createNotification).mockReset()
+  vi.mocked(listProjectInvites).mockReset()
+  vi.mocked(deleteProjectInvite).mockReset()
 })
 
 describe('api/v1/projects/[projectId]/invites', () => {
@@ -41,67 +52,102 @@ describe('api/v1/projects/[projectId]/invites', () => {
     expect(res.statusCode).toBe(204)
   })
 
-  it('tolerates absent body / non-string email', async () => {
-    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
-
-    // no body at all → 400 Invalid email (req.body ?? {} path)
+  it('rejects unsupported methods + unauthenticated + missing projectKey', async () => {
+    // unsupported method
     let res = mockRes()
-    await call({ method: 'POST', query: { projectId: 'p' }, headers: {} }, res)
-    expect(res.statusCode).toBe(400)
-
-    // non-string email → 400
-    res = mockRes()
-    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 123 }, headers: {} }, res)
-    expect(res.statusCode).toBe(400)
-  })
-
-  it('rejects non-POST + unauthenticated', async () => {
-    let res = mockRes()
-    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    await call({ method: 'PUT', query: { projectId: 'p' }, headers: {} }, res)
     expect(res.statusCode).toBe(405)
 
+    // unauthenticated
     vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
       r.status(401).json({ error: 'Unauthorized' }); return null
     })
     res = mockRes()
     await call({ method: 'POST', query: { projectId: 'p' }, body: {}, headers: {} }, res)
     expect(res.statusCode).toBe(401)
-  })
-
-  it('validates projectKey + email + admin role + already_invited + happy path', async () => {
-    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
 
     // missing projectKey
-    let res = mockRes()
-    await call({ method: 'POST', query: {}, body: { email: 'x@y.z' }, headers: {} }, res)
-    expect(res.statusCode).toBe(400)
-
-    // bad email
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
     res = mockRes()
-    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'nope' }, headers: {} }, res)
+    await call({ method: 'GET', query: {}, headers: {} }, res)
     expect(res.statusCode).toBe(400)
+  })
+
+  it('enforces admin membership for every method', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
 
     // non-member
     vi.mocked(getProjectMember).mockResolvedValueOnce(null)
-    res = mockRes()
-    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    let res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
     expect(res.statusCode).toBe(403)
 
     // member but not admin
     vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'member' })
     res = mockRes()
-    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
     expect(res.statusCode).toBe(403)
+  })
+
+  it('GET lists pending invites', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
+    vi.mocked(listProjectInvites).mockResolvedValueOnce([{ email: 'x@y.z' }] as never)
+    const res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual([{ email: 'x@y.z' }])
+  })
+
+  it('DELETE cancels an invite (missing email, not found, success)', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
+
+    // missing email
+    let res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // not found
+    vi.mocked(deleteProjectInvite).mockResolvedValueOnce(false)
+    res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p', email: 'X@Y.Z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    // success (email normalized)
+    vi.mocked(deleteProjectInvite).mockResolvedValueOnce(true)
+    res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p', email: 'X@Y.Z' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(deleteProjectInvite).toHaveBeenCalledWith('p', 'x@y.z')
+  })
+
+  it('POST validates email + already_invited + happy paths + errors', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
+
+    // no body → invalid email
+    let res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // non-string email → invalid
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 123 }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    // bad email string
+    res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'nope' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
 
     // already_invited
-    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
     vi.mocked(createInvite).mockRejectedValueOnce(new Error('already_invited'))
     res = mockRes()
     await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
     expect(res.statusCode).toBe(409)
 
     // happy path: invitee exists → notification fired
-    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
     vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
     vi.mocked(findUserIdByEmail).mockResolvedValueOnce('invitee-1')
     res = mockRes()
@@ -112,7 +158,6 @@ describe('api/v1/projects/[projectId]/invites', () => {
     }))
 
     // happy path: invitee has no account → notification skipped
-    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
     vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
     vi.mocked(findUserIdByEmail).mockResolvedValueOnce(null)
     vi.mocked(createNotification).mockClear()
@@ -123,7 +168,6 @@ describe('api/v1/projects/[projectId]/invites', () => {
 
     // notif emit fails → invite still returns 201 (fanout is fire-and-forget)
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
     vi.mocked(createInvite).mockResolvedValueOnce({ projectKey: 'p', email: 'x@y.z' } as never)
     vi.mocked(findUserIdByEmail).mockResolvedValueOnce('invitee-1')
     vi.mocked(createNotification).mockRejectedValueOnce(new Error('notif down'))
@@ -134,14 +178,12 @@ describe('api/v1/projects/[projectId]/invites', () => {
     warnSpy.mockRestore()
 
     // generic 500
-    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
     vi.mocked(createInvite).mockRejectedValueOnce(new Error('db down'))
     res = mockRes()
     await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)
     expect(res.statusCode).toBe(500)
 
     // non-Error throw → 500
-    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
     vi.mocked(createInvite).mockImplementationOnce(() => { throw 'string-not-error' })
     res = mockRes()
     await call({ method: 'POST', query: { projectId: 'p' }, body: { email: 'x@y.z' }, headers: {} }, res)

--- a/api/v1/projects/[projectId]/invites.ts
+++ b/api/v1/projects/[projectId]/invites.ts
@@ -3,14 +3,20 @@ import { requireUser } from '../../../_lib/auth.js'
 import {
   createInvite,
   createNotification,
+  deleteProjectInvite,
   findUserIdByEmail,
   getProjectMember,
+  listProjectInvites,
 } from '../../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
 
+const METHODS = ['GET', 'POST', 'DELETE', 'OPTIONS']
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  if (handleOptions(req, res, ['POST', 'OPTIONS'])) return
-  if (req.method !== 'POST') return methodNotAllowed(req, res, ['POST', 'OPTIONS'])
+  if (handleOptions(req, res, METHODS)) return
+  if (req.method !== 'GET' && req.method !== 'POST' && req.method !== 'DELETE') {
+    return methodNotAllowed(req, res, METHODS)
+  }
   const user = await requireUser(req, res)
   if (!user) return
 
@@ -20,17 +26,33 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const projectKey = getStringQuery(req.query.projectId)
   if (!projectKey) return jsonError(req, res, 400, 'Missing projectId')
 
-  const body = (req.body ?? {}) as { email?: unknown; role?: unknown }
-  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
-  const role = body.role === 'admin' ? 'admin' : 'member'
-  if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
-    return jsonError(req, res, 400, 'Invalid email')
-  }
-
   try {
     const membership = await getProjectMember(user.userId, projectKey)
     if (!membership) return jsonError(req, res, 403, 'Forbidden')
     if (membership.role !== 'admin') return jsonError(req, res, 403, 'Admin role required')
+
+    if (req.method === 'GET') {
+      const invites = await listProjectInvites(projectKey)
+      setCors(req, res, METHODS)
+      return res.status(200).json(invites)
+    }
+
+    if (req.method === 'DELETE') {
+      const email = (getStringQuery(req.query.email) ?? '').trim().toLowerCase()
+      if (!email) return jsonError(req, res, 400, 'Missing email')
+      const cancelled = await deleteProjectInvite(projectKey, email)
+      if (!cancelled) return jsonError(req, res, 404, 'Invite not found')
+      setCors(req, res, METHODS)
+      return res.status(200).json({ projectKey, email })
+    }
+
+    // POST: send an invite.
+    const body = (req.body ?? {}) as { email?: unknown; role?: unknown }
+    const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
+    const role = body.role === 'admin' ? 'admin' : 'member'
+    if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+      return jsonError(req, res, 400, 'Invalid email')
+    }
 
     const invite = await createInvite({ projectKey, email, role, invitedBy: user.userId })
 
@@ -50,7 +72,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       console.warn('invite.received notif failed:', notifError)
     }
 
-    setCors(req, res, ['POST', 'OPTIONS'])
+    setCors(req, res, METHODS)
     return res.status(201).json(invite)
   } catch (error) {
     const msg = error instanceof Error ? error.message : undefined

--- a/api/v1/projects/[projectId]/members.test.ts
+++ b/api/v1/projects/[projectId]/members.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({
+  getProjectMember: vi.fn(),
+  listProjectMembers: vi.fn(),
+}))
+
+import handler from './members.js'
+import { requireUser } from '../../../_lib/auth.js'
+import { getProjectMember, listProjectMembers } from '../../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(getProjectMember).mockReset()
+  vi.mocked(listProjectMembers).mockReset()
+})
+
+describe('api/v1/projects/[projectId]/members GET', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('rejects non-GET + unauthenticated + missing projectKey', async () => {
+    let res = mockRes()
+    await call({ method: 'POST', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('requires membership, returns the roster, and 500s on error', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    // non-member
+    vi.mocked(getProjectMember).mockResolvedValueOnce(null)
+    let res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    // member → roster
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'member' })
+    vi.mocked(listProjectMembers).mockResolvedValueOnce([{ userId: 'u', email: 'a@b.c', role: 'admin' }] as never)
+    res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual([{ userId: 'u', email: 'a@b.c', role: 'admin' }])
+
+    // error
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    vi.mocked(listProjectMembers).mockRejectedValueOnce(new Error('db down'))
+    res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/projects/[projectId]/members.ts
+++ b/api/v1/projects/[projectId]/members.ts
@@ -1,0 +1,28 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../../_lib/auth.js'
+import { getProjectMember, listProjectMembers } from '../../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  // `projectId` is the project public_key (see sibling invites.ts note).
+  const projectKey = getStringQuery(req.query.projectId)
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectId')
+
+  try {
+    // Any member may view the roster; mutations elsewhere stay admin-only.
+    const membership = await getProjectMember(user.userId, projectKey)
+    if (!membership) return jsonError(req, res, 403, 'Forbidden')
+
+    const members = await listProjectMembers(projectKey)
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json(members)
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/projects/[projectId]/members/[userId].test.ts
+++ b/api/v1/projects/[projectId]/members/[userId].test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
+vi.mock('../../../../_lib/store.js', () => ({
+  getProjectMember: vi.fn(),
+  removeProjectMember: vi.fn(),
+}))
+
+import handler from './[userId].js'
+import { requireUser } from '../../../../_lib/auth.js'
+import { getProjectMember, removeProjectMember } from '../../../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(getProjectMember).mockReset()
+  vi.mocked(removeProjectMember).mockReset()
+})
+
+describe('api/v1/projects/[projectId]/members/[userId] DELETE', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: { projectId: 'p', userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('rejects non-DELETE + unauthenticated', async () => {
+    let res = mockRes()
+    await call({ method: 'GET', query: { projectId: 'p', userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    vi.mocked(requireUser).mockImplementationOnce(async (_q, r) => {
+      r.status(401).json({ error: 'Unauthorized' }); return null
+    })
+    res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p', userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('validates projectKey + userId', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    let res = mockRes()
+    await call({ method: 'DELETE', query: { userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('enforces admin role', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    vi.mocked(getProjectMember).mockResolvedValueOnce(null)
+    let res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p', userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'member' })
+    res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p', userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('removes a member, 404s a missing one, 409s the last admin, 500s on error', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
+
+    // success
+    vi.mocked(removeProjectMember).mockResolvedValueOnce(true)
+    let res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p', userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(removeProjectMember).toHaveBeenCalledWith('p', 'm')
+    expect(res.body).toMatchObject({ projectKey: 'p', userId: 'm' })
+
+    // not found
+    vi.mocked(removeProjectMember).mockResolvedValueOnce(false)
+    res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p', userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(404)
+
+    // last admin
+    vi.mocked(removeProjectMember).mockRejectedValueOnce(new Error('last_admin'))
+    res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p', userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(409)
+
+    // generic error
+    vi.mocked(removeProjectMember).mockRejectedValueOnce(new Error('db down'))
+    res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p', userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+
+    // non-Error throw → 500 (msg stays undefined)
+    vi.mocked(removeProjectMember).mockImplementationOnce(() => { throw 'string-not-error' })
+    res = mockRes()
+    await call({ method: 'DELETE', query: { projectId: 'p', userId: 'm' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/projects/[projectId]/members/[userId].ts
+++ b/api/v1/projects/[projectId]/members/[userId].ts
@@ -1,0 +1,34 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireUser } from '../../../../_lib/auth.js'
+import { getProjectMember, removeProjectMember } from '../../../../_lib/store.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../../_lib/http.js'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['DELETE', 'OPTIONS'])) return
+  if (req.method !== 'DELETE') return methodNotAllowed(req, res, ['DELETE', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  // `projectId` is the project public_key (see sibling invites.ts note).
+  const projectKey = getStringQuery(req.query.projectId)
+  const targetUserId = getStringQuery(req.query.userId)
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectId')
+  if (!targetUserId) return jsonError(req, res, 400, 'Missing userId')
+
+  try {
+    const membership = await getProjectMember(user.userId, projectKey)
+    if (!membership) return jsonError(req, res, 403, 'Forbidden')
+    if (membership.role !== 'admin') return jsonError(req, res, 403, 'Admin role required')
+
+    const removed = await removeProjectMember(projectKey, targetUserId)
+    if (!removed) return jsonError(req, res, 404, 'Member not found')
+
+    setCors(req, res, ['DELETE', 'OPTIONS'])
+    return res.status(200).json({ projectKey, userId: targetUserId })
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : undefined
+    if (msg === 'last_admin') return jsonError(req, res, 409, 'Cannot remove the last admin')
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/db/migrations/0003_remove_project_member_rpc.sql
+++ b/db/migrations/0003_remove_project_member_rpc.sql
@@ -1,0 +1,50 @@
+-- Atomic last-admin-safe member removal.
+--
+-- Replaces the read-count-then-delete sequence in `removeProjectMember`, which
+-- could race: two concurrent admin removals each saw two admins, both passed the
+-- guard, and both deleted — orphaning the project with zero admins.
+--
+-- The lock is what makes this safe: when removing an admin we `for update` every
+-- admin row of the project before counting. Two concurrent admin removals now
+-- serialize on that lock — the second waker re-reads after the first commits,
+-- sees one admin left, and returns 'last_admin' instead of deleting.
+--
+-- Returns: 'not_found' (no such member), 'last_admin' (would orphan), 'removed'.
+create or replace function remove_project_member(p_project_key text, p_user_id uuid)
+returns text
+language plpgsql
+as $$
+declare
+  v_role text;
+  v_admin_count int;
+begin
+  select role into v_role
+    from project_members
+    where project_key = p_project_key and user_id = p_user_id;
+
+  if v_role is null then
+    return 'not_found';
+  end if;
+
+  if v_role = 'admin' then
+    -- Lock all admin rows for the project so concurrent admin removals serialize.
+    perform 1
+      from project_members
+      where project_key = p_project_key and role = 'admin'
+      for update;
+
+    select count(*) into v_admin_count
+      from project_members
+      where project_key = p_project_key and role = 'admin';
+
+    if v_admin_count <= 1 then
+      return 'last_admin';
+    end if;
+  end if;
+
+  delete from project_members
+    where project_key = p_project_key and user_id = p_user_id;
+
+  return 'removed';
+end;
+$$;

--- a/db/migrations/meta/0003_snapshot.json
+++ b/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1102 @@
+{
+  "id": "8c595774-df42-4972-a34b-c0de5fff347b",
+  "prevId": "3d7f732e-a64a-464e-992e-06473eb2b386",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_presence_share_seen_idx": {
+          "name": "agent_presence_share_seen_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_presence_share_id_feedback_shares_id_fk": {
+          "name": "agent_presence_share_id_feedback_shares_id_fk",
+          "tableFrom": "agent_presence",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_presence_share_id_agent_id_pk": {
+          "name": "agent_presence_share_id_agent_id_pk",
+          "columns": [
+            "share_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "implementation_status": {
+          "name": "implementation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unassigned'"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_project_created_idx": {
+          "name": "comments_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "comments_project_url_idx": {
+          "name": "comments_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "comments_project_status_idx": {
+          "name": "comments_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "implementation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_events": {
+      "name": "feedback_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "feedback_events_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_events_share_id_idx": {
+          "name": "feedback_events_share_id_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_events_share_id_feedback_shares_id_fk": {
+          "name": "feedback_events_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_events",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_events_comment_id_comments_id_fk": {
+          "name": "feedback_events_comment_id_comments_id_fk",
+          "tableFrom": "feedback_events",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_operation_keys": {
+      "name": "feedback_operation_keys",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_event_id": {
+          "name": "feedback_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_operation_keys_share_id_feedback_shares_id_fk": {
+          "name": "feedback_operation_keys_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_operation_keys_feedback_event_id_feedback_events_id_fk": {
+          "name": "feedback_operation_keys_feedback_event_id_feedback_events_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "columnsFrom": [
+            "feedback_event_id"
+          ],
+          "tableTo": "feedback_events",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_operation_keys_share_id_agent_id_idempotency_key_pk": {
+          "name": "feedback_operation_keys_share_id_agent_id_idempotency_key_pk",
+          "columns": [
+            "share_id",
+            "agent_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_share_items": {
+      "name": "feedback_share_items",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_share_items_share_id_feedback_shares_id_fk": {
+          "name": "feedback_share_items_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_share_items",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_share_items_comment_id_comments_id_fk": {
+          "name": "feedback_share_items_comment_id_comments_id_fk",
+          "tableFrom": "feedback_share_items",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_share_items_share_id_comment_id_pk": {
+          "name": "feedback_share_items_share_id_comment_id_pk",
+          "columns": [
+            "share_id",
+            "comment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_shares": {
+      "name": "feedback_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_page_url": {
+          "name": "scope_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_shares_one_project_scope_per_project": {
+          "name": "feedback_shares_one_project_scope_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "scope_type = 'project' and revoked_at is null",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_shares_project_id_projects_public_key_fk": {
+          "name": "feedback_shares_project_id_projects_public_key_fk",
+          "tableFrom": "feedback_shares",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_shares_slug_unique": {
+          "name": "feedback_shares_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feedback_shares_scope_type_check": {
+          "name": "feedback_shares_scope_type_check",
+          "value": "\"feedback_shares\".\"scope_type\" in ('page', 'selection', 'project')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_kind_check": {
+          "name": "notifications_kind_check",
+          "value": "\"notifications\".\"kind\" in ('invite.received', 'invite.accepted', 'invite.declined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_invites": {
+      "name": "project_invites",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invites_email_idx": {
+          "name": "project_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "project_invites_project_key_projects_public_key_fk": {
+          "name": "project_invites_project_key_projects_public_key_fk",
+          "tableFrom": "project_invites",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_invites_project_key_email_pk": {
+          "name": "project_invites_project_key_email_pk",
+          "columns": [
+            "project_key",
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_invites_role_check": {
+          "name": "project_invites_role_check",
+          "value": "\"project_invites\".\"role\" in ('admin', 'member')"
+        },
+        "project_invites_email_lower_check": {
+          "name": "project_invites_email_lower_check",
+          "value": "\"project_invites\".\"email\" = lower(\"project_invites\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_key_projects_public_key_fk": {
+          "name": "project_members_project_key_projects_public_key_fk",
+          "tableFrom": "project_members",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_key_user_id_pk": {
+          "name": "project_members_project_key_user_id_pk",
+          "columns": [
+            "project_key",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_members_role_check": {
+          "name": "project_members_role_check",
+          "value": "\"project_members\".\"role\" in ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_repo_configs": {
+      "name": "project_repo_configs",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_command": {
+          "name": "dev_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command": {
+          "name": "build_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instructions": {
+          "name": "agent_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_repo_configs_project_key_projects_public_key_fk": {
+          "name": "project_repo_configs_project_key_projects_public_key_fk",
+          "tableFrom": "project_repo_configs",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claimable": {
+          "name": "claimable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1779692374320,
       "tag": "0002_wild_black_bird",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1780463824190,
+      "tag": "0003_remove_project_member_rpc",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
- Add a PATCH endpoint to rename a project (admin only); the public key and slug stay immutable.
- Add an endpoint to list a project's members with their emails resolved from the auth system.
- Add member removal (admin only) that refuses to remove the last remaining admin so a project can't be orphaned.
- Extend the invites endpoint to list and cancel pending invites, alongside the existing send-invite.