### PR TITLE
Enforce per-project domain allowlist on public comments

### DIFF
--- a/api/_lib/http.ts
+++ b/api/_lib/http.ts
@@ -66,7 +66,7 @@ export function getReviewerToken(req: VercelRequest): string | undefined {
   return typeof reviewer === 'string' && reviewer.length > 0 ? reviewer : undefined
 }
 
-function firstHeaderValue(value: string | string[] | undefined) {
+export function firstHeaderValue(value: string | string[] | undefined) {
   const raw = Array.isArray(value) ? value[0] : value
   if (!raw) return undefined
   return raw.split(',')[0]?.trim() || undefined

--- a/api/_lib/origins.test.ts
+++ b/api/_lib/origins.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { getRequestHostname, isHostnameAllowed, normalizeAllowedDomain } from './origins.js'
+
+describe('normalizeAllowedDomain', () => {
+  it('normalizes bare domains, full URLs, casing, ports, and paths', () => {
+    expect(normalizeAllowedDomain('Example.com')).toBe('example.com')
+    expect(normalizeAllowedDomain(' https://App.Example.com/path?q=1 ')).toBe('app.example.com')
+    expect(normalizeAllowedDomain('example.com/docs')).toBe('example.com')
+    expect(normalizeAllowedDomain('localhost:3000')).toBe('localhost')
+    expect(normalizeAllowedDomain('example.com.')).toBe('example.com')
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(normalizeAllowedDomain('')).toBeNull()
+    expect(normalizeAllowedDomain('   ')).toBeNull()
+    expect(normalizeAllowedDomain('https://')).toBeNull()
+    expect(normalizeAllowedDomain('not a domain')).toBeNull()
+    expect(normalizeAllowedDomain('file:///etc/hosts')).toBeNull()
+  })
+})
+
+describe('getRequestHostname', () => {
+  const req = (headers: Record<string, unknown>) => ({ headers }) as never
+
+  it('prefers Origin over Referer and lowercases', () => {
+    expect(getRequestHostname(req({ origin: 'https://App.Example.com', referer: 'https://other.com/x' }))).toBe('app.example.com')
+  })
+
+  it('falls back to Referer when Origin is absent or empty', () => {
+    expect(getRequestHostname(req({ referer: 'https://site.example/page' }))).toBe('site.example')
+    expect(getRequestHostname(req({ origin: '', referer: 'https://site.example/page' }))).toBe('site.example')
+  })
+
+  it('uses the first value of a repeated header', () => {
+    expect(getRequestHostname(req({ origin: ['https://a.com', 'https://b.com'] }))).toBe('a.com')
+  })
+
+  it('returns null when no header is present', () => {
+    expect(getRequestHostname(req({}))).toBeNull()
+  })
+
+  it('returns null for unparseable or hostless sources', () => {
+    expect(getRequestHostname(req({ origin: 'null' }))).toBeNull()
+    expect(getRequestHostname(req({ origin: 'file:///tmp/page.html' }))).toBeNull()
+  })
+})
+
+describe('isHostnameAllowed', () => {
+  it('allows every hostname when the allowlist is empty', () => {
+    expect(isHostnameAllowed('anywhere.com', [])).toBe(true)
+    expect(isHostnameAllowed(null, [])).toBe(true)
+  })
+
+  it('blocks requests without a hostname when the allowlist is set', () => {
+    expect(isHostnameAllowed(null, ['example.com'])).toBe(false)
+  })
+
+  it('matches exact hostnames and subdomains', () => {
+    expect(isHostnameAllowed('example.com', ['example.com'])).toBe(true)
+    expect(isHostnameAllowed('app.example.com', ['example.com'])).toBe(true)
+  })
+
+  it('rejects unrelated hostnames and suffix lookalikes', () => {
+    expect(isHostnameAllowed('other.com', ['example.com'])).toBe(false)
+    expect(isHostnameAllowed('evilexample.com', ['example.com'])).toBe(false)
+  })
+
+  it('never matches entries that are not normalized hostnames', () => {
+    expect(isHostnameAllowed('example.com', ['   ', 'example.com'])).toBe(true)
+    expect(isHostnameAllowed('example.com', ['   '])).toBe(false)
+  })
+})

--- a/api/_lib/origins.ts
+++ b/api/_lib/origins.ts
@@ -1,0 +1,51 @@
+import type { VercelRequest } from '@vercel/node'
+import { firstHeaderValue } from './http.js'
+
+// Per-project origin allowlist for public comment ingestion.
+//
+// `projects.allowed_origins` stores normalized hostnames ("example.com").
+// An empty list disables the check entirely — every origin may post. A
+// request hostname matches an entry when it is equal to it or is a
+// subdomain of it ("app.example.com" matches "example.com").
+
+/**
+ * Normalize a user-supplied domain to a bare lowercase hostname, accepting
+ * full URLs and origins as input ("Example.com/", "https://a.b/x" → "a.b").
+ * Returns null when the input cannot be parsed into a hostname.
+ */
+export function normalizeAllowedDomain(input: string): string | null {
+  const trimmed = input.trim().toLowerCase()
+  if (!trimmed) return null
+  const candidate = trimmed.includes('://') ? trimmed : `https://${trimmed}`
+  try {
+    return new URL(candidate).hostname.replace(/\.$/, '') || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Hostname the browser reports for the request — Origin first, falling back
+ * to Referer (some user agents omit Origin on same-origin requests). Null
+ * when neither header carries a parseable URL.
+ */
+export function getRequestHostname(req: VercelRequest): string | null {
+  const source = firstHeaderValue(req.headers.origin) ?? firstHeaderValue(req.headers.referer)
+  if (!source) return null
+  try {
+    return new URL(source).hostname.toLowerCase().replace(/\.$/, '') || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * `allowedDomains` entries are assumed pre-normalized — bare lowercase
+ * hostnames, which is what the project PATCH handler writes — so matching is
+ * plain string comparison. Un-normalized entries simply never match.
+ */
+export function isHostnameAllowed(hostname: string | null, allowedDomains: string[]): boolean {
+  if (allowedDomains.length === 0) return true
+  if (!hostname) return false
+  return allowedDomains.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`))
+}

--- a/api/_lib/store.settings.test.ts
+++ b/api/_lib/store.settings.test.ts
@@ -9,7 +9,7 @@ import {
   listProjectInvites,
   listProjectMembers,
   removeProjectMember,
-  updateProjectName,
+  updateProject,
 } from './store.js'
 
 type Result = { data: unknown; error: { code?: string; message: string } | null }
@@ -51,27 +51,35 @@ beforeEach(() => {
   vi.mocked(getServiceSupabase).mockReset()
 })
 
-describe('updateProjectName', () => {
-  it('returns the renamed project', async () => {
+describe('updateProject', () => {
+  it('returns the renamed project, defaulting a missing allowlist to []', async () => {
     vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       projects: [{ data: [{ public_key: 'p', slug: 'p', name: 'New', created_at: 't', updated_at: 't' }], error: null }],
     }) as never)
-    const out = await updateProjectName('p', 'New')
-    expect(out).toMatchObject({ publicKey: 'p', name: 'New' })
+    const out = await updateProject('p', { name: 'New' })
+    expect(out).toMatchObject({ publicKey: 'p', name: 'New', allowedOrigins: [] })
+  })
+
+  it('returns the project with its updated allowlist', async () => {
+    vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
+      projects: [{ data: [{ public_key: 'p', slug: 'p', name: 'P', allowed_origins: ['example.com'], created_at: 't', updated_at: 't' }], error: null }],
+    }) as never)
+    const out = await updateProject('p', { allowedOrigins: ['example.com'] })
+    expect(out).toMatchObject({ publicKey: 'p', allowedOrigins: ['example.com'] })
   })
 
   it('returns null when no row matched', async () => {
     vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       projects: [{ data: [], error: null }],
     }) as never)
-    expect(await updateProjectName('missing', 'New')).toBeNull()
+    expect(await updateProject('missing', { name: 'New' })).toBeNull()
   })
 
   it('throws on db error', async () => {
     vi.mocked(getServiceSupabase).mockReturnValue(supabaseWith({
       projects: [{ data: null, error: { message: 'boom' } }],
     }) as never)
-    await expect(updateProjectName('p', 'New')).rejects.toThrow('boom')
+    await expect(updateProject('p', { name: 'New' })).rejects.toThrow('boom')
   })
 })
 

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -31,9 +31,12 @@ type ProjectRow = {
   public_key: string
   slug: string
   name: string
+  allowed_origins: string[] | null
   created_at: string
   updated_at: string
 }
+
+const PROJECT_COLUMNS = 'public_key, slug, name, allowed_origins, created_at, updated_at'
 
 type ProjectMemberRow = {
   project_key: string
@@ -110,6 +113,7 @@ function mapProject(row: ProjectRow) {
     publicKey: row.public_key,
     slug: row.slug,
     name: row.name,
+    allowedOrigins: row.allowed_origins ?? [],
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -182,7 +186,7 @@ export async function listProjectsForUser(userId: string) {
 
   const { data, error } = await supabase
     .from('projects')
-    .select('public_key, slug, name, created_at, updated_at')
+    .select(PROJECT_COLUMNS)
     .in('public_key', keys)
     .order('created_at', { ascending: true })
 
@@ -319,7 +323,7 @@ export async function claimProject(
     .update({ claimable: false, updated_at: new Date().toISOString() })
     .eq('public_key', projectKey)
     .eq('claimable', true)
-    .select('public_key, slug, name, created_at, updated_at')
+    .select(PROJECT_COLUMNS)
 
   if (updateError) throw new Error(updateError.message)
 
@@ -361,7 +365,7 @@ async function createClaimedProject(projectKey: string, name: string) {
       allowed_origins: [],
       claimable: false,
     }] as never)
-    .select('public_key, slug, name, created_at, updated_at')
+    .select(PROJECT_COLUMNS)
     .single()
 
   if (error) {
@@ -413,7 +417,7 @@ export async function getProject(projectKey: string) {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('projects')
-    .select('public_key, slug, name, created_at, updated_at')
+    .select(PROJECT_COLUMNS)
     .eq('public_key', projectKey)
     .maybeSingle()
 
@@ -422,17 +426,21 @@ export async function getProject(projectKey: string) {
 }
 
 /**
- * Rename a project (display name only — public_key and slug are immutable).
- * Returns the updated project, or null when no project matched the key so the
- * caller can map that to a 404.
+ * Update a project's mutable settings (display name, origin allowlist —
+ * public_key and slug are immutable). Returns the updated project, or null
+ * when no project matched the key so the caller can map that to a 404.
  */
-export async function updateProjectName(projectKey: string, name: string) {
+export async function updateProject(projectKey: string, patch: { name?: string; allowedOrigins?: string[] }) {
   const supabase = getSupabase()
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  if (patch.name !== undefined) update.name = patch.name
+  if (patch.allowedOrigins !== undefined) update.allowed_origins = patch.allowedOrigins
+
   const { data, error } = await supabase
     .from('projects')
-    .update({ name, updated_at: new Date().toISOString() })
+    .update(update)
     .eq('public_key', projectKey)
-    .select('public_key, slug, name, created_at, updated_at')
+    .select(PROJECT_COLUMNS)
 
   if (error) throw new Error(error.message)
   if (!data || data.length === 0) return null
@@ -452,7 +460,7 @@ export async function ensurePublicProject(publicKey: string) {
       name: publicKey,
       allowed_origins: [],
     }] as never)
-    .select('public_key, slug, name, created_at, updated_at')
+    .select(PROJECT_COLUMNS)
     .single()
 
   if (error) {

--- a/api/v1/projects/[projectId]/index.test.ts
+++ b/api/v1/projects/[projectId]/index.test.ts
@@ -3,12 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('../../../_lib/auth.js', () => ({ requireUser: vi.fn() }))
 vi.mock('../../../_lib/store.js', () => ({
   getProjectMember: vi.fn(),
-  updateProjectName: vi.fn(),
+  updateProject: vi.fn(),
 }))
 
 import handler from './index.js'
 import { requireUser } from '../../../_lib/auth.js'
-import { getProjectMember, updateProjectName } from '../../../_lib/store.js'
+import { getProjectMember, updateProject } from '../../../_lib/store.js'
 
 function mockRes() {
   return {
@@ -27,7 +27,7 @@ const call = (req: unknown, res: unknown) =>
 beforeEach(() => {
   vi.mocked(requireUser).mockReset()
   vi.mocked(getProjectMember).mockReset()
-  vi.mocked(updateProjectName).mockReset()
+  vi.mocked(updateProject).mockReset()
 })
 
 describe('api/v1/projects/[projectId] PATCH (rename)', () => {
@@ -92,23 +92,100 @@ describe('api/v1/projects/[projectId] PATCH (rename)', () => {
     vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
 
     // success
-    vi.mocked(updateProjectName).mockResolvedValueOnce({ publicKey: 'p', name: 'New' } as never)
+    vi.mocked(updateProject).mockResolvedValueOnce({ publicKey: 'p', name: 'New' } as never)
     let res = mockRes()
     await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: '  New  ' }, headers: {} }, res)
     expect(res.statusCode).toBe(200)
-    expect(updateProjectName).toHaveBeenCalledWith('p', 'New')
+    expect(updateProject).toHaveBeenCalledWith('p', { name: 'New' })
     expect(res.body).toMatchObject({ name: 'New' })
 
     // not found
-    vi.mocked(updateProjectName).mockResolvedValueOnce(null)
+    vi.mocked(updateProject).mockResolvedValueOnce(null)
     res = mockRes()
     await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: 'New' }, headers: {} }, res)
     expect(res.statusCode).toBe(404)
 
     // error
-    vi.mocked(updateProjectName).mockRejectedValueOnce(new Error('db down'))
+    vi.mocked(updateProject).mockRejectedValueOnce(new Error('db down'))
     res = mockRes()
     await call({ method: 'PATCH', query: { projectId: 'p' }, body: { name: 'New' }, headers: {} }, res)
     expect(res.statusCode).toBe(500)
+  })
+
+  describe('allowedOrigins', () => {
+    beforeEach(() => {
+      vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+      vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
+    })
+
+    it('normalizes and dedupes domains before saving, without requiring a name', async () => {
+      vi.mocked(updateProject).mockResolvedValueOnce({ publicKey: 'p', allowedOrigins: ['example.com', 'app.foo.io'] } as never)
+      const res = mockRes()
+      await call({
+        method: 'PATCH',
+        query: { projectId: 'p' },
+        body: { allowedOrigins: ['Example.com/', 'https://app.foo.io/path', 'example.com'] },
+        headers: {},
+      }, res)
+      expect(res.statusCode).toBe(200)
+      expect(updateProject).toHaveBeenCalledWith('p', { allowedOrigins: ['example.com', 'app.foo.io'] })
+    })
+
+    it('accepts an empty array to disable the allowlist', async () => {
+      vi.mocked(updateProject).mockResolvedValueOnce({ publicKey: 'p', allowedOrigins: [] } as never)
+      const res = mockRes()
+      await call({ method: 'PATCH', query: { projectId: 'p' }, body: { allowedOrigins: [] }, headers: {} }, res)
+      expect(res.statusCode).toBe(200)
+      expect(updateProject).toHaveBeenCalledWith('p', { allowedOrigins: [] })
+    })
+
+    it('updates name and allowlist together', async () => {
+      vi.mocked(updateProject).mockResolvedValueOnce({ publicKey: 'p', name: 'New', allowedOrigins: ['example.com'] } as never)
+      const res = mockRes()
+      await call({
+        method: 'PATCH',
+        query: { projectId: 'p' },
+        body: { name: 'New', allowedOrigins: ['example.com'] },
+        headers: {},
+      }, res)
+      expect(res.statusCode).toBe(200)
+      expect(updateProject).toHaveBeenCalledWith('p', { name: 'New', allowedOrigins: ['example.com'] })
+    })
+
+    it('still validates the name when sent alongside allowedOrigins', async () => {
+      const res = mockRes()
+      await call({
+        method: 'PATCH',
+        query: { projectId: 'p' },
+        body: { name: '   ', allowedOrigins: ['example.com'] },
+        headers: {},
+      }, res)
+      expect(res.statusCode).toBe(400)
+      expect(updateProject).not.toHaveBeenCalled()
+    })
+
+    it('rejects malformed allowlists', async () => {
+      // not an array
+      let res = mockRes()
+      await call({ method: 'PATCH', query: { projectId: 'p' }, body: { allowedOrigins: 'example.com' }, headers: {} }, res)
+      expect(res.statusCode).toBe(400)
+
+      // over the entry limit
+      res = mockRes()
+      await call({ method: 'PATCH', query: { projectId: 'p' }, body: { allowedOrigins: Array(51).fill('example.com') }, headers: {} }, res)
+      expect(res.statusCode).toBe(400)
+
+      // non-string entry
+      res = mockRes()
+      await call({ method: 'PATCH', query: { projectId: 'p' }, body: { allowedOrigins: [42] }, headers: {} }, res)
+      expect(res.statusCode).toBe(400)
+
+      // unparseable domain
+      res = mockRes()
+      await call({ method: 'PATCH', query: { projectId: 'p' }, body: { allowedOrigins: ['not a domain'] }, headers: {} }, res)
+      expect(res.statusCode).toBe(400)
+
+      expect(updateProject).not.toHaveBeenCalled()
+    })
   })
 })

--- a/api/v1/projects/[projectId]/index.ts
+++ b/api/v1/projects/[projectId]/index.ts
@@ -1,7 +1,24 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { requireUser } from '../../../_lib/auth.js'
-import { getProjectMember, updateProjectName } from '../../../_lib/store.js'
+import { normalizeAllowedDomain } from '../../../_lib/origins.js'
+import { getProjectMember, updateProject } from '../../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
+
+const MAX_ALLOWED_ORIGINS = 50
+
+function parseAllowedOrigins(value: unknown): { domains: string[] } | { error: string } {
+  if (!Array.isArray(value)) return { error: 'allowedOrigins must be an array of domains' }
+  if (value.length > MAX_ALLOWED_ORIGINS) return { error: `allowedOrigins is limited to ${MAX_ALLOWED_ORIGINS} domains` }
+
+  const domains = new Set<string>()
+  for (const entry of value) {
+    if (typeof entry !== 'string') return { error: 'allowedOrigins entries must be strings' }
+    const domain = normalizeAllowedDomain(entry)
+    if (!domain) return { error: `allowedOrigins contains an invalid domain: "${entry.trim()}"` }
+    domains.add(domain)
+  }
+  return { domains: [...domains] }
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (handleOptions(req, res, ['PATCH', 'OPTIONS'])) return
@@ -13,17 +30,31 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const projectKey = getStringQuery(req.query.projectId)
   if (!projectKey) return jsonError(req, res, 400, 'Missing projectId')
 
-  const body = (req.body ?? {}) as { name?: unknown }
-  const name = typeof body.name === 'string' ? body.name.trim() : ''
-  if (!name) return jsonError(req, res, 400, 'Project name is required')
-  if (name.length > 80) return jsonError(req, res, 400, 'Project name must be 80 characters or fewer')
+  const body = (req.body ?? {}) as { name?: unknown; allowedOrigins?: unknown }
+  const patch: { name?: string; allowedOrigins?: string[] } = {}
+
+  if (body.allowedOrigins !== undefined) {
+    const parsed = parseAllowedOrigins(body.allowedOrigins)
+    if ('error' in parsed) return jsonError(req, res, 400, parsed.error)
+    patch.allowedOrigins = parsed.domains
+  }
+
+  // Name is required whenever it is present, and also when the request
+  // carries no allowedOrigins — that case is a plain rename, preserving the
+  // original PATCH contract.
+  if (body.name !== undefined || patch.allowedOrigins === undefined) {
+    const name = typeof body.name === 'string' ? body.name.trim() : ''
+    if (!name) return jsonError(req, res, 400, 'Project name is required')
+    if (name.length > 80) return jsonError(req, res, 400, 'Project name must be 80 characters or fewer')
+    patch.name = name
+  }
 
   try {
     const membership = await getProjectMember(user.userId, projectKey)
     if (!membership) return jsonError(req, res, 403, 'Forbidden')
     if (membership.role !== 'admin') return jsonError(req, res, 403, 'Admin role required')
 
-    const project = await updateProjectName(projectKey, name)
+    const project = await updateProject(projectKey, patch)
     if (!project) return jsonError(req, res, 404, 'Project not found')
 
     setCors(req, res, ['PATCH', 'OPTIONS'])

--- a/api/v1/public/comments.test.ts
+++ b/api/v1/public/comments.test.ts
@@ -94,6 +94,7 @@ describe('api/v1/public/comments', () => {
       publicKey: 'missing',
       slug: 'missing',
       name: 'missing',
+      allowedOrigins: [],
       createdAt: '',
       updatedAt: '',
     })
@@ -140,6 +141,7 @@ describe('api/v1/public/comments', () => {
       publicKey: 'demo-project',
       slug: 'demo-project',
       name: 'Demo',
+      allowedOrigins: [],
       createdAt: '',
       updatedAt: '',
     })
@@ -184,6 +186,7 @@ describe('api/v1/public/comments', () => {
       publicKey: 'demo-project',
       slug: 'demo-project',
       name: 'Demo',
+      allowedOrigins: [],
       createdAt: '',
       updatedAt: '',
     })
@@ -227,6 +230,71 @@ describe('api/v1/public/comments', () => {
       body: 'Hello',
       imageUrl: null,
       authorName: null,
+    })
+  })
+
+  describe('origin allowlist', () => {
+    const project = {
+      publicKey: 'demo-project',
+      slug: 'demo-project',
+      name: 'Demo',
+      allowedOrigins: ['example.com'],
+      createdAt: '',
+      updatedAt: '',
+    }
+    const postBody = {
+      projectKey: 'demo-project',
+      pageUrl: 'https://example.com',
+      selector: 'body',
+      x: 10,
+      y: 20,
+      body: 'Hello',
+    }
+
+    it('rejects POSTs from origins outside the allowlist', async () => {
+      vi.mocked(ensurePublicProject).mockResolvedValue(project)
+
+      const res = mockRes()
+      await call(mockReq({ headers: { origin: 'https://evil.com' }, body: postBody }), res)
+
+      expect(res.statusCode).toBe(403)
+      expect(createPublicComment).not.toHaveBeenCalled()
+    })
+
+    it('rejects POSTs without an Origin or Referer when the allowlist is set', async () => {
+      vi.mocked(ensurePublicProject).mockResolvedValue(project)
+
+      const res = mockRes()
+      await call(mockReq({ headers: {}, body: postBody }), res)
+
+      expect(res.statusCode).toBe(403)
+      expect(createPublicComment).not.toHaveBeenCalled()
+    })
+
+    it('accepts POSTs from an allowed subdomain', async () => {
+      vi.mocked(ensurePublicProject).mockResolvedValue(project)
+      vi.mocked(createPublicComment).mockResolvedValue({
+        id: 'comment-1',
+        projectId: 'demo-project',
+        pageUrl: 'https://example.com',
+        selector: 'body',
+        x: 10,
+        y: 20,
+        body: 'Hello',
+        reviewStatus: 'open',
+        implementationStatus: 'unassigned',
+        claimedByAgentId: null,
+        imageUrl: null,
+        authorName: null,
+        createdAt: '',
+        updatedAt: '',
+      })
+
+      const res = mockRes()
+      await call(mockReq({ headers: { origin: 'https://app.example.com' }, body: postBody }), res)
+
+      expect(res.statusCode).toBe(201)
+      expect(createPublicComment).toHaveBeenCalledOnce()
     })
   })
 

--- a/api/v1/public/comments.ts
+++ b/api/v1/public/comments.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { createPublicComment, deleteCommentById, deleteCommentsForProject, ensurePublicProject, listComments, updateReviewStatus } from '../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+import { getRequestHostname, isHostnameAllowed } from '../../_lib/origins.js'
 import type { ReviewStatus } from '../../_lib/status.js'
 import { getServiceSupabase } from '../../_lib/supabase.js'
 
@@ -173,7 +174,11 @@ async function handlePost(req: VercelRequest, res: VercelResponse) {
       }
     }
 
-    await ensurePublicProject(resolvedProjectKey)
+    const project = await ensurePublicProject(resolvedProjectKey)
+
+    if (!isHostnameAllowed(getRequestHostname(req), project.allowedOrigins)) {
+      return jsonError(req, res, 403, 'Origin is not in this project\'s domain allowlist')
+    }
 
     let imageUrl: string | null = null
     if (imageBase64 && imageMimeType) {


### PR DESCRIPTION
- Reject widget comments whose page origin isn't on the project's domain allowlist, returning a 403 instead of saving them
- Keep the current behavior as the default — an empty allowlist accepts feedback from any domain
- Match subdomains automatically, so allowing example.com also covers app.example.com
- Let project admins set the allowlist through the existing project update endpoint, with domains cleaned up and de-duplicated before saving
- Cover the new matching rules and endpoint validation with tests at 100% diff coverage