### PR TITLE
Add a disabled prop to turn the feedback widget off

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Props:
 | --- | --- | --- | --- |
 | `projectId` | `string` | yes | Project public key used for comment capture. |
 | `apiBase` | `string` | no | Base URL of the backend that serves the widget API. Defaults to `https://crrt.ai/api`. Override to point at a self-hosted deployment. |
+| `disabled` | `boolean` | no | When `true`, the widget renders nothing — no UI, no listeners, no API calls. Defaults to `false`. Useful for turning the widget off per environment (e.g. production). |
 
 ## API surfaces
 

--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -190,6 +190,24 @@ describe('<FeedbackWidget />', () => {
     expect(roots.length).toBeGreaterThan(0)
   })
 
+  it('renders nothing and fetches nothing when disabled', () => {
+    const calls = mockFetch()
+    render(<FeedbackWidget projectId="p" apiBase="https://x.example/api" disabled />)
+    expect(document.querySelectorAll('[data-fw]').length).toBe(0)
+    expect(calls.length).toBe(0)
+  })
+
+  it('unmounts the widget when disabled flips to true at runtime', () => {
+    mockFetch()
+    const { rerender } = render(
+      <FeedbackWidget projectId="p" apiBase="https://x.example/api" disabled={false} />,
+    )
+    expect(document.querySelectorAll('[data-fw]').length).toBeGreaterThan(0)
+
+    rerender(<FeedbackWidget projectId="p" apiBase="https://x.example/api" disabled />)
+    expect(document.querySelectorAll('[data-fw]').length).toBe(0)
+  })
+
   it('does not crash when the GET endpoint is unavailable', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -52,7 +52,12 @@ function CarrotPixelIcon({ size = 20 }: { size?: number | string }) {
   )
 }
 
-export function FeedbackWidget({ projectId, apiBase = 'https://crrt.ai/api' }: FeedbackWidgetProps) {
+export function FeedbackWidget({ disabled = false, ...props }: FeedbackWidgetProps) {
+  if (disabled) return null
+  return <FeedbackWidgetInner {...props} />
+}
+
+function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omit<FeedbackWidgetProps, 'disabled'>) {
   const [mode, setMode] = useState<Mode>('idle')
   const [target, setTarget] = useState<ClickTarget | null>(null)
   const [comment, setComment] = useState('')

--- a/src/components/FeedbackWidget/types.ts
+++ b/src/components/FeedbackWidget/types.ts
@@ -1,6 +1,8 @@
 export interface FeedbackWidgetProps {
   projectId: string
   apiBase?: string
+  /** When true, the widget renders nothing and registers no listeners. */
+  disabled?: boolean
 }
 
 export type Mode = 'idle' | 'selecting' | 'commenting'


### PR DESCRIPTION
- Add an optional `disabled` prop to `<FeedbackWidget>` so consumers can switch the widget off programmatically, e.g. per environment
- When disabled, the widget renders nothing at all — no UI, no keyboard or scroll listeners, no API calls
- Flipping the prop at runtime cleanly mounts or unmounts the whole widget without breaking React's rules of hooks
- Document the new prop in the README props table; it defaults to `false`, so existing usage is unchanged