### PR TITLE
Store selected text on comments

### DIFF
--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -8,9 +8,11 @@ import {
   claimProject,
   createInvite,
   createNotification,
+  createPublicComment,
   declineInvite,
   ensurePublicProject,
   findUserIdByEmail,
+  listComments,
   getProjectMember,
   isProjectKeyAvailable,
   isProjectMember,
@@ -696,5 +698,119 @@ describe('findUserIdByEmail', () => {
       status: 200, headers: { 'content-type': 'application/json' },
     })) as never
     expect(await findUserIdByEmail('x@y.z')).toBeNull()
+  })
+})
+
+describe('public comments — selectedText column', () => {
+  function buildCommentRow(imageUrl: string | null, selectedText: string | null = null) {
+    return {
+      id: 'c1',
+      project_id: 'proj',
+      url: 'https://ex.com',
+      x: 1,
+      y: 2,
+      element: 'body',
+      comment: 'hi',
+      status: 'pending',
+      implementation_status: null,
+      claimed_by_agent_id: null,
+      image_url: imageUrl,
+      selected_text: selectedText,
+      author_name: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: null,
+    }
+  }
+
+  function buildInsertSupabase(returnedRow: ReturnType<typeof buildCommentRow>) {
+    const insert = vi.fn((rows: Array<Record<string, unknown>>) => {
+      void rows
+      return {
+        select: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve({ data: returnedRow, error: null })),
+        })),
+      }
+    })
+    return { supabase: { from: vi.fn(() => ({ insert })) }, insert }
+  }
+
+  it('stores selectedText in its own column and maps it back out', async () => {
+    const row = buildCommentRow(null, 'quoted words')
+    const { supabase, insert } = buildInsertSupabase(row)
+    vi.mocked(getServiceSupabase).mockReturnValue(supabase as never)
+
+    const comment = await createPublicComment({
+      projectKey: 'proj',
+      pageUrl: 'https://ex.com',
+      x: 1,
+      y: 2,
+      selector: 'body',
+      body: 'hi',
+      selectedText: 'quoted words',
+    })
+
+    expect(insert.mock.calls[0][0][0].selected_text).toBe('quoted words')
+    expect(insert.mock.calls[0][0][0].image_url).toBeNull()
+    expect(comment.selectedText).toBe('quoted words')
+    expect(comment.imageUrl).toBeNull()
+  })
+
+  it('stores an image URL with selected_text left null', async () => {
+    const row = buildCommentRow('https://cdn.example/img.png')
+    const { supabase, insert } = buildInsertSupabase(row)
+    vi.mocked(getServiceSupabase).mockReturnValue(supabase as never)
+
+    const comment = await createPublicComment({
+      projectKey: 'proj',
+      pageUrl: 'https://ex.com',
+      x: 1,
+      y: 2,
+      selector: 'body',
+      body: 'hi',
+      imageUrl: 'https://cdn.example/img.png',
+    })
+
+    expect(insert.mock.calls[0][0][0].image_url).toBe('https://cdn.example/img.png')
+    expect(insert.mock.calls[0][0][0].selected_text).toBeNull()
+    expect(comment.imageUrl).toBe('https://cdn.example/img.png')
+    expect(comment.selectedText).toBeNull()
+  })
+
+  it('stores nulls when there is neither selection nor image', async () => {
+    const row = buildCommentRow(null)
+    const { supabase, insert } = buildInsertSupabase(row)
+    vi.mocked(getServiceSupabase).mockReturnValue(supabase as never)
+
+    const comment = await createPublicComment({
+      projectKey: 'proj',
+      pageUrl: 'https://ex.com',
+      x: 1,
+      y: 2,
+      selector: 'body',
+      body: 'hi',
+    })
+
+    expect(insert.mock.calls[0][0][0].image_url).toBeNull()
+    expect(insert.mock.calls[0][0][0].selected_text).toBeNull()
+    expect(comment.imageUrl).toBeNull()
+    expect(comment.selectedText).toBeNull()
+  })
+
+  it('listComments maps selected_text rows and leaves others alone', async () => {
+    const rows = [buildCommentRow(null, 'snippet'), buildCommentRow(null)]
+    const query: { eq: ReturnType<typeof vi.fn>; order: ReturnType<typeof vi.fn> } = {
+      eq: vi.fn(() => query),
+      order: vi.fn(() => Promise.resolve({ data: rows, error: null })),
+    }
+    const supabase = {
+      from: vi.fn(() => ({ select: vi.fn(() => ({ eq: vi.fn(() => query) })) })),
+    }
+    vi.mocked(getServiceSupabase).mockReturnValue(supabase as never)
+
+    const comments = await listComments('proj')
+    expect(comments[0].selectedText).toBe('snippet')
+    expect(comments[0].imageUrl).toBeNull()
+    expect(comments[1].selectedText).toBeNull()
+    expect(comments[1].imageUrl).toBeNull()
   })
 })

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -22,6 +22,7 @@ type CommentRow = {
   implementation_status: ImplementationStatus | null
   claimed_by_agent_id: string | null
   image_url: string | null
+  selected_text: string | null
   author_name: string | null
   created_at: string
   updated_at: string | null
@@ -99,6 +100,7 @@ function mapComment(row: CommentRow) {
     implementationStatus: row.implementation_status || 'unassigned',
     claimedByAgentId: row.claimed_by_agent_id,
     imageUrl: row.image_url || null,
+    selectedText: row.selected_text || null,
     authorName: row.author_name || null,
     createdAt: row.created_at,
     updatedAt: row.updated_at || row.created_at,
@@ -498,6 +500,7 @@ export async function createPublicComment(input: {
   selector: string
   body: string
   imageUrl?: string | null
+  selectedText?: string | null
   authorName?: string | null
 }) {
   const supabase = getSupabase()
@@ -514,10 +517,11 @@ export async function createPublicComment(input: {
       implementation_status: 'unassigned',
       created_by: 'public',
       image_url: input.imageUrl ?? null,
+      selected_text: input.selectedText ?? null,
       author_name: input.authorName ?? null,
       updated_at: new Date().toISOString(),
     }] as never)
-    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, author_name, created_at, updated_at')
+    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, selected_text, author_name, created_at, updated_at')
     .single()
 
   if (error) throw new Error(error.message)
@@ -532,7 +536,7 @@ export async function listComments(projectKey: string, filters: {
   const supabase = getSupabase()
   let query = supabase
     .from('comments')
-    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, author_name, created_at, updated_at')
+    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, selected_text, author_name, created_at, updated_at')
     .eq('project_id', projectKey)
 
   if (filters.pageUrl) query = query.eq('url', filters.pageUrl)
@@ -548,7 +552,7 @@ export async function listAcceptedCommentsForPage(projectKey: string, pageUrl: s
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('comments')
-    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, author_name, created_at, updated_at')
+    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, selected_text, author_name, created_at, updated_at')
     .eq('project_id', projectKey)
     .eq('url', pageUrl)
     .eq('status', 'approved')
@@ -564,7 +568,7 @@ export async function listAcceptedCommentsByIds(projectKey: string, commentIds: 
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('comments')
-    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, author_name, created_at, updated_at')
+    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, selected_text, author_name, created_at, updated_at')
     .eq('project_id', projectKey)
     .eq('status', 'approved')
     .in('id', commentIds)
@@ -608,7 +612,7 @@ export async function getComment(commentId: string) {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('comments')
-    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, author_name, created_at, updated_at')
+    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, selected_text, author_name, created_at, updated_at')
     .eq('id', commentId)
     .maybeSingle()
 
@@ -625,7 +629,7 @@ export async function updateReviewStatus(commentId: string, reviewStatus: Review
       updated_at: new Date().toISOString(),
     })
     .eq('id', commentId)
-    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, author_name, created_at, updated_at')
+    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, selected_text, author_name, created_at, updated_at')
     .single()
 
   if (error) throw new Error(error.message)
@@ -648,7 +652,7 @@ export async function updateImplementationStatus(commentId: string, patch: {
     .from('comments')
     .update(updates)
     .eq('id', commentId)
-    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, author_name, created_at, updated_at')
+    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, selected_text, author_name, created_at, updated_at')
     .single()
 
   if (error) throw new Error(error.message)
@@ -774,7 +778,7 @@ export async function listCommentsForShare(share: {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('comments')
-    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, author_name, created_at, updated_at')
+    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, selected_text, author_name, created_at, updated_at')
     .in('id', commentIds)
     .order('created_at', { ascending: false })
 
@@ -786,7 +790,7 @@ export async function listAcceptedCommentsForProject(projectKey: string) {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('comments')
-    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, author_name, created_at, updated_at')
+    .select('id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, selected_text, author_name, created_at, updated_at')
     .eq('project_id', projectKey)
     .eq('status', 'approved')
     .order('created_at', { ascending: false })

--- a/api/v1/public/comments.test.ts
+++ b/api/v1/public/comments.test.ts
@@ -109,6 +109,7 @@ describe('api/v1/public/comments', () => {
       implementationStatus: 'unassigned',
       claimedByAgentId: null,
       imageUrl: null,
+      selectedText: null,
       authorName: null,
       createdAt: '',
       updatedAt: '',
@@ -155,6 +156,7 @@ describe('api/v1/public/comments', () => {
       implementationStatus: 'unassigned',
       claimedByAgentId: null,
       imageUrl: 'https://cdn.example/img.png',
+      selectedText: null,
       authorName: null,
       createdAt: '',
       updatedAt: '',
@@ -199,6 +201,7 @@ describe('api/v1/public/comments', () => {
       implementationStatus: 'unassigned',
       claimedByAgentId: null,
       imageUrl: null,
+      selectedText: null,
       authorName: null,
       createdAt: '',
       updatedAt: '',
@@ -226,7 +229,115 @@ describe('api/v1/public/comments', () => {
       y: 20,
       body: 'Hello',
       imageUrl: null,
+      selectedText: null,
       authorName: null,
+    })
+  })
+
+  it('returns 400 for a POST with no body at all', async () => {
+    const res = mockRes()
+    await call(mockReq({ body: undefined }), res)
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toMatchObject({ error: 'Missing required fields: projectKey, pageUrl, selector, body' })
+  })
+
+  describe('selectedText', () => {
+    function mockCreateOk() {
+      vi.mocked(ensurePublicProject).mockResolvedValue({
+        publicKey: 'demo-project',
+        slug: 'demo-project',
+        name: 'Demo',
+        createdAt: '',
+        updatedAt: '',
+      })
+      vi.mocked(createPublicComment).mockResolvedValue({
+        id: 'comment-1',
+        projectId: 'demo-project',
+        pageUrl: 'https://example.com',
+        selector: 'body',
+        x: 10,
+        y: 20,
+        body: 'Hello',
+        reviewStatus: 'open',
+        implementationStatus: 'unassigned',
+        claimedByAgentId: null,
+        imageUrl: null,
+        selectedText: 'quoted words',
+        authorName: null,
+        createdAt: '',
+        updatedAt: '',
+      })
+    }
+
+    const baseBody = {
+      projectKey: 'demo-project',
+      pageUrl: 'https://example.com',
+      selector: 'body',
+      x: 10,
+      y: 20,
+      body: 'Hello',
+    }
+
+    it('passes a trimmed selectedText through to createPublicComment', async () => {
+      mockCreateOk()
+      const res = mockRes()
+      await call(mockReq({ body: { ...baseBody, selectedText: '  quoted words  ' } }), res)
+
+      expect(res.statusCode).toBe(201)
+      expect(vi.mocked(createPublicComment).mock.calls[0]?.[0].selectedText).toBe('quoted words')
+    })
+
+    it('rejects non-string selectedText', async () => {
+      const res = mockRes()
+      await call(mockReq({ body: { ...baseBody, selectedText: 42 } }), res)
+      expect(res.statusCode).toBe(400)
+      expect(res.body).toMatchObject({ error: 'selectedText must be a string' })
+    })
+
+    it('rejects selectedText over 2000 characters', async () => {
+      const res = mockRes()
+      await call(mockReq({ body: { ...baseBody, selectedText: 'a'.repeat(2001) } }), res)
+      expect(res.statusCode).toBe(400)
+      expect(res.body).toMatchObject({ error: 'selectedText must be 2000 characters or fewer' })
+    })
+
+    it('treats whitespace-only and null selectedText as absent', async () => {
+      mockCreateOk()
+      const res = mockRes()
+      await call(mockReq({ body: { ...baseBody, selectedText: '   ' } }), res)
+      expect(res.statusCode).toBe(201)
+      expect(vi.mocked(createPublicComment).mock.calls[0]?.[0].selectedText).toBeNull()
+
+      const res2 = mockRes()
+      await call(mockReq({ body: { ...baseBody, selectedText: null } }), res2)
+      expect(res2.statusCode).toBe(201)
+      expect(vi.mocked(createPublicComment).mock.calls[1]?.[0].selectedText).toBeNull()
+    })
+
+    it('stores selectedText and an uploaded image independently', async () => {
+      const upload = vi.fn().mockResolvedValue({ error: null })
+      const getPublicUrl = vi.fn().mockReturnValue({ data: { publicUrl: 'https://cdn.example/img.png' } })
+      vi.mocked(getServiceSupabase).mockReturnValue({
+        storage: { from: () => ({ upload, getPublicUrl }) },
+      } as never)
+      mockCreateOk()
+
+      const res = mockRes()
+      await call(mockReq({
+        body: {
+          ...baseBody,
+          selectedText: 'quoted words',
+          imageBase64: Buffer.from('png-bytes').toString('base64'),
+          imageMimeType: 'image/png',
+        },
+      }), res)
+
+      expect(res.statusCode).toBe(201)
+      expect(upload).toHaveBeenCalledOnce()
+      expect(vi.mocked(createPublicComment).mock.calls[0]?.[0]).toMatchObject({
+        imageUrl: 'https://cdn.example/img.png',
+        selectedText: 'quoted words',
+      })
     })
   })
 
@@ -298,6 +409,7 @@ describe('api/v1/public/comments', () => {
       implementationStatus: 'unassigned',
       claimedByAgentId: null,
       imageUrl: null,
+      selectedText: null,
       authorName: null,
       createdAt: '',
       updatedAt: '',

--- a/api/v1/public/comments.ts
+++ b/api/v1/public/comments.ts
@@ -120,6 +120,7 @@ async function handlePatch(req: VercelRequest, res: VercelResponse) {
 
 const ALLOWED_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif'])
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024 // 5 MB
+const MAX_SELECTED_TEXT_CHARS = 2000
 
 async function uploadImage(projectKey: string, mimeType: string, base64Data: string): Promise<string> {
   const buffer = Buffer.from(base64Data, 'base64')
@@ -141,7 +142,7 @@ async function uploadImage(projectKey: string, mimeType: string, base64Data: str
 
 async function handlePost(req: VercelRequest, res: VercelResponse) {
   try {
-    const { projectKey, projectId, pageUrl, selector, x, y, body, imageBase64, imageMimeType, authorName } = req.body ?? {}
+    const { projectKey, projectId, pageUrl, selector, x, y, body, imageBase64, imageMimeType, authorName, selectedText } = req.body ?? {}
     const resolvedProjectKey = typeof projectKey === 'string' ? projectKey : projectId
 
     if (!resolvedProjectKey || !pageUrl || !selector || !body) {
@@ -162,6 +163,18 @@ async function handlePost(req: VercelRequest, res: VercelResponse) {
         return jsonError(req, res, 400, 'authorName must be 80 characters or fewer')
       }
       resolvedAuthorName = trimmed || null
+    }
+
+    let resolvedSelectedText: string | null = null
+    if (selectedText !== undefined && selectedText !== null) {
+      if (typeof selectedText !== 'string') {
+        return jsonError(req, res, 400, 'selectedText must be a string')
+      }
+      const trimmed = selectedText.trim()
+      if (trimmed.length > MAX_SELECTED_TEXT_CHARS) {
+        return jsonError(req, res, 400, `selectedText must be ${MAX_SELECTED_TEXT_CHARS} characters or fewer`)
+      }
+      resolvedSelectedText = trimmed || null
     }
 
     if (imageBase64 !== undefined) {
@@ -188,6 +201,7 @@ async function handlePost(req: VercelRequest, res: VercelResponse) {
       y,
       body,
       imageUrl,
+      selectedText: resolvedSelectedText,
       authorName: resolvedAuthorName,
     })
 

--- a/db/migrations/0005_lush_wonder_man.sql
+++ b/db/migrations/0005_lush_wonder_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "comments" ADD COLUMN "selected_text" text;

--- a/db/migrations/meta/0005_snapshot.json
+++ b/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1108 @@
+{
+  "id": "355fe202-e340-426a-8138-bb2a8bc98495",
+  "prevId": "1247c040-5b16-428e-b563-ed9fbabecbff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_presence_share_seen_idx": {
+          "name": "agent_presence_share_seen_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_presence_share_id_feedback_shares_id_fk": {
+          "name": "agent_presence_share_id_feedback_shares_id_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_presence_share_id_agent_id_pk": {
+          "name": "agent_presence_share_id_agent_id_pk",
+          "columns": [
+            "share_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "implementation_status": {
+          "name": "implementation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unassigned'"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_text": {
+          "name": "selected_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_project_created_idx": {
+          "name": "comments_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_project_url_idx": {
+          "name": "comments_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_project_status_idx": {
+          "name": "comments_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "implementation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_events": {
+      "name": "feedback_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feedback_events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_events_share_id_idx": {
+          "name": "feedback_events_share_id_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_events_share_id_feedback_shares_id_fk": {
+          "name": "feedback_events_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_events",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_events_comment_id_comments_id_fk": {
+          "name": "feedback_events_comment_id_comments_id_fk",
+          "tableFrom": "feedback_events",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_operation_keys": {
+      "name": "feedback_operation_keys",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_event_id": {
+          "name": "feedback_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_operation_keys_share_id_feedback_shares_id_fk": {
+          "name": "feedback_operation_keys_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_operation_keys_feedback_event_id_feedback_events_id_fk": {
+          "name": "feedback_operation_keys_feedback_event_id_feedback_events_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "tableTo": "feedback_events",
+          "columnsFrom": [
+            "feedback_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_operation_keys_share_id_agent_id_idempotency_key_pk": {
+          "name": "feedback_operation_keys_share_id_agent_id_idempotency_key_pk",
+          "columns": [
+            "share_id",
+            "agent_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_share_items": {
+      "name": "feedback_share_items",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_share_items_share_id_feedback_shares_id_fk": {
+          "name": "feedback_share_items_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_share_items",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_share_items_comment_id_comments_id_fk": {
+          "name": "feedback_share_items_comment_id_comments_id_fk",
+          "tableFrom": "feedback_share_items",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_share_items_share_id_comment_id_pk": {
+          "name": "feedback_share_items_share_id_comment_id_pk",
+          "columns": [
+            "share_id",
+            "comment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_shares": {
+      "name": "feedback_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_page_url": {
+          "name": "scope_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_shares_one_project_scope_per_project": {
+          "name": "feedback_shares_one_project_scope_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "scope_type = 'project' and revoked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_shares_project_id_projects_public_key_fk": {
+          "name": "feedback_shares_project_id_projects_public_key_fk",
+          "tableFrom": "feedback_shares",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_shares_slug_unique": {
+          "name": "feedback_shares_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feedback_shares_scope_type_check": {
+          "name": "feedback_shares_scope_type_check",
+          "value": "\"feedback_shares\".\"scope_type\" in ('page', 'selection', 'project')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_kind_check": {
+          "name": "notifications_kind_check",
+          "value": "\"notifications\".\"kind\" in ('invite.received', 'invite.accepted', 'invite.declined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_invites": {
+      "name": "project_invites",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invites_email_idx": {
+          "name": "project_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invites_project_key_projects_public_key_fk": {
+          "name": "project_invites_project_key_projects_public_key_fk",
+          "tableFrom": "project_invites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_invites_project_key_email_pk": {
+          "name": "project_invites_project_key_email_pk",
+          "columns": [
+            "project_key",
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_invites_role_check": {
+          "name": "project_invites_role_check",
+          "value": "\"project_invites\".\"role\" in ('admin', 'member')"
+        },
+        "project_invites_email_lower_check": {
+          "name": "project_invites_email_lower_check",
+          "value": "\"project_invites\".\"email\" = lower(\"project_invites\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_key_projects_public_key_fk": {
+          "name": "project_members_project_key_projects_public_key_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_key_user_id_pk": {
+          "name": "project_members_project_key_user_id_pk",
+          "columns": [
+            "project_key",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_members_role_check": {
+          "name": "project_members_role_check",
+          "value": "\"project_members\".\"role\" in ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_repo_configs": {
+      "name": "project_repo_configs",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_command": {
+          "name": "dev_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command": {
+          "name": "build_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instructions": {
+          "name": "agent_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_repo_configs_project_key_projects_public_key_fk": {
+          "name": "project_repo_configs_project_key_projects_public_key_fk",
+          "tableFrom": "project_repo_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claimable": {
+          "name": "claimable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1781014285688,
       "tag": "0004_enable_rls",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1781262472950,
+      "tag": "0005_lush_wonder_man",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -103,6 +103,7 @@ export const comments = pgTable(
     claimedByAgentId: text('claimed_by_agent_id'),
     createdBy: text('created_by').default('public'),
     imageUrl: text('image_url'),
+    selectedText: text('selected_text'),
     authorName: text('author_name'),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),


### PR DESCRIPTION
- Add a nullable selected_text column to comments via a Drizzle migration, so feedback can anchor to a quoted passage of text instead of a screenshot
- Accept selectedText when posting a public comment, validated as a trimmed string capped at 2000 characters
- Return selectedText alongside the existing image URL wherever comments are read
- Keep text and screenshot attachments independent — a comment can carry either or both