### PR TITLE
Drop the redundant apiBase prop from the dashboard install snippet

### DIFF
--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -429,7 +429,6 @@ function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: strin
         <CommentDetail
           selectedComment={selectedComment}
           selectedProject={selectedProject}
-          apiBase={API_BASE}
           commentsLoading={commentsLoading}
           commentsError={commentsError}
           projectComments={projectComments}

--- a/apps/dashboard/components/CommentDetail.tsx
+++ b/apps/dashboard/components/CommentDetail.tsx
@@ -19,7 +19,6 @@ import { ProjectEmptyState } from './ProjectEmptyState'
 interface CommentDetailProps {
   selectedComment: Comment | null
   selectedProject: string
-  apiBase: string
   commentsLoading: boolean
   commentsError: string | null
   projectComments: Comment[]
@@ -34,7 +33,6 @@ interface CommentDetailProps {
 export function CommentDetail({
   selectedComment,
   selectedProject,
-  apiBase,
   commentsLoading,
   commentsError,
   projectComments,
@@ -187,7 +185,7 @@ export function CommentDetail({
           </div>
         </>
       ) : selectedProject && !commentsLoading && !commentsError && projectComments.length === 0 ? (
-        <ProjectEmptyState projectId={selectedProject} apiBase={apiBase} />
+        <ProjectEmptyState projectId={selectedProject} />
       ) : (
         <div className="flex-1 flex flex-col items-center justify-center text-center px-8">
           <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center mb-4">

--- a/apps/dashboard/components/ProjectEmptyState.tsx
+++ b/apps/dashboard/components/ProjectEmptyState.tsx
@@ -3,8 +3,6 @@ import { useState } from 'react'
 interface ProjectEmptyStateProps {
   /** Project public key shown inline in the mount snippet. */
   projectId: string
-  /** Backend URL shown inline in the mount snippet. */
-  apiBase: string
 }
 
 /**
@@ -13,7 +11,7 @@ interface ProjectEmptyStateProps {
  * through the two install snippets with copy buttons so they can drop the
  * widget into their app without leaving the dashboard.
  */
-export function ProjectEmptyState({ projectId, apiBase }: ProjectEmptyStateProps) {
+export function ProjectEmptyState({ projectId }: ProjectEmptyStateProps) {
   const installCode = `pnpm add @thedesignproject/crrt`
   const mountCode = `import { FeedbackWidget } from '@thedesignproject/crrt'
 
@@ -21,10 +19,7 @@ export default function App() {
   return (
     <>
       <YourApp />
-      <FeedbackWidget
-        projectId="${projectId}"
-        apiBase="${apiBase}"
-      />
+      <FeedbackWidget projectId="${projectId}" />
     </>
   )
 }`


### PR DESCRIPTION
- Remove `apiBase` from the mount snippet in the project empty state, since the widget now defaults to the hosted API and the extra prop only added noise for new users
- Collapse the example to a single-line `<FeedbackWidget projectId="..." />` mount
- Stop threading `apiBase` through CommentDetail, which only carried it for the empty state