### PR TITLE
Serve the dashboard under /dashboard on the landing deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,10 @@ Supabase client (`@supabase/supabase-js`) stays the runtime query layer. Do **no
 
 `supabase/legacy/` is frozen historical record from before Drizzle. Do not add new files there. Do not run those SQLs against any environment.
 
+## Dashboard routing
+
+The dashboard ships under a base path (`/dashboard/`), so all in-app routes/links and public assets must be base-aware — use `route()`/`asset()` from `apps/dashboard/lib/routes.ts`, never hardcode absolute `/foo` paths.
+
 ## Diff coverage
 
 After any code change, MUST invoke `diff-coverage` skill before handing work back. Both line and branch diff coverage vs `trunk` required at 100%.

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -5,6 +5,7 @@ import { useComments } from './hooks/useComments'
 import { useAgentSession } from './hooks/useAgentSession'
 import { useAuth } from './hooks/useAuth'
 import { getDisplayStatus, isInactive, mapServerComment } from './lib/comment'
+import { relPath } from './lib/routes'
 import { AGENTS, type Comment, type ImplStatus, type ReviewStatus, type StatusFilter } from './lib/types'
 import { Header } from './components/Header'
 import { CommentList } from './components/CommentList'
@@ -40,11 +41,11 @@ function markOnboarded() {
 
 export function App() {
   const { session, user, loading: authLoading, signOut } = useAuth()
-  const [pathname, setPathname] = useState(typeof window === 'undefined' ? '/' : window.location.pathname)
+  const [pathname, setPathname] = useState(typeof window === 'undefined' ? '/' : relPath(window.location.pathname))
 
   useEffect(() => {
     function onPop() {
-      setPathname(window.location.pathname)
+      setPathname(relPath(window.location.pathname))
     }
     window.addEventListener('popstate', onPop)
     return () => window.removeEventListener('popstate', onPop)

--- a/apps/dashboard/components/AgentSidebar.tsx
+++ b/apps/dashboard/components/AgentSidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { cn } from '../lib/utils'
+import { asset } from '../lib/routes'
 import type { ShareEventsResponse } from '../api'
 import { describeEvent } from '../lib/format'
 import { AGENTS, type AgentMeta, type Comment } from '../lib/types'
@@ -223,7 +224,7 @@ function HandoffHero({ count, filtered }: { count: number; filtered: boolean }) 
         )}
       >
         <img
-          src="/crrt-isologo.png"
+          src={asset('crrt-isologo.png')}
           alt=""
           width={logoSize}
           height={logoSize}

--- a/apps/dashboard/components/Header.tsx
+++ b/apps/dashboard/components/Header.tsx
@@ -1,5 +1,6 @@
 import type { User } from '@supabase/supabase-js'
 import { cn } from '../lib/utils'
+import { asset } from '../lib/routes'
 import type { Project, ProjectKeyAvailability } from '../api'
 import type { StatusFilter } from '../lib/types'
 import { MoonIcon, PlusIcon, SearchIcon, SettingsIcon, SunIcon } from './icons'
@@ -67,7 +68,7 @@ export function Header({
     <header className="flex items-center gap-3 px-5 h-[60px] shrink-0 border-b border-border bg-card">
       <div className="flex items-center gap-2 mr-2">
         <img
-          src="/crrt-isologo.png"
+          src={asset('crrt-isologo.png')}
           alt="CRRT"
           width={24}
           height={24}

--- a/apps/dashboard/components/LoginPage.tsx
+++ b/apps/dashboard/components/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
+import { relPath, route } from '../lib/routes'
 import { Spinner } from './primitives'
 
 type Mode = 'signin' | 'signup' | 'forgot'
@@ -14,7 +15,7 @@ type AuthPath = '/login' | '/signup' | '/forgot-password' | '/'
 
 export function LoginPage() {
   const [mode, setMode] = useState<Mode>(() =>
-    typeof window === 'undefined' ? 'signin' : modeFromPath(window.location.pathname),
+    typeof window === 'undefined' ? 'signin' : modeFromPath(relPath(window.location.pathname)),
   )
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -26,7 +27,7 @@ export function LoginPage() {
   // Sync mode if the user uses browser back / forward.
   useEffect(() => {
     function onPop() {
-      setMode(modeFromPath(window.location.pathname))
+      setMode(modeFromPath(relPath(window.location.pathname)))
       setError(null)
       setSignupSent(false)
       setResetSent(false)
@@ -36,8 +37,8 @@ export function LoginPage() {
   }, [])
 
   function navigate(path: AuthPath) {
-    if (window.location.pathname === path) return
-    window.history.pushState({}, '', path)
+    if (relPath(window.location.pathname) === path) return
+    window.history.pushState({}, '', route(path))
     setMode(modeFromPath(path))
     setError(null)
     setSignupSent(false)
@@ -57,13 +58,13 @@ export function LoginPage() {
         const { error: signupError } = await supabase.auth.signUp({
           email,
           password,
-          options: { emailRedirectTo: window.location.origin },
+          options: { emailRedirectTo: `${window.location.origin}${route('/')}` },
         })
         if (signupError) throw signupError
         setSignupSent(true)
       } else {
         const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
-          redirectTo: `${window.location.origin}/reset-password`,
+          redirectTo: `${window.location.origin}${route('/reset-password')}`,
         })
         if (resetError) throw resetError
         setResetSent(true)
@@ -227,7 +228,7 @@ export function LoginPage() {
               <FieldLabel htmlFor="auth-password">password</FieldLabel>
               {!isSignup && (
                 <a
-                  href="/forgot-password"
+                  href={route('/forgot-password')}
                   onClick={(e) => {
                     if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
                     e.preventDefault()
@@ -327,7 +328,7 @@ export function LoginPage() {
           <>
             have an account?{' '}
             <a
-              href="/login"
+              href={route('/login')}
               onClick={(e) => {
                 if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
                 e.preventDefault()
@@ -342,7 +343,7 @@ export function LoginPage() {
           <>
             remembered it?{' '}
             <a
-              href="/login"
+              href={route('/login')}
               onClick={(e) => {
                 if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
                 e.preventDefault()
@@ -357,7 +358,7 @@ export function LoginPage() {
           <>
             new here?{' '}
             <a
-              href="/signup"
+              href={route('/signup')}
               onClick={(e) => {
                 if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return
                 e.preventDefault()

--- a/apps/dashboard/components/LoginPage.tsx
+++ b/apps/dashboard/components/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
-import { relPath, route } from '../lib/routes'
+import { asset, relPath, route } from '../lib/routes'
 import { Spinner } from './primitives'
 
 type Mode = 'signin' | 'signup' | 'forgot'
@@ -141,7 +141,7 @@ export function LoginPage() {
       {/* CRRT identity mark */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(24px, 5vh, 36px)' }}>
         <img
-          src="/crrt-isologo.png"
+          src={asset('crrt-isologo.png')}
           alt=""
           width={40}
           height={40}
@@ -462,7 +462,7 @@ function CheckEmail({
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(24px, 5vh, 36px)' }}>
         <img
-          src="/crrt-isologo.png"
+          src={asset('crrt-isologo.png')}
           alt=""
           width={40}
           height={40}

--- a/apps/dashboard/components/ResetPasswordPage.tsx
+++ b/apps/dashboard/components/ResetPasswordPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
+import { route } from '../lib/routes'
 import { Spinner } from './primitives'
 
 /**
@@ -65,7 +66,7 @@ export function ResetPasswordPage() {
       // password active.
       await supabase.auth.signOut()
       window.setTimeout(() => {
-        window.location.href = '/login'
+        window.location.href = route('/login')
       }, 1400)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not update password')
@@ -277,7 +278,7 @@ export function ResetPasswordPage() {
 
       <p style={{ marginTop: 28, fontFamily: 'var(--crrt-font-body)', fontSize: 14, color: 'var(--muted-foreground)' }}>
         remembered it?{' '}
-        <a href="/login" style={{ color: 'var(--crrt-carrot)', textDecoration: 'none' }}>
+        <a href={route('/login')} style={{ color: 'var(--crrt-carrot)', textDecoration: 'none' }}>
           back to sign in →
         </a>
       </p>

--- a/apps/dashboard/components/ResetPasswordPage.tsx
+++ b/apps/dashboard/components/ResetPasswordPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
-import { route } from '../lib/routes'
+import { asset, route } from '../lib/routes'
 import { Spinner } from './primitives'
 
 /**
@@ -135,7 +135,7 @@ export function ResetPasswordPage() {
       {/* CRRT identity mark */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(24px, 5vh, 36px)' }}>
         <img
-          src="/crrt-isologo.png"
+          src={asset('crrt-isologo.png')}
           alt=""
           width={40}
           height={40}
@@ -304,7 +304,7 @@ function SuccessScreen() {
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 36 }}>
         <img
-          src="/crrt-isologo.png"
+          src={asset('crrt-isologo.png')}
           alt=""
           width={40}
           height={40}

--- a/apps/dashboard/components/WelcomeScreen.tsx
+++ b/apps/dashboard/components/WelcomeScreen.tsx
@@ -1,3 +1,5 @@
+import { asset } from '../lib/routes'
+
 interface WelcomeScreenProps {
   /** Called when the user clicks the "create your first project" CTA. */
   onCreateProject: () => void
@@ -68,7 +70,7 @@ export function WelcomeScreen({ onCreateProject }: WelcomeScreenProps) {
       {/* CRRT identity mark */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(24px, 5vh, 36px)' }}>
         <img
-          src="/crrt-isologo.png"
+          src={asset('crrt-isologo.png')}
           alt=""
           width={40}
           height={40}

--- a/apps/dashboard/lib/routes.ts
+++ b/apps/dashboard/lib/routes.ts
@@ -8,6 +8,11 @@ export function route(path: string): string {
   return path === '/' ? `${BASE}/` : `${BASE}${path}`
 }
 
+/** Resolve a public-dir asset under the base, e.g. asset('crrt-isologo.png') -> '/dashboard/crrt-isologo.png'. */
+export function asset(file: string): string {
+  return `${import.meta.env.BASE_URL}${file}`
+}
+
 /** Strip the base prefix off a real pathname so route matching stays base-agnostic. */
 export function relPath(pathname: string): string {
   if (!BASE) return pathname

--- a/apps/dashboard/lib/routes.ts
+++ b/apps/dashboard/lib/routes.ts
@@ -1,0 +1,16 @@
+// The dashboard is served under Vite's configured base (e.g. /dashboard/) so it
+// can share one Vercel deployment with the landing site. BASE_URL is injected at
+// build time and always carries a trailing slash.
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '')
+
+/** Build an absolute app path under the base, e.g. route('/login') -> '/dashboard/login'. */
+export function route(path: string): string {
+  return path === '/' ? `${BASE}/` : `${BASE}${path}`
+}
+
+/** Strip the base prefix off a real pathname so route matching stays base-agnostic. */
+export function relPath(pathname: string): string {
+  if (!BASE) return pathname
+  if (pathname === BASE) return '/'
+  return pathname.startsWith(`${BASE}/`) ? pathname.slice(BASE.length) : pathname
+}

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -10,6 +10,8 @@ export default defineConfig(({ mode }) => {
   const env = { ...loadEnv(mode, envDir, ''), ...process.env }
   return {
     root: __dirname,
+    // Served as a sub-path of the landing site so both ship from one Vercel deploy.
+    base: '/dashboard/',
     envDir,
     plugins: [react(), tailwindcss()],
     resolve: {
@@ -22,7 +24,9 @@ export default defineConfig(({ mode }) => {
       __SUPABASE_ANON_KEY__: JSON.stringify(env.SUPABASE_KEY ?? ''),
     },
     build: {
-      outDir: 'dist',
+      // Emit into the landing build output so one Vercel project serves both.
+      // Only this sub-dir is cleared, leaving the landing build (run first) intact.
+      outDir: path.resolve(__dirname, '../landing/dist/dashboard'),
       emptyOutDir: true,
     },
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "db:studio": "drizzle-kit studio",
     "db:seed": "bun db/seed.ts",
     "db:baseline": "bun db/baseline.ts",
-    "vercel-build": "bun run typecheck && vite build --config apps/landing/vite.config.ts && bun run db:migrate"
+    "vercel-build": "bun run typecheck && vite build --config apps/landing/vite.config.ts && vite build --config apps/dashboard/vite.config.ts && bun run db:migrate"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,9 @@
   },
   "rewrites": [
     { "source": "/d/:slug", "destination": "/index.html" },
-    { "source": "/docs/:path*", "destination": "/index.html" }
+    { "source": "/docs/:path*", "destination": "/index.html" },
+    { "source": "/dashboard", "destination": "/dashboard/index.html" },
+    { "source": "/dashboard/:path*", "destination": "/dashboard/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
- Ship the dashboard from the same Vercel project as the landing site instead of a separate deployment, served at `/dashboard`
- Build both apps in one step so the dashboard lands inside the landing output, keeping their styles and bundles fully isolated
- Make every dashboard route, link, and auth redirect base-aware so they resolve under the `/dashboard` prefix
- Add SPA rewrites so dashboard deep-links (login, signup, reset-password) route correctly on refresh