### PR TITLE
Enable Row Level Security on all tables and route the API through the service role

### DIFF
--- a/api/_lib/store.settings.test.ts
+++ b/api/_lib/store.settings.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('./supabase.js', () => ({ getSupabase: vi.fn(), getServiceSupabase: vi.fn() }))
+vi.mock('./supabase.js', () => ({ getServiceSupabase: vi.fn() }))
 
-import { getSupabase } from './supabase.js'
+import { getServiceSupabase } from './supabase.js'
 import {
   deleteProjectInvite,
   getUserEmailsByIds,
@@ -48,12 +48,12 @@ function supabaseRpc(result: Result) {
 }
 
 beforeEach(() => {
-  vi.mocked(getSupabase).mockReset()
+  vi.mocked(getServiceSupabase).mockReset()
 })
 
 describe('updateProjectName', () => {
   it('returns the renamed project', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       projects: [{ data: [{ public_key: 'p', slug: 'p', name: 'New', created_at: 't', updated_at: 't' }], error: null }],
     }) as never)
     const out = await updateProjectName('p', 'New')
@@ -61,14 +61,14 @@ describe('updateProjectName', () => {
   })
 
   it('returns null when no row matched', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       projects: [{ data: [], error: null }],
     }) as never)
     expect(await updateProjectName('missing', 'New')).toBeNull()
   })
 
   it('throws on db error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       projects: [{ data: null, error: { message: 'boom' } }],
     }) as never)
     await expect(updateProjectName('p', 'New')).rejects.toThrow('boom')
@@ -85,7 +85,7 @@ describe('listProjectMembers', () => {
 
   it('maps rows with null emails when no service key is configured', async () => {
     delete process.env.SUPABASE_SERVICE_ROLE_KEY
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       project_members: [{ data: [{ user_id: 'u1', role: 'admin', created_at: 't' }], error: null }],
     }) as never)
     const out = await listProjectMembers('p')
@@ -93,14 +93,14 @@ describe('listProjectMembers', () => {
   })
 
   it('returns an empty roster when the table yields no rows', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       project_members: [{ data: null, error: null }],
     }) as never)
     expect(await listProjectMembers('p')).toEqual([])
   })
 
   it('throws on db error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       project_members: [{ data: null, error: { message: 'boom' } }],
     }) as never)
     await expect(listProjectMembers('p')).rejects.toThrow('boom')
@@ -109,22 +109,22 @@ describe('listProjectMembers', () => {
 
 describe('removeProjectMember', () => {
   it('returns false when the member is not in the project', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseRpc({ data: 'not_found', error: null }) as never)
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseRpc({ data: 'not_found', error: null }) as never)
     expect(await removeProjectMember('p', 'gone')).toBe(false)
   })
 
   it('refuses to remove the last admin', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseRpc({ data: 'last_admin', error: null }) as never)
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseRpc({ data: 'last_admin', error: null }) as never)
     await expect(removeProjectMember('p', 'a')).rejects.toThrow('last_admin')
   })
 
   it('removes a member when the guard passes', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseRpc({ data: 'removed', error: null }) as never)
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseRpc({ data: 'removed', error: null }) as never)
     expect(await removeProjectMember('p', 'a')).toBe(true)
   })
 
   it('throws when the rpc errors', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseRpc({ data: null, error: { message: 'boom' } }) as never)
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseRpc({ data: null, error: { message: 'boom' } }) as never)
     await expect(removeProjectMember('p', 'a')).rejects.toThrow('boom')
   })
 })
@@ -174,7 +174,7 @@ describe('getUserEmailsByIds', () => {
 
 describe('listProjectInvites', () => {
   it('returns mapped invites', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       project_invites: [{ data: [{ project_key: 'p', email: 'x@y.z', role: 'member', invited_by: 'u', created_at: 't' }], error: null }],
     }) as never)
     const out = await listProjectInvites('p')
@@ -182,14 +182,14 @@ describe('listProjectInvites', () => {
   })
 
   it('returns an empty list when the table yields no rows', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       project_invites: [{ data: null, error: null }],
     }) as never)
     expect(await listProjectInvites('p')).toEqual([])
   })
 
   it('throws on db error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       project_invites: [{ data: null, error: { message: 'boom' } }],
     }) as never)
     await expect(listProjectInvites('p')).rejects.toThrow('boom')
@@ -198,21 +198,21 @@ describe('listProjectInvites', () => {
 
 describe('deleteProjectInvite', () => {
   it('returns true when a row was deleted', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       project_invites: [{ data: [{ email: 'x@y.z' }], error: null }],
     }) as never)
     expect(await deleteProjectInvite('p', 'X@Y.Z')).toBe(true)
   })
 
   it('returns false when nothing matched', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       project_invites: [{ data: [], error: null }],
     }) as never)
     expect(await deleteProjectInvite('p', 'x@y.z')).toBe(false)
   })
 
   it('throws on db error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(supabaseWith({
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       project_invites: [{ data: null, error: { message: 'boom' } }],
     }) as never)
     await expect(deleteProjectInvite('p', 'x@y.z')).rejects.toThrow('boom')

--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('./supabase.js', () => ({ getSupabase: vi.fn(), getServiceSupabase: vi.fn() }))
+vi.mock('./supabase.js', () => ({ getServiceSupabase: vi.fn() }))
 
-import { getServiceSupabase, getSupabase } from './supabase.js'
+import { getServiceSupabase } from './supabase.js'
 import {
   acceptInvite,
   claimProject,
@@ -81,13 +81,13 @@ const PROJECT_ROW: ProjectRow = {
 }
 
 beforeEach(() => {
-  vi.mocked(getSupabase).mockReset()
+  vi.mocked(getServiceSupabase).mockReset()
   vi.mocked(getServiceSupabase).mockReset()
 })
 
 describe('ensurePublicProject', () => {
   it('returns the existing project without inserting', async () => {
-    vi.mocked(getSupabase).mockReturnValue(
+    vi.mocked(getServiceSupabase).mockReturnValue(
       buildSupabase({ maybeSingleResults: [{ data: PROJECT_ROW, error: null }] }) as never,
     )
 
@@ -96,7 +96,7 @@ describe('ensurePublicProject', () => {
   })
 
   it('inserts the project and seeds the repo config when missing', async () => {
-    vi.mocked(getSupabase).mockReturnValue(
+    vi.mocked(getServiceSupabase).mockReturnValue(
       buildSupabase({
         maybeSingleResults: [{ data: null, error: null }],
         insertSingleResult: { data: PROJECT_ROW, error: null },
@@ -111,7 +111,7 @@ describe('ensurePublicProject', () => {
   })
 
   it('refetches and returns the project when a concurrent insert wins (23505)', async () => {
-    vi.mocked(getSupabase).mockReturnValue(
+    vi.mocked(getServiceSupabase).mockReturnValue(
       buildSupabase({
         maybeSingleResults: [
           { data: null, error: null },
@@ -126,7 +126,7 @@ describe('ensurePublicProject', () => {
   })
 
   it('throws when a 23505 hits but the refetch still finds nothing', async () => {
-    vi.mocked(getSupabase).mockReturnValue(
+    vi.mocked(getServiceSupabase).mockReturnValue(
       buildSupabase({
         maybeSingleResults: [
           { data: null, error: null },
@@ -140,7 +140,7 @@ describe('ensurePublicProject', () => {
   })
 
   it('throws when the project insert fails with a non-conflict error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(
+    vi.mocked(getServiceSupabase).mockReturnValue(
       buildSupabase({
         maybeSingleResults: [{ data: null, error: null }],
         insertSingleResult: { data: null, error: { code: '50000', message: 'boom' } },
@@ -151,7 +151,7 @@ describe('ensurePublicProject', () => {
   })
 
   it('throws when seeding the repo config fails with a non-conflict error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(
+    vi.mocked(getServiceSupabase).mockReturnValue(
       buildSupabase({
         maybeSingleResults: [{ data: null, error: null }],
         insertSingleResult: { data: PROJECT_ROW, error: null },
@@ -163,7 +163,7 @@ describe('ensurePublicProject', () => {
   })
 
   it('ignores a 23505 on the repo config insert (already exists)', async () => {
-    vi.mocked(getSupabase).mockReturnValue(
+    vi.mocked(getServiceSupabase).mockReturnValue(
       buildSupabase({
         maybeSingleResults: [{ data: null, error: null }],
         insertSingleResult: { data: PROJECT_ROW, error: null },
@@ -228,44 +228,44 @@ function membershipSupabase(m: MembershipMocks = {}) {
 
 describe('membership helpers + claim', () => {
   it('getProjectMember + isProjectMember cover hit / miss / error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       memberSingle: { data: { role: 'admin' }, error: null },
     }) as never)
     expect(await getProjectMember('u', 'p')).toEqual({ role: 'admin' })
     expect(await isProjectMember('u', 'p')).toBe(true)
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       memberSingle: { data: null, error: null },
     }) as never)
     expect(await getProjectMember('u', 'p')).toBeNull()
     expect(await isProjectMember('u', 'p')).toBe(false)
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       memberSingle: { data: null, error: { message: 'boom' } },
     }) as never)
     await expect(getProjectMember('u', 'p')).rejects.toThrow('boom')
   })
 
   it('listProjectsForUser returns empty / member-error / joined rows / projects-error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({ memberList: { data: [], error: null } }) as never)
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({ memberList: { data: [], error: null } }) as never)
     expect(await listProjectsForUser('u')).toEqual([])
 
     // defensive `data || []` fallback when supabase returns data:null, error:null
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({ memberList: { data: null, error: null } }) as never)
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({ memberList: { data: null, error: null } }) as never)
     expect(await listProjectsForUser('u')).toEqual([])
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       memberList: { data: null, error: { message: 'boom' } },
     }) as never)
     await expect(listProjectsForUser('u')).rejects.toThrow('boom')
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       memberList: { data: [{ project_key: 'p1' }], error: null },
       projectsIn: { data: [PROJECT_ROW], error: null },
     }) as never)
     expect((await listProjectsForUser('u')).map((p) => p.publicKey)).toEqual(['pk'])
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       memberList: { data: [{ project_key: 'p1' }], error: null },
       projectsIn: { data: null, error: { message: 'boom' } },
     }) as never)
@@ -273,45 +273,45 @@ describe('membership helpers + claim', () => {
   })
 
   it('claimProject: success path', async () => {
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: [PROJECT_ROW], error: null },
     }) as never)
     expect((await claimProject('u', 'pk')).publicKey).toBe('pk')
   })
 
   it('claimProject: not_found / already_claimed / 23505 race / member-insert error / update error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: [], error: null },
       projectsSingle: { data: null, error: null },
     }) as never)
     await expect(claimProject('u', 'pk')).rejects.toThrow('not_found')
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: [], error: null },
       projectsSingle: { data: PROJECT_ROW, error: null },
     }) as never)
     await expect(claimProject('u', 'pk')).rejects.toThrow('already_claimed')
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: [PROJECT_ROW], error: null },
       memberInsertError: { code: '23505', message: 'dup' },
     }) as never)
     expect((await claimProject('u', 'pk')).publicKey).toBe('pk')
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: [PROJECT_ROW], error: null },
       memberInsertError: { code: '50000', message: 'boom' },
     }) as never)
     await expect(claimProject('u', 'pk')).rejects.toThrow('boom')
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: null, error: { message: 'db boom' } },
     }) as never)
     await expect(claimProject('u', 'pk')).rejects.toThrow('db boom')
   })
 
   it('claimProject create-and-claim: creates a new project when none exists and a name is given', async () => {
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: [], error: null },
       projectsSingle: { data: null, error: null },
       projectInsert: { data: PROJECT_ROW, error: null },
@@ -320,14 +320,14 @@ describe('membership helpers + claim', () => {
   })
 
   it('claimProject create-and-claim: maps insert 23505 to already_claimed, propagates other errors', async () => {
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: [], error: null },
       projectsSingle: { data: null, error: null },
       projectInsert: { data: null, error: { code: '23505', message: 'dup' } },
     }) as never)
     await expect(claimProject('u', 'pk', 'Acme')).rejects.toThrow('already_claimed')
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: [], error: null },
       projectsSingle: { data: null, error: null },
       projectInsert: { data: null, error: { code: '50000', message: 'boom' } },
@@ -336,7 +336,7 @@ describe('membership helpers + claim', () => {
   })
 
   it('claimProject create-and-claim: surfaces repo-config errors but ignores 23505', async () => {
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: [], error: null },
       projectsSingle: { data: null, error: null },
       projectInsert: { data: PROJECT_ROW, error: null },
@@ -344,7 +344,7 @@ describe('membership helpers + claim', () => {
     }) as never)
     await expect(claimProject('u', 'pk', 'Acme')).rejects.toThrow('repo boom')
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsUpdate: { data: [], error: null },
       projectsSingle: { data: null, error: null },
       projectInsert: { data: PROJECT_ROW, error: null },
@@ -371,19 +371,19 @@ describe('project key helpers', () => {
   })
 
   it('isProjectKeyAvailable reflects whether a row exists', async () => {
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsSingle: { data: null, error: null },
     }) as never)
     expect(await isProjectKeyAvailable('free')).toBe(true)
 
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsSingle: { data: PROJECT_ROW, error: null },
     }) as never)
     expect(await isProjectKeyAvailable('taken')).toBe(false)
   })
 
   it('suggestAvailableProjectKey returns the base when free', async () => {
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsSingle: { data: null, error: null },
     }) as never)
     expect(await suggestAvailableProjectKey('acme')).toBe('acme')
@@ -394,7 +394,7 @@ describe('project key helpers', () => {
     const single = vi.fn()
       .mockResolvedValueOnce({ data: PROJECT_ROW, error: null })
       .mockResolvedValue({ data: null, error: null })
-    vi.mocked(getSupabase).mockReturnValue({
+    vi.mocked(getServiceSupabase).mockReturnValue({
       from: vi.fn(() => ({
         select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: single })) })),
       })),
@@ -404,7 +404,7 @@ describe('project key helpers', () => {
   })
 
   it('suggestAvailableProjectKey throws when no free key is found', async () => {
-    vi.mocked(getSupabase).mockReturnValue(membershipSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(membershipSupabase({
       projectsSingle: { data: PROJECT_ROW, error: null },
     }) as never)
     await expect(suggestAvailableProjectKey('acme')).rejects.toThrow('no_available_key')
@@ -570,54 +570,54 @@ describe('invite helpers', () => {
   const INVITE: InviteRow = { project_key: 'p', email: 'x@y.z', role: 'member', invited_by: 'inviter-1', created_at: 't' }
 
   it('createInvite: success / already_invited / other error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({
       inviteInsertResult: { data: INVITE, error: null },
     }) as never)
     expect((await createInvite({ projectKey: 'p', email: 'X@Y.Z', role: 'member', invitedBy: 'inviter-1' })).email).toBe('x@y.z')
 
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({
       inviteInsertResult: { data: null, error: { code: '23505', message: 'dup' } },
     }) as never)
     await expect(createInvite({ projectKey: 'p', email: 'x@y.z', role: 'member', invitedBy: 'i' })).rejects.toThrow('already_invited')
 
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({
       inviteInsertResult: { data: null, error: { code: '50000', message: 'boom' } },
     }) as never)
     await expect(createInvite({ projectKey: 'p', email: 'x@y.z', role: 'member', invitedBy: 'i' })).rejects.toThrow('boom')
   })
 
   it('listInvitesForEmail: success / null fallback / error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({
       inviteList: { data: [INVITE], error: null },
     }) as never)
     expect((await listInvitesForEmail('X@Y.Z')).map((i) => i.projectKey)).toEqual(['p'])
 
     // defensive `data || []` fallback
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({
       inviteList: { data: null, error: null },
     }) as never)
     expect(await listInvitesForEmail('x@y.z')).toEqual([])
 
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({
       inviteList: { data: null, error: { message: 'boom' } },
     }) as never)
     await expect(listInvitesForEmail('x@y.z')).rejects.toThrow('boom')
   })
 
   it('acceptInvite: not_found / happy / membership 23505 tolerated / other error', async () => {
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: null, error: null } }) as never)
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: null, error: null } }) as never)
     await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('not_found')
 
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: INVITE, error: null } }) as never)
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: INVITE, error: null } }) as never)
     expect(await acceptInvite('u', 'x@y.z', 'p')).toBe('inviter-1')
 
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({
       inviteSingle: { data: INVITE, error: null },
       memberInsertError: { code: '23505', message: 'dup' },
     }) as never)
     expect(await acceptInvite('u', 'x@y.z', 'p')).toBe('inviter-1')
 
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({
       inviteSingle: { data: INVITE, error: null },
       memberInsertError: { code: '50000', message: 'boom' },
     }) as never)
@@ -625,22 +625,22 @@ describe('invite helpers', () => {
   })
 
   it('declineInvite: not_found / happy', async () => {
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: null, error: null } }) as never)
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: null, error: null } }) as never)
     await expect(declineInvite('x@y.z', 'p')).rejects.toThrow('not_found')
 
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: INVITE, error: null } }) as never)
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({ inviteSingle: { data: INVITE, error: null } }) as never)
     expect(await declineInvite('x@y.z', 'p')).toBe('inviter-1')
   })
 
   it('getInvite lookup error / deleteInvite error bubble through accept', async () => {
     // getInvite error path
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({
       inviteSingle: { data: null, error: { message: 'lookup boom' } },
     }) as never)
     await expect(acceptInvite('u', 'x@y.z', 'p')).rejects.toThrow('lookup boom')
 
     // deleteInvite error path (invite found, member insert ok, delete fails)
-    vi.mocked(getSupabase).mockReturnValue(inviteSupabase({
+    vi.mocked(getServiceSupabase).mockReturnValue(inviteSupabase({
       inviteSingle: { data: INVITE, error: null },
       inviteDeleteError: { message: 'delete boom' },
     }) as never)

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -1,5 +1,14 @@
-import { getServiceSupabase, getSupabase } from './supabase.js'
+import { getServiceSupabase } from './supabase.js'
 import { fromLegacyStatus, toLegacyStatus, type ImplementationStatus, type ReviewStatus } from './status.js'
+
+// Every table/storage operation in this module goes through the service-role
+// client. Every public table has RLS enabled with no permissive policy
+// (migration 0004), so the anon key — which ships in the dashboard bundle —
+// can't reach them directly. The service-role client bypasses RLS; each
+// function below enforces its own scoping (project membership, user_id, project
+// key) and callers gate access via `requireUser` / `requireProjectMembership`
+// in `api/`.
+const getSupabase = getServiceSupabase
 
 type CommentRow = {
   id: string
@@ -972,17 +981,16 @@ function mapNotification(row: NotificationRow) {
   }
 }
 
-// Notifications uses the service-role client because the table has RLS
-// (`auth.uid() = user_id`) enabled for safe per-user realtime subscriptions.
-// The backend has no user JWT in its supabase client, so anon-key queries
-// would always see zero rows / fail to insert. Service role bypasses RLS;
-// these helpers enforce the user_id scope themselves.
+// Notifications has a `notifications_select_own` policy (the dashboard
+// subscribes to its own rows over realtime with the authenticated key), so the
+// backend — which holds no user JWT — must use the service-role client to read
+// or write across users. These helpers enforce the user_id scope themselves.
 export async function createNotification(input: {
   userId: string
   kind: NotificationKind
   payload?: Record<string, unknown>
 }) {
-  const supabase = getServiceSupabase()
+  const supabase = getSupabase()
   const { data, error } = await supabase
     .from('notifications')
     .insert([{ user_id: input.userId, kind: input.kind, payload: input.payload ?? {} }] as never)
@@ -996,7 +1004,7 @@ export async function listNotificationsForUser(
   userId: string,
   opts: { unreadOnly?: boolean; limit?: number } = {},
 ) {
-  const supabase = getServiceSupabase()
+  const supabase = getSupabase()
   let query = supabase
     .from('notifications')
     .select('id, user_id, kind, payload, read_at, created_at')
@@ -1010,7 +1018,7 @@ export async function listNotificationsForUser(
 }
 
 export async function markNotificationRead(notificationId: string, userId: string): Promise<boolean> {
-  const supabase = getServiceSupabase()
+  const supabase = getSupabase()
   const { data, error } = await supabase
     .from('notifications')
     .update({ read_at: new Date().toISOString() })
@@ -1023,7 +1031,7 @@ export async function markNotificationRead(notificationId: string, userId: strin
 }
 
 export async function markAllNotificationsRead(userId: string) {
-  const supabase = getServiceSupabase()
+  const supabase = getSupabase()
   const { error } = await supabase
     .from('notifications')
     .update({ read_at: new Date().toISOString() })

--- a/api/_lib/supabase.ts
+++ b/api/_lib/supabase.ts
@@ -12,9 +12,11 @@ export function getSupabase(): SupabaseClient {
 }
 
 /**
- * Service-role client. Bypasses RLS, so use it only for backend writes/reads
- * on RLS-protected tables (currently: `notifications`). Frontend code must
- * never call this. SUPABASE_SERVICE_ROLE_KEY is required.
+ * Service-role client. Bypasses RLS, so it's the client the backend uses for
+ * all table access and storage writes — every public table has RLS enabled
+ * with no permissive policy (migration 0004), and the API does its own
+ * authorization. Frontend code must never call this.
+ * SUPABASE_SERVICE_ROLE_KEY is required.
  */
 export function getServiceSupabase(): SupabaseClient {
   const supabaseUrl = process.env.SUPABASE_URL

--- a/api/v1/public/comments.test.ts
+++ b/api/v1/public/comments.test.ts
@@ -8,7 +8,10 @@ vi.mock('../../_lib/store.js', () => ({
   deleteCommentsForProject: vi.fn(),
 }))
 
+vi.mock('../../_lib/supabase.js', () => ({ getServiceSupabase: vi.fn() }))
+
 import { createPublicComment, deleteCommentsForProject, ensurePublicProject, listComments, updateReviewStatus } from '../../_lib/store.js'
+import { getServiceSupabase } from '../../_lib/supabase.js'
 import handler from './comments.js'
 
 interface MockRes {
@@ -56,6 +59,7 @@ beforeEach(() => {
   vi.mocked(listComments).mockReset()
   vi.mocked(updateReviewStatus).mockReset()
   vi.mocked(deleteCommentsForProject).mockReset()
+  vi.mocked(getServiceSupabase).mockReset()
   delete process.env.SMOKE_CLEANUP_TOKEN
   delete process.env.SMOKE_PROJECT_KEY
 })
@@ -124,6 +128,55 @@ describe('api/v1/public/comments', () => {
 
     expect(ensurePublicProject).toHaveBeenCalledWith('missing')
     expect(res.statusCode).toBe(201)
+  })
+
+  it('uploads an image via the service-role client and stores its public URL', async () => {
+    const upload = vi.fn().mockResolvedValue({ error: null })
+    const getPublicUrl = vi.fn().mockReturnValue({ data: { publicUrl: 'https://cdn.example/img.png' } })
+    vi.mocked(getServiceSupabase).mockReturnValue({
+      storage: { from: () => ({ upload, getPublicUrl }) },
+    } as never)
+    vi.mocked(ensurePublicProject).mockResolvedValue({
+      publicKey: 'demo-project',
+      slug: 'demo-project',
+      name: 'Demo',
+      createdAt: '',
+      updatedAt: '',
+    })
+    vi.mocked(createPublicComment).mockResolvedValue({
+      id: 'comment-1',
+      projectId: 'demo-project',
+      pageUrl: 'https://example.com',
+      selector: 'body',
+      x: 10,
+      y: 20,
+      body: 'Hi',
+      reviewStatus: 'open',
+      implementationStatus: 'unassigned',
+      claimedByAgentId: null,
+      imageUrl: 'https://cdn.example/img.png',
+      authorName: null,
+      createdAt: '',
+      updatedAt: '',
+    })
+
+    const res = mockRes()
+    await call(mockReq({
+      body: {
+        projectKey: 'demo-project',
+        pageUrl: 'https://example.com',
+        selector: 'body',
+        x: 10,
+        y: 20,
+        body: 'Hi',
+        imageBase64: Buffer.from('png-bytes').toString('base64'),
+        imageMimeType: 'image/png',
+      },
+    }), res)
+
+    expect(upload).toHaveBeenCalledOnce()
+    expect(res.statusCode).toBe(201)
+    expect(vi.mocked(createPublicComment).mock.calls[0]?.[0].imageUrl).toBe('https://cdn.example/img.png')
   })
 
   it('creates a public comment', async () => {

--- a/api/v1/public/comments.ts
+++ b/api/v1/public/comments.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createPublicComment, deleteCommentById, deleteCommentsForProject, ensurePublicProject, listComments, updateReviewStatus } from '../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
 import type { ReviewStatus } from '../../_lib/status.js'
-import { getSupabase } from '../../_lib/supabase.js'
+import { getServiceSupabase } from '../../_lib/supabase.js'
 
 const METHODS = ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS']
 const VALID_STATUSES = new Set(['open', 'accepted', 'approved', 'rejected', 'pending'])
@@ -128,7 +128,7 @@ async function uploadImage(projectKey: string, mimeType: string, base64Data: str
   const ext = mimeType.split('/')[1] ?? 'png'
   const path = `${projectKey}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
 
-  const supabase = getSupabase()
+  const supabase = getServiceSupabase()
   const { error } = await supabase.storage
     .from('feedback-images')
     .upload(path, buffer, { contentType: mimeType, upsert: false })

--- a/db/migrations/0004_enable_rls.sql
+++ b/db/migrations/0004_enable_rls.sql
@@ -1,0 +1,37 @@
+-- Enable Row Level Security on every remaining public table.
+--
+-- The Supabase publishable (anon) key is shipped in the dashboard bundle by
+-- design; Supabase's model assumes RLS guards every table. Until now only
+-- `notifications` had RLS (migration 0002), so anyone could take the bundled
+-- key and read/write/delete the other tables directly via the Supabase REST
+-- API, bypassing the app-layer authorization in `api/`.
+--
+-- Enabling RLS with NO permissive policy = deny-all for the `anon` and
+-- `authenticated` roles. The API talks to these tables through the
+-- service-role client (`getServiceSupabase`), which bypasses RLS, and does its
+-- own authorization. FORCE also subjects the table owner to RLS.
+--
+-- `notifications` is intentionally omitted: it already has RLS + a
+-- `notifications_select_own` policy so the dashboard can subscribe to its own
+-- rows over realtime with the authenticated key.
+
+ALTER TABLE "comments" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "comments" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "projects" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "projects" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "project_members" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "project_members" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "project_invites" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "project_invites" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "project_repo_configs" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "project_repo_configs" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "feedback_shares" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "feedback_shares" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "feedback_share_items" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "feedback_share_items" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "feedback_events" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "feedback_events" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "agent_presence" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "agent_presence" FORCE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "feedback_operation_keys" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "feedback_operation_keys" FORCE ROW LEVEL SECURITY;

--- a/db/migrations/meta/0004_snapshot.json
+++ b/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1102 @@
+{
+  "id": "1247c040-5b16-428e-b563-ed9fbabecbff",
+  "prevId": "8c595774-df42-4972-a34b-c0de5fff347b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_presence_share_seen_idx": {
+          "name": "agent_presence_share_seen_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_presence_share_id_feedback_shares_id_fk": {
+          "name": "agent_presence_share_id_feedback_shares_id_fk",
+          "tableFrom": "agent_presence",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_presence_share_id_agent_id_pk": {
+          "name": "agent_presence_share_id_agent_id_pk",
+          "columns": [
+            "share_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "implementation_status": {
+          "name": "implementation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unassigned'"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_project_created_idx": {
+          "name": "comments_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "comments_project_url_idx": {
+          "name": "comments_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "comments_project_status_idx": {
+          "name": "comments_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "implementation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_events": {
+      "name": "feedback_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "feedback_events_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_events_share_id_idx": {
+          "name": "feedback_events_share_id_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_events_share_id_feedback_shares_id_fk": {
+          "name": "feedback_events_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_events",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_events_comment_id_comments_id_fk": {
+          "name": "feedback_events_comment_id_comments_id_fk",
+          "tableFrom": "feedback_events",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_operation_keys": {
+      "name": "feedback_operation_keys",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_event_id": {
+          "name": "feedback_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_operation_keys_share_id_feedback_shares_id_fk": {
+          "name": "feedback_operation_keys_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_operation_keys_feedback_event_id_feedback_events_id_fk": {
+          "name": "feedback_operation_keys_feedback_event_id_feedback_events_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "columnsFrom": [
+            "feedback_event_id"
+          ],
+          "tableTo": "feedback_events",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_operation_keys_share_id_agent_id_idempotency_key_pk": {
+          "name": "feedback_operation_keys_share_id_agent_id_idempotency_key_pk",
+          "columns": [
+            "share_id",
+            "agent_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_share_items": {
+      "name": "feedback_share_items",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_share_items_share_id_feedback_shares_id_fk": {
+          "name": "feedback_share_items_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_share_items",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_share_items_comment_id_comments_id_fk": {
+          "name": "feedback_share_items_comment_id_comments_id_fk",
+          "tableFrom": "feedback_share_items",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_share_items_share_id_comment_id_pk": {
+          "name": "feedback_share_items_share_id_comment_id_pk",
+          "columns": [
+            "share_id",
+            "comment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_shares": {
+      "name": "feedback_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_page_url": {
+          "name": "scope_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_shares_one_project_scope_per_project": {
+          "name": "feedback_shares_one_project_scope_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "scope_type = 'project' and revoked_at is null",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_shares_project_id_projects_public_key_fk": {
+          "name": "feedback_shares_project_id_projects_public_key_fk",
+          "tableFrom": "feedback_shares",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_shares_slug_unique": {
+          "name": "feedback_shares_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feedback_shares_scope_type_check": {
+          "name": "feedback_shares_scope_type_check",
+          "value": "\"feedback_shares\".\"scope_type\" in ('page', 'selection', 'project')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_kind_check": {
+          "name": "notifications_kind_check",
+          "value": "\"notifications\".\"kind\" in ('invite.received', 'invite.accepted', 'invite.declined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_invites": {
+      "name": "project_invites",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invites_email_idx": {
+          "name": "project_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "project_invites_project_key_projects_public_key_fk": {
+          "name": "project_invites_project_key_projects_public_key_fk",
+          "tableFrom": "project_invites",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_invites_project_key_email_pk": {
+          "name": "project_invites_project_key_email_pk",
+          "columns": [
+            "project_key",
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_invites_role_check": {
+          "name": "project_invites_role_check",
+          "value": "\"project_invites\".\"role\" in ('admin', 'member')"
+        },
+        "project_invites_email_lower_check": {
+          "name": "project_invites_email_lower_check",
+          "value": "\"project_invites\".\"email\" = lower(\"project_invites\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_key_projects_public_key_fk": {
+          "name": "project_members_project_key_projects_public_key_fk",
+          "tableFrom": "project_members",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_key_user_id_pk": {
+          "name": "project_members_project_key_user_id_pk",
+          "columns": [
+            "project_key",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_members_role_check": {
+          "name": "project_members_role_check",
+          "value": "\"project_members\".\"role\" in ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_repo_configs": {
+      "name": "project_repo_configs",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_command": {
+          "name": "dev_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command": {
+          "name": "build_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instructions": {
+          "name": "agent_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_repo_configs_project_key_projects_public_key_fk": {
+          "name": "project_repo_configs_project_key_projects_public_key_fk",
+          "tableFrom": "project_repo_configs",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claimable": {
+          "name": "claimable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1780463824190,
       "tag": "0003_remove_project_member_rpc",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1781014285688,
+      "tag": "0004_enable_rls",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -14,6 +14,16 @@ import {
   uuid,
 } from 'drizzle-orm/pg-core'
 
+// Row Level Security: every table below has RLS enabled with NO permissive
+// policy (migration 0004_enable_rls), i.e. deny-all for the `anon` /
+// `authenticated` roles. This is required because the publishable (anon) key
+// ships in the dashboard bundle — without RLS anyone could query these tables
+// directly via the Supabase REST API. The API reaches them through the
+// service-role client (`getServiceSupabase`), which bypasses RLS and does its
+// own authorization. `notifications` is the exception: it has a
+// `notifications_select_own` policy (migration 0002) so the dashboard can
+// subscribe to its own rows over realtime with the authenticated key.
+
 export const projects = pgTable('projects', {
   publicKey: text('public_key').primaryKey(),
   slug: text('slug').notNull().unique(),

--- a/supabase/policies/feedback-images.sql
+++ b/supabase/policies/feedback-images.sql
@@ -6,13 +6,11 @@
 --
 -- Bucket itself must already exist (create via Supabase dashboard → Storage).
 
--- Allow anyone to upload into feedback-images (widget runs as anon)
+-- Uploads go through the API (`api/v1/public/comments.ts`), which writes with
+-- the service-role client — that bypasses storage RLS, so no anon insert policy
+-- is needed. We explicitly drop the old one so existing environments stop
+-- accepting direct anon uploads with the publishable key.
 drop policy if exists "anon upload feedback images" on storage.objects;
-create policy "anon upload feedback images"
-  on storage.objects
-  for insert
-  to anon
-  with check (bucket_id = 'feedback-images');
 
 -- Allow public read of feedback images
 drop policy if exists "public read feedback images" on storage.objects;


### PR DESCRIPTION
- Turn on Row Level Security (deny-all, no policies) for every remaining table so the publishable key — which ships in the dashboard bundle — can no longer read or write them directly through the Supabase REST API.
- Switch the API's database and storage access to the service-role client, which keeps the existing app-layer authorization the real gate while bypassing RLS for trusted server code.
- Keep anonymous commenting and the notifications realtime feed working unchanged, since both already flow through the API or an authenticated per-user policy.
- Drop the anonymous upload policy on the feedback-images bucket now that image uploads go through the API.