### PR TITLE
Capture text selections as feedback anchors in the widget

### DIFF
--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -3063,4 +3063,179 @@ describe('<FeedbackWidget />', () => {
       }
     })
   })
+
+  describe('text selection feedback', () => {
+    function stubCaretText(node: Node | null) {
+      ;(document as unknown as Record<string, unknown>).caretPositionFromPoint =
+        () => (node ? { offsetNode: node } : null)
+    }
+
+    function stubRangeRects() {
+      vi.spyOn(document, 'createRange').mockReturnValue({
+        selectNodeContents: vi.fn(),
+        getClientRects: () => [{ left: 0, right: 800, top: 0, bottom: 600 }],
+      } as never)
+    }
+
+    afterEach(() => {
+      delete (document as unknown as Record<string, unknown>).caretPositionFromPoint
+      document.querySelectorAll('[data-test-target]').forEach((n) => n.remove())
+    })
+
+    async function mountSelecting() {
+      const target = document.createElement('p')
+      target.setAttribute('data-test-target', '')
+      target.textContent = 'Quoted snippet lives here'
+      document.body.appendChild(target)
+
+      await waitFor(() => {
+        if (document.querySelectorAll('[data-fw]').length === 0) {
+          throw new Error('widget root not mounted yet')
+        }
+      })
+      await act(async () => {
+        fireEvent.keyDown(window, { key: 'c' })
+      })
+      return target
+    }
+
+    it('switches the cursor to text over glyphs and back to crosshair elsewhere', async () => {
+      mockFetch()
+      render(<FeedbackWidget projectId="p" apiBase="https://x.example/api" />)
+      const target = await mountSelecting()
+      expect(document.body.style.cursor).toBe('crosshair')
+
+      stubCaretText(target.firstChild)
+      stubRangeRects()
+      await act(async () => {
+        fireEvent.mouseMove(target, { clientX: 40, clientY: 40 })
+      })
+      expect(document.body.style.cursor).toBe('text')
+
+      stubCaretText(null)
+      await act(async () => {
+        fireEvent.mouseMove(target, { clientX: 41, clientY: 41 })
+      })
+      expect(document.body.style.cursor).toBe('crosshair')
+
+      // Moving over the widget's own UI resets the text-hover state too.
+      const widgetRoot = document.querySelector('[data-fw]')!
+      await act(async () => {
+        fireEvent.mouseMove(widgetRoot, { clientX: 42, clientY: 42 })
+      })
+      expect(document.body.style.cursor).toBe('crosshair')
+    })
+
+    it('captures the selected text instead of a screenshot and sends it', async () => {
+      const calls = mockFetch(() => new Response(
+        JSON.stringify({ id: 'c-9', selectedText: 'Quoted snippet' }),
+        { status: 200 },
+      ))
+      localStorage.setItem('fw-crrt-author-name', 'Sel Tester')
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+      const target = await mountSelecting()
+
+      const removeAllRanges = vi.fn()
+      vi.spyOn(window, 'getSelection').mockReturnValue({
+        rangeCount: 1,
+        isCollapsed: false,
+        toString: () => 'Quoted snippet',
+        getRangeAt: () => ({ commonAncestorContainer: target.firstChild }),
+        removeAllRanges,
+      } as never)
+
+      await act(async () => {
+        target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 60, clientY: 60 }))
+      })
+
+      expect(removeAllRanges).toHaveBeenCalled()
+
+      // The commenting popover quotes the selection and skips the screenshot row.
+      await waitFor(() => {
+        const quote = document.querySelector('[data-fw-selected-text]')
+        expect(quote?.textContent).toContain('Quoted snippet')
+      })
+      expect(document.body.textContent).not.toContain('Screenshot')
+
+      const textarea = document.querySelector<HTMLTextAreaElement>('textarea')!
+      fireEvent.change(textarea, { target: { value: 'fix this copy' } })
+      const send = document.querySelector<HTMLButtonElement>('button[aria-label="Send"]')!
+      fireEvent.click(send)
+
+      await waitFor(() => {
+        const post = calls.find((c) => c.init?.method === 'POST')
+        expect(post).toBeDefined()
+        const body = JSON.parse(String(post?.init?.body))
+        expect(body.selectedText).toBe('Quoted snippet')
+        expect(body.imageBase64).toBeUndefined()
+      })
+
+      // After a successful send the sidebar card quotes the selection too.
+      await waitFor(() => {
+        const quotes = Array.from(document.querySelectorAll('[data-fw-selected-text]'))
+        expect(quotes.some((q) => q.textContent?.includes('Quoted snippet'))).toBe(true)
+        expect(document.body.textContent).toContain('fix this copy')
+      })
+    })
+
+    it('sends without imageBase64 when the screenshot was removed and nothing is selected', async () => {
+      const calls = mockFetch()
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+
+      const { textarea, getSendButton } = await enterCommentingMode()
+      fireEvent.change(textarea, { target: { value: 'no attachments' } })
+
+      const removeBtn = await waitFor(() => {
+        const btn = document.querySelector<HTMLButtonElement>('button[aria-label="Remove screenshot"]')
+        if (!btn) throw new Error('remove-screenshot button not mounted yet')
+        return btn
+      })
+      await act(async () => { fireEvent.click(removeBtn) })
+      fireEvent.click(getSendButton())
+
+      await waitFor(() => {
+        const post = calls.find((c) => c.init?.method === 'POST')
+        expect(post).toBeDefined()
+        const body = JSON.parse(String(post?.init?.body))
+        expect(body.imageBase64).toBeUndefined()
+        expect(body.selectedText).toBeUndefined()
+      })
+    })
+
+    it('quotes the selection on the pin tooltip and detail popover for fetched comments', async () => {
+      const pageUrl = window.location.href.split('#')[0]
+      mockFetch(undefined, () => new Response(JSON.stringify([
+        {
+          id: 'comment-q',
+          projectId: 'proj',
+          pageUrl,
+          x: 20,
+          y: 30,
+          selector: 'body',
+          body: 'about that wording',
+          reviewStatus: 'open',
+          selectedText: 'lorem ipsum',
+          createdAt: '2026-04-22T00:00:00Z',
+        },
+      ]), { status: 200 }))
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+
+      const pin = await waitFor(() => {
+        const el = document.querySelector<HTMLDivElement>('[data-fw-pin]')
+        if (!el) throw new Error('pin not mounted yet')
+        return el
+      })
+
+      await act(async () => { fireEvent.mouseEnter(pin) })
+      await waitFor(() => {
+        expect(document.querySelector('[data-fw-selected-text]')?.textContent).toContain('lorem ipsum')
+      })
+      await act(async () => { fireEvent.mouseLeave(pin) })
+
+      await act(async () => { fireEvent.click(pin) })
+      await waitFor(() => {
+        expect(document.querySelector('[data-fw-selected-text]')?.textContent).toContain('lorem ipsum')
+      })
+    })
+  })
 })

--- a/src/__tests__/textSelection.test.ts
+++ b/src/__tests__/textSelection.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  MAX_SELECTED_TEXT_LENGTH,
+  clearSelection,
+  getSelectionSnapshot,
+  isTextAtPoint,
+} from '../lib/textSelection'
+
+// happy-dom doesn't implement the caret APIs — install own properties per test.
+const doc = document as unknown as Record<string, unknown>
+
+function stubRangeRects(rects: Array<{ left: number; right: number; top: number; bottom: number }>) {
+  vi.spyOn(document, 'createRange').mockReturnValue({
+    selectNodeContents: vi.fn(),
+    getClientRects: () => rects,
+  } as never)
+}
+
+function textNode(content: string) {
+  return document.createTextNode(content)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete doc.caretPositionFromPoint
+  delete doc.caretRangeFromPoint
+})
+
+describe('isTextAtPoint', () => {
+  it('returns true when the point falls inside a text node rect', () => {
+    doc.caretPositionFromPoint = () => ({ offsetNode: textNode('hello world') })
+    stubRangeRects([{ left: 0, right: 100, top: 0, bottom: 20 }])
+    expect(isTextAtPoint(50, 10)).toBe(true)
+  })
+
+  it('returns false when the point misses every rect (each edge)', () => {
+    doc.caretPositionFromPoint = () => ({ offsetNode: textNode('hello world') })
+    stubRangeRects([
+      { left: 60, right: 100, top: 0, bottom: 20 }, // x < left
+      { left: 0, right: 40, top: 0, bottom: 20 }, // x > right
+      { left: 0, right: 100, top: 15, bottom: 20 }, // y < top
+      { left: 0, right: 100, top: 0, bottom: 5 }, // y > bottom
+    ])
+    expect(isTextAtPoint(50, 10)).toBe(false)
+  })
+
+  it('returns false when the text node has no rects at all', () => {
+    doc.caretPositionFromPoint = () => ({ offsetNode: textNode('hello') })
+    stubRangeRects([])
+    expect(isTextAtPoint(50, 10)).toBe(false)
+  })
+
+  it('returns false when caretPositionFromPoint yields nothing', () => {
+    doc.caretPositionFromPoint = () => null
+    expect(isTextAtPoint(5, 5)).toBe(false)
+  })
+
+  it('returns false for non-text nodes', () => {
+    doc.caretPositionFromPoint = () => ({ offsetNode: document.createElement('div') })
+    expect(isTextAtPoint(5, 5)).toBe(false)
+  })
+
+  it('returns false for whitespace-only and null text content', () => {
+    doc.caretPositionFromPoint = () => ({ offsetNode: textNode('   ') })
+    expect(isTextAtPoint(5, 5)).toBe(false)
+
+    doc.caretPositionFromPoint = () => ({ offsetNode: { nodeType: Node.TEXT_NODE, textContent: null } })
+    expect(isTextAtPoint(5, 5)).toBe(false)
+  })
+
+  it('falls back to caretRangeFromPoint when caretPositionFromPoint is unavailable', () => {
+    doc.caretPositionFromPoint = undefined
+    doc.caretRangeFromPoint = () => ({ startContainer: textNode('fallback text') })
+    stubRangeRects([{ left: 0, right: 100, top: 0, bottom: 20 }])
+    expect(isTextAtPoint(50, 10)).toBe(true)
+
+    doc.caretRangeFromPoint = () => null
+    expect(isTextAtPoint(50, 10)).toBe(false)
+  })
+
+  it('returns false when neither caret API exists', () => {
+    doc.caretPositionFromPoint = undefined
+    doc.caretRangeFromPoint = undefined
+    expect(isTextAtPoint(5, 5)).toBe(false)
+  })
+})
+
+describe('getSelectionSnapshot', () => {
+  function stubSelection(sel: unknown) {
+    vi.spyOn(window, 'getSelection').mockReturnValue(sel as never)
+  }
+
+  function fakeSelection(overrides: Record<string, unknown> = {}) {
+    const container = document.createElement('p')
+    document.body.appendChild(container)
+    return {
+      rangeCount: 1,
+      isCollapsed: false,
+      toString: () => 'picked text',
+      getRangeAt: () => ({ commonAncestorContainer: container }),
+      ...overrides,
+    }
+  }
+
+  afterEach(() => {
+    document.querySelectorAll('p, [data-fw]').forEach((n) => n.remove())
+  })
+
+  it('returns null when there is no selection object', () => {
+    stubSelection(null)
+    expect(getSelectionSnapshot('data-fw')).toBeNull()
+  })
+
+  it('returns null for empty or collapsed selections', () => {
+    stubSelection(fakeSelection({ rangeCount: 0 }))
+    expect(getSelectionSnapshot('data-fw')).toBeNull()
+
+    stubSelection(fakeSelection({ isCollapsed: true }))
+    expect(getSelectionSnapshot('data-fw')).toBeNull()
+  })
+
+  it('returns null for whitespace-only selections', () => {
+    stubSelection(fakeSelection({ toString: () => '  \n ' }))
+    expect(getSelectionSnapshot('data-fw')).toBeNull()
+  })
+
+  it('anchors to the common ancestor element and trims the text', () => {
+    stubSelection(fakeSelection({ toString: () => '  picked text  ' }))
+    const snap = getSelectionSnapshot('data-fw')
+    expect(snap?.text).toBe('picked text')
+    expect(snap?.element.tagName).toBe('P')
+  })
+
+  it('resolves a text-node ancestor through its parent element', () => {
+    const container = document.createElement('p')
+    container.textContent = 'inner words'
+    document.body.appendChild(container)
+    stubSelection(fakeSelection({
+      getRangeAt: () => ({ commonAncestorContainer: container.firstChild }),
+      toString: () => 'inner words',
+    }))
+    const snap = getSelectionSnapshot('data-fw')
+    expect(snap?.text).toBe('inner words')
+    expect(snap?.element).toBe(container)
+  })
+
+  it('returns null when the text node has no parent element', () => {
+    stubSelection(fakeSelection({
+      getRangeAt: () => ({ commonAncestorContainer: document.createTextNode('orphan') }),
+      toString: () => 'orphan',
+    }))
+    expect(getSelectionSnapshot('data-fw')).toBeNull()
+  })
+
+  it('ignores selections inside the widget UI', () => {
+    const widget = document.createElement('div')
+    widget.setAttribute('data-fw', '')
+    const inner = document.createElement('span')
+    widget.appendChild(inner)
+    document.body.appendChild(widget)
+    stubSelection(fakeSelection({ getRangeAt: () => ({ commonAncestorContainer: inner }) }))
+    expect(getSelectionSnapshot('data-fw')).toBeNull()
+  })
+
+  it('caps the captured text at the maximum length', () => {
+    stubSelection(fakeSelection({ toString: () => 'x'.repeat(MAX_SELECTED_TEXT_LENGTH + 500) }))
+    const snap = getSelectionSnapshot('data-fw')
+    expect(snap?.text.length).toBe(MAX_SELECTED_TEXT_LENGTH)
+  })
+})
+
+describe('clearSelection', () => {
+  it('removes all ranges from the current selection', () => {
+    const removeAllRanges = vi.fn()
+    vi.spyOn(window, 'getSelection').mockReturnValue({ removeAllRanges } as never)
+    clearSelection()
+    expect(removeAllRanges).toHaveBeenCalledOnce()
+  })
+
+  it('is a no-op when there is no selection object', () => {
+    vi.spyOn(window, 'getSelection').mockReturnValue(null)
+    expect(() => clearSelection()).not.toThrow()
+  })
+})

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { X, SlidersHorizontal, Check } from 'lucide-react'
 import { getSelector } from '../../lib/getSelector'
 import { useScreenshotCapture } from '../../lib/screenshotCapture'
+import { clearSelection, getSelectionSnapshot, isTextAtPoint } from '../../lib/textSelection'
 import { AgentBridgeModal } from '../AgentBridgeModal'
 import type { ClickTarget, Comment, FeedbackWidgetProps, Mode, ReviewStatus } from './types'
 import { AUTHOR_NAME_KEY, COMMENT_CUTOFF, CRRT_CARROT_LOGO_URL, PIN_GRADIENT, WIDGET_ATTR } from './constants'
@@ -29,6 +30,34 @@ function getElementFixedPos(
   } catch {
     return null
   }
+}
+
+// Google-Docs-style quote chip shown wherever a comment anchors to a text
+// selection instead of a screenshot.
+function SelectedTextQuote({ text, style }: { text: string; style?: React.CSSProperties }) {
+  return (
+    <div
+      data-fw-selected-text
+      style={{
+        borderLeft: '3px solid #E8853D',
+        background: 'rgba(232, 133, 61, 0.07)',
+        borderRadius: '0 6px 6px 0',
+        padding: '6px 10px',
+        fontSize: 12.5,
+        lineHeight: 1.5,
+        color: '#C9C4BC',
+        fontStyle: 'italic',
+        wordBreak: 'break-word',
+        display: '-webkit-box',
+        WebkitLineClamp: 3,
+        WebkitBoxOrient: 'vertical',
+        overflow: 'hidden',
+        ...style,
+      }}
+    >
+      “{text}”
+    </div>
+  )
 }
 
 function CarrotPixelIcon({ size = 20 }: { size?: number | string }) {
@@ -243,20 +272,22 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
     if (!agentsRevealed) setAgentOpen(false)
   }, [agentsRevealed])
 
-  // --- Set crosshair cursor when selecting ---
+  // --- Set crosshair cursor when selecting (text cursor over selectable text) ---
+  const [textHover, setTextHover] = useState(false)
   useEffect(() => {
     if (mode !== 'selecting') return
     const prev = document.body.style.cursor
-    document.body.style.cursor = 'crosshair'
+    document.body.style.cursor = textHover ? 'text' : 'crosshair'
     return () => {
       document.body.style.cursor = prev
     }
-  }, [mode])
+  }, [mode, textHover])
 
   // --- Highlight hovered element ---
   useEffect(() => {
     if (mode !== 'selecting') {
       setHovered(null)
+      setTextHover(false)
       return
     }
 
@@ -264,8 +295,10 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
       const el = e.target as HTMLElement
       if (el && !el.closest?.(`[${WIDGET_ATTR}]`)) {
         setHovered(el)
+        setTextHover(isTextAtPoint(e.clientX, e.clientY))
       } else {
         setHovered(null)
+        setTextHover(false)
       }
     }
 
@@ -302,14 +335,27 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
       setSidebarOpen(false)
       clearImage()
       const pct = toPagePercent(e.pageX, e.pageY)
-      setTarget({
-        selector: getSelector(el),
-        x: pct.x,
-        y: pct.y,
-        url: window.location.href,
-      })
-
-      captureImage(el)
+      // A live text selection wins over element capture — anchor the comment
+      // to the quoted text (Google-Docs style) and skip the screenshot.
+      const snapshot = getSelectionSnapshot(WIDGET_ATTR)
+      if (snapshot) {
+        setTarget({
+          selector: getSelector(snapshot.element),
+          x: pct.x,
+          y: pct.y,
+          url: window.location.href,
+          selectedText: snapshot.text,
+        })
+        clearSelection()
+      } else {
+        setTarget({
+          selector: getSelector(el),
+          x: pct.x,
+          y: pct.y,
+          url: window.location.href,
+        })
+        captureImage(el)
+      }
 
       if (!authorNameRef.current) {
         setShowNameModal(true)
@@ -361,10 +407,14 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
         payload.authorName = authorNameRef.current
       }
 
-      const encoded = await encodeImage()
-      if (encoded) {
-        payload.imageBase64 = encoded.base64
-        payload.imageMimeType = encoded.mimeType
+      if (targetData.selectedText) {
+        payload.selectedText = targetData.selectedText
+      } else {
+        const encoded = await encodeImage()
+        if (encoded) {
+          payload.imageBase64 = encoded.base64
+          payload.imageMimeType = encoded.mimeType
+        }
       }
 
       const data = await postComment(apiBase, payload)
@@ -380,6 +430,7 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
         body: commentText,
         reviewStatus: 'open',
         imageUrl: data.imageUrl ?? null,
+        selectedText: targetData.selectedText ?? null,
         createdAt: data.createdAt ?? new Date().toISOString(),
         authorName: data.authorName ?? authorNameRef.current ?? undefined,
       }
@@ -781,6 +832,11 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
               />
             </div>
 
+            {/* Quoted text selection */}
+            {target.selectedText && (
+              <SelectedTextQuote text={target.selectedText} style={{ margin: '0 14px 6px' }} />
+            )}
+
             {/* Screenshot thumbnail */}
             {imagePreviewUrl && (
               <div style={{
@@ -1025,6 +1081,9 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
                       <span style={{ fontSize: 13, fontWeight: 700, color: '#FFFFFF' }}>{pinAuthor}</span>
                       <span style={{ fontSize: 12, color: '#6B6560' }}>{timeAgo(c.createdAt)}</span>
                     </div>
+                    {c.selectedText && (
+                      <SelectedTextQuote text={c.selectedText} style={{ marginBottom: 6 }} />
+                    )}
                     <div style={{ fontSize: 13, color: '#E8E5DF', lineHeight: 1.4, wordBreak: 'break-word' }}>
                       {c.body}
                     </div>
@@ -1085,6 +1144,10 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
                         onDelete={() => { deleteComment(c.id); setSelectedPin(null) }}
                       />
                     </div>
+
+                    {c.selectedText && (
+                      <SelectedTextQuote text={c.selectedText} style={{ marginBottom: 10 }} />
+                    )}
 
                     {editingId === c.id ? (
                       <div style={{ marginBottom: c.imageUrl ? 10 : 14 }}>
@@ -1466,6 +1529,9 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
                       >
                         {c.body}
                       </div>
+                      {c.selectedText && (
+                        <SelectedTextQuote text={c.selectedText} style={{ marginTop: 8, marginLeft: 32 }} />
+                      )}
                       {c.imageUrl && (
                         <img
                           src={c.imageUrl}

--- a/src/components/FeedbackWidget/types.ts
+++ b/src/components/FeedbackWidget/types.ts
@@ -13,6 +13,8 @@ export interface ClickTarget {
   x: number
   y: number
   url: string
+  /** Present when the comment anchors to a text selection instead of an element screenshot. */
+  selectedText?: string
 }
 
 export interface Comment {
@@ -25,6 +27,7 @@ export interface Comment {
   body: string
   reviewStatus: ReviewStatus
   imageUrl?: string | null
+  selectedText?: string | null
   createdAt: string
   authorName?: string
 }

--- a/src/lib/textSelection.ts
+++ b/src/lib/textSelection.ts
@@ -1,0 +1,67 @@
+// Helpers for text-anchored feedback in selecting mode. Both caret APIs are
+// point-based: caretPositionFromPoint is the standard, caretRangeFromPoint
+// the WebKit fallback.
+
+/** Hard cap mirrored by the API — selections beyond this are truncated. */
+export const MAX_SELECTED_TEXT_LENGTH = 2000
+
+export interface SelectionSnapshot {
+  text: string
+  element: HTMLElement
+}
+
+type CaretPositionDocument = Document & {
+  caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node } | null
+  caretRangeFromPoint?: (x: number, y: number) => Range | null
+}
+
+function textNodeAtPoint(x: number, y: number): Node | null {
+  const doc = document as CaretPositionDocument
+  if (typeof doc.caretPositionFromPoint === 'function') {
+    return doc.caretPositionFromPoint(x, y)?.offsetNode ?? null
+  }
+  if (typeof doc.caretRangeFromPoint === 'function') {
+    return doc.caretRangeFromPoint(x, y)?.startContainer ?? null
+  }
+  return null
+}
+
+// True when the pointer sits over actual glyphs — not merely inside an
+// element that contains text somewhere. Caret APIs snap to the nearest text
+// position, so confirm the point falls within one of the text node's rects.
+export function isTextAtPoint(x: number, y: number): boolean {
+  const node = textNodeAtPoint(x, y)
+  if (!node || node.nodeType !== Node.TEXT_NODE) return false
+  if (!(node.textContent ?? '').trim()) return false
+
+  const range = document.createRange()
+  range.selectNodeContents(node)
+  for (const rect of Array.from(range.getClientRects())) {
+    if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+      return true
+    }
+  }
+  return false
+}
+
+// Snapshot of the user's live text selection, or null when there is none
+// (collapsed, whitespace-only, or inside the widget's own UI).
+export function getSelectionSnapshot(widgetAttr: string): SelectionSnapshot | null {
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null
+
+  const text = selection.toString().trim().slice(0, MAX_SELECTED_TEXT_LENGTH)
+  if (!text) return null
+
+  const container = selection.getRangeAt(0).commonAncestorContainer
+  const element = container.nodeType === Node.ELEMENT_NODE
+    ? (container as HTMLElement)
+    : container.parentElement
+  if (!element || element.closest(`[${widgetAttr}]`)) return null
+
+  return { text, element }
+}
+
+export function clearSelection() {
+  window.getSelection()?.removeAllRanges()
+}


### PR DESCRIPTION
Stacked on #135.

- Switch the crosshair to a text I-beam when hovering over actual text while picking an element
- Let reviewers select a passage and click to save that exact quote as the comment's anchor instead of an element screenshot, Google-Docs style
- Show the quoted text in the comment popover, on pin tooltips and detail popovers, and in sidebar cards
- Cap captured selections at 2000 characters to match the API limit