### PR TITLE
Release v0.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thedesignproject/crrt",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "CRRT 🥕 visual feedback capture for React apps",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
- Bump the package version to 0.3.13 so a `v0.3.13` tag can trigger the npm publish workflow.
- No runtime or API changes — version bump only.