### PR TITLE
feat(dashboard): super-admin section (users + projects overview)

### DIFF
--- a/api/_lib/auth.test.ts
+++ b/api/_lib/auth.test.ts
@@ -1,11 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('./supabase.js', () => ({ getSupabase: vi.fn() }))
+vi.mock('./supabase.js', () => ({ getSupabase: vi.fn(), getServiceSupabase: vi.fn() }))
 vi.mock('./store.js', () => ({ isProjectMember: vi.fn() }))
 
-import { getSupabase } from './supabase.js'
+import { getServiceSupabase, getSupabase } from './supabase.js'
 import { isProjectMember } from './store.js'
-import { requireProjectMembership, requireReviewer, requireUser } from './auth.js'
+import { isSuperAdmin, requireProjectMembership, requireReviewer, requireSuperAdmin, requireUser } from './auth.js'
+
+// Stub getServiceSupabase().from('super_admins').select(...).eq(...).maybeSingle()
+function mockSuperAdminLookup(result: { data: unknown; error: unknown }) {
+  const maybeSingle = vi.fn().mockResolvedValue(result)
+  const eq = vi.fn().mockReturnValue({ maybeSingle })
+  const select = vi.fn().mockReturnValue({ eq })
+  const from = vi.fn().mockReturnValue({ select })
+  vi.mocked(getServiceSupabase).mockReturnValue({ from } as never)
+  return { from, select, eq, maybeSingle }
+}
+
+function mockValidUser(id = 'u-1', email = 'a@example.com') {
+  vi.mocked(getSupabase).mockReturnValue({
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id, email } }, error: null }) },
+  } as never)
+}
 
 interface MockRes {
   statusCode: number
@@ -45,6 +61,7 @@ function mockRes(): MockRes {
 
 beforeEach(() => {
   vi.mocked(getSupabase).mockReset()
+  vi.mocked(getServiceSupabase).mockReset()
   delete process.env.REVIEWER_API_TOKEN
 })
 
@@ -134,6 +151,58 @@ describe('requireUser', () => {
     const res = mockRes()
     const user = await requireUser(mockReq({ authorization: 'Bearer tok' }), res as never)
     expect(user).toEqual({ userId: 'u-1', email: 'a@example.com' })
+  })
+})
+
+describe('isSuperAdmin', () => {
+  it('returns true when a row exists', async () => {
+    mockSuperAdminLookup({ data: { user_id: 'u-1' }, error: null })
+    expect(await isSuperAdmin('u-1')).toBe(true)
+  })
+
+  it('returns false when no row exists', async () => {
+    mockSuperAdminLookup({ data: null, error: null })
+    expect(await isSuperAdmin('u-1')).toBe(false)
+  })
+
+  it('throws when the lookup errors', async () => {
+    mockSuperAdminLookup({ data: null, error: { message: 'db down' } })
+    await expect(isSuperAdmin('u-1')).rejects.toThrow('db down')
+  })
+})
+
+describe('requireSuperAdmin', () => {
+  it('returns 401 when the caller is unauthenticated', async () => {
+    const res = mockRes()
+    const user = await requireSuperAdmin(mockReq(), res as never)
+    expect(user).toBeNull()
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('returns the user when they are a super admin', async () => {
+    mockValidUser()
+    mockSuperAdminLookup({ data: { user_id: 'u-1' }, error: null })
+    const res = mockRes()
+    const user = await requireSuperAdmin(mockReq({ authorization: 'Bearer tok' }), res as never)
+    expect(user).toEqual({ userId: 'u-1', email: 'a@example.com' })
+  })
+
+  it('writes 403 when the caller is not a super admin', async () => {
+    mockValidUser()
+    mockSuperAdminLookup({ data: null, error: null })
+    const res = mockRes()
+    const user = await requireSuperAdmin(mockReq({ authorization: 'Bearer tok' }), res as never)
+    expect(user).toBeNull()
+    expect(res.statusCode).toBe(403)
+  })
+
+  it('writes 500 when the super-admin check throws', async () => {
+    mockValidUser()
+    mockSuperAdminLookup({ data: null, error: { message: 'db down' } })
+    const res = mockRes()
+    const user = await requireSuperAdmin(mockReq({ authorization: 'Bearer tok' }), res as never)
+    expect(user).toBeNull()
+    expect(res.statusCode).toBe(500)
   })
 })
 

--- a/api/_lib/auth.ts
+++ b/api/_lib/auth.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { getBearerToken, getReviewerToken, jsonError } from './http.js'
 import { isProjectMember } from './store.js'
-import { getSupabase } from './supabase.js'
+import { getServiceSupabase, getSupabase } from './supabase.js'
 
 export type AuthenticatedUser = { userId: string; email: string }
 
@@ -41,6 +41,44 @@ export function requireReviewer(req: VercelRequest, res: VercelResponse) {
   }
 
   return true
+}
+
+/**
+ * True when the user is in the global `super_admins` allowlist. Reads through
+ * the service-role client since `super_admins` is RLS deny-all like every other
+ * table. A query error throws so callers fail closed rather than silently
+ * granting/denying.
+ */
+export async function isSuperAdmin(userId: string): Promise<boolean> {
+  const { data, error } = await getServiceSupabase()
+    .from('super_admins')
+    .select('user_id')
+    .eq('user_id', userId)
+    .maybeSingle()
+  if (error) throw new Error(error.message)
+  return data !== null
+}
+
+/**
+ * Gate for the `/api/v1/admin/*` endpoints. Authenticates the caller, then
+ * requires super-admin membership. Writes 403 on miss so callers can
+ * `const user = await requireSuperAdmin(...); if (!user) return`.
+ */
+export async function requireSuperAdmin(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<AuthenticatedUser | null> {
+  const user = await requireUser(req, res)
+  if (!user) return null
+
+  try {
+    if (await isSuperAdmin(user.userId)) return user
+  } catch {
+    jsonError(req, res, 500, 'Super admin check failed')
+    return null
+  }
+  jsonError(req, res, 403, 'Forbidden')
+  return null
 }
 
 export async function requireUser(

--- a/api/_lib/store.admin.test.ts
+++ b/api/_lib/store.admin.test.ts
@@ -94,6 +94,12 @@ describe('listAllUsers', () => {
     buildClient({ listUsers, tables: { project_members: { data: null, error: { message: 'db down' } } } })
     await expect(listAllUsers()).rejects.toThrow('db down')
   })
+
+  it('tolerates null data from both queries', async () => {
+    const listUsers = vi.fn().mockResolvedValue({ data: null, error: null })
+    buildClient({ listUsers, tables: { project_members: { data: null, error: null } } })
+    expect(await listAllUsers()).toEqual([])
+  })
 })
 
 describe('listProjectsWithComments', () => {
@@ -109,7 +115,7 @@ describe('listProjectsWithComments', () => {
     )
   }
 
-  it('aggregates comments per project, resolves owners, sorts by latest comment', async () => {
+  it('aggregates comments per project, resolves members with roles, sorts by latest comment', async () => {
     buildClient({
       tables: {
         comments: {
@@ -132,13 +138,14 @@ describe('listProjectsWithComments', () => {
         project_members: {
           data: [
             { project_key: 'p1', user_id: 'owner1', role: 'admin' },
-            { project_key: 'p1', user_id: 'ghost', role: 'admin' }, // email won't resolve
+            { project_key: 'p1', user_id: 'mem1', role: 'member' },
+            { project_key: 'p1', user_id: 'ghost', role: 'admin' }, // email won't resolve → dropped
           ],
           error: null,
         },
       },
     })
-    stubEmails({ owner1: 'owner1@x.com' })
+    stubEmails({ owner1: 'owner1@x.com', mem1: 'mem1@x.com' })
 
     const projects = await listProjectsWithComments()
     expect(projects).toEqual([
@@ -149,7 +156,7 @@ describe('listProjectsWithComments', () => {
         commentCount: 1,
         latestCommentAt: '2026-05-01T00:00:00Z',
         claimed: false,
-        owners: [],
+        members: [],
       },
       {
         publicKey: 'p1',
@@ -158,7 +165,10 @@ describe('listProjectsWithComments', () => {
         commentCount: 3,
         latestCommentAt: '2026-01-03T00:00:00Z',
         claimed: true,
-        owners: ['owner1@x.com'],
+        members: [
+          { email: 'owner1@x.com', role: 'admin' },
+          { email: 'mem1@x.com', role: 'member' },
+        ],
       },
     ])
   })
@@ -192,5 +202,21 @@ describe('listProjectsWithComments', () => {
       },
     })
     await expect(listProjectsWithComments()).rejects.toThrow('m down')
+  })
+
+  it('returns [] when the comments query yields null data', async () => {
+    buildClient({ tables: { comments: { data: null, error: null } } })
+    expect(await listProjectsWithComments()).toEqual([])
+  })
+
+  it('tolerates null data from the project and member queries', async () => {
+    buildClient({
+      tables: {
+        comments: { data: [{ project_id: 'p1', created_at: '2026-01-01T00:00:00Z' }], error: null },
+        projects: { data: null, error: null },
+        project_members: { data: null, error: null },
+      },
+    })
+    expect(await listProjectsWithComments()).toEqual([])
   })
 })

--- a/api/_lib/store.admin.test.ts
+++ b/api/_lib/store.admin.test.ts
@@ -94,6 +94,12 @@ describe('listAllUsers', () => {
     buildClient({ listUsers, tables: { project_members: { data: null, error: { message: 'db down' } } } })
     await expect(listAllUsers()).rejects.toThrow('db down')
   })
+
+  it('tolerates null data from both queries', async () => {
+    const listUsers = vi.fn().mockResolvedValue({ data: null, error: null })
+    buildClient({ listUsers, tables: { project_members: { data: null, error: null } } })
+    expect(await listAllUsers()).toEqual([])
+  })
 })
 
 describe('listProjectsWithComments', () => {
@@ -165,6 +171,22 @@ describe('listProjectsWithComments', () => {
 
   it('returns [] when no project has comments', async () => {
     buildClient({ tables: { comments: { data: [{ project_id: null, created_at: '2026-01-01T00:00:00Z' }], error: null } } })
+    expect(await listProjectsWithComments()).toEqual([])
+  })
+
+  it('returns [] when the comments query yields null data', async () => {
+    buildClient({ tables: { comments: { data: null, error: null } } })
+    expect(await listProjectsWithComments()).toEqual([])
+  })
+
+  it('tolerates null data from the project and member queries', async () => {
+    buildClient({
+      tables: {
+        comments: { data: [{ project_id: 'p1', created_at: '2026-01-01T00:00:00Z' }], error: null },
+        projects: { data: null, error: null },
+        project_members: { data: null, error: null },
+      },
+    })
     expect(await listProjectsWithComments()).toEqual([])
   })
 

--- a/api/_lib/store.admin.test.ts
+++ b/api/_lib/store.admin.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./supabase.js', () => ({ getServiceSupabase: vi.fn() }))
+
+import { getServiceSupabase } from './supabase.js'
+import { listAllUsers, listProjectsWithComments } from './store.js'
+
+// A chainable, awaitable query stub: select/in/eq/order all return `this`, and
+// awaiting the object resolves to the configured { data, error } result.
+function qb(result: { data: unknown; error: unknown }) {
+  const obj: Record<string, unknown> = {}
+  for (const m of ['select', 'in', 'eq', 'order']) obj[m] = vi.fn(() => obj)
+  obj.then = (resolve: (v: unknown) => unknown) => resolve(result)
+  return obj
+}
+
+type Tables = {
+  comments?: { data: unknown; error: unknown }
+  projects?: { data: unknown; error: unknown }
+  project_members?: { data: unknown; error: unknown }
+}
+
+function buildClient(opts: { listUsers?: unknown; tables?: Tables }) {
+  vi.mocked(getServiceSupabase).mockReturnValue({
+    auth: { admin: { listUsers: opts.listUsers ?? vi.fn() } },
+    from: vi.fn((table: string) => {
+      const t = opts.tables?.[table as keyof Tables]
+      if (!t) throw new Error(`Unmocked table ${table}`)
+      return qb(t)
+    }),
+  } as never)
+}
+
+beforeEach(() => {
+  vi.mocked(getServiceSupabase).mockReset()
+  process.env.SUPABASE_URL = 'https://x.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc'
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('listAllUsers', () => {
+  it('returns users newest-first with project counts', async () => {
+    const listUsers = vi.fn().mockResolvedValue({
+      data: {
+        users: [
+          { id: 'a', email: 'a@x.com', created_at: '2026-01-01T00:00:00Z' },
+          { id: 'b', email: null, created_at: '2026-03-01T00:00:00Z' },
+        ],
+      },
+      error: null,
+    })
+    buildClient({
+      listUsers,
+      tables: { project_members: { data: [{ user_id: 'a' }, { user_id: 'a' }], error: null } },
+    })
+
+    const users = await listAllUsers()
+    expect(users).toEqual([
+      { id: 'b', email: null, createdAt: '2026-03-01T00:00:00Z', projectCount: 0 },
+      { id: 'a', email: 'a@x.com', createdAt: '2026-01-01T00:00:00Z', projectCount: 2 },
+    ])
+    expect(listUsers).toHaveBeenCalledWith({ page: 1, perPage: 200 })
+  })
+
+  it('pages through the admin API until a short batch', async () => {
+    const fullPage = Array.from({ length: 200 }, (_, i) => ({
+      id: `p1-${i}`,
+      email: `p1-${i}@x.com`,
+      created_at: '2026-01-01T00:00:00Z',
+    }))
+    const listUsers = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { users: fullPage }, error: null })
+      .mockResolvedValueOnce({ data: { users: [{ id: 'last', email: 'l@x.com', created_at: '2026-02-01T00:00:00Z' }] }, error: null })
+    buildClient({ listUsers, tables: { project_members: { data: [], error: null } } })
+
+    const users = await listAllUsers()
+    expect(users).toHaveLength(201)
+    expect(listUsers).toHaveBeenCalledTimes(2)
+    expect(listUsers).toHaveBeenLastCalledWith({ page: 2, perPage: 200 })
+    expect(users[0].id).toBe('last') // newest first
+  })
+
+  it('throws when the admin API errors', async () => {
+    buildClient({ listUsers: vi.fn().mockResolvedValue({ data: null, error: { message: 'auth down' } }) })
+    await expect(listAllUsers()).rejects.toThrow('auth down')
+  })
+
+  it('throws when the membership query errors', async () => {
+    const listUsers = vi.fn().mockResolvedValue({ data: { users: [] }, error: null })
+    buildClient({ listUsers, tables: { project_members: { data: null, error: { message: 'db down' } } } })
+    await expect(listAllUsers()).rejects.toThrow('db down')
+  })
+})
+
+describe('listProjectsWithComments', () => {
+  function stubEmails(map: Record<string, string>) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const id = decodeURIComponent(url.split('/').pop() as string)
+        const email = map[id]
+        if (!email) return { ok: false } as never
+        return { ok: true, json: async () => ({ email }) } as never
+      }),
+    )
+  }
+
+  it('aggregates comments per project, resolves owners, sorts by latest comment', async () => {
+    buildClient({
+      tables: {
+        comments: {
+          data: [
+            { project_id: null, created_at: '2026-01-01T00:00:00Z' }, // orphan, skipped
+            { project_id: 'p1', created_at: '2026-01-01T00:00:00Z' },
+            { project_id: 'p1', created_at: '2026-01-03T00:00:00Z' }, // newer → updates latest
+            { project_id: 'p1', created_at: '2026-01-02T00:00:00Z' }, // older → no update
+            { project_id: 'p2', created_at: '2026-05-01T00:00:00Z' },
+          ],
+          error: null,
+        },
+        projects: {
+          data: [
+            { public_key: 'p1', name: 'One', claimable: false, created_at: '2025-12-01T00:00:00Z' },
+            { public_key: 'p2', name: 'Two', claimable: true, created_at: '2025-12-02T00:00:00Z' },
+          ],
+          error: null,
+        },
+        project_members: {
+          data: [
+            { project_key: 'p1', user_id: 'owner1', role: 'admin' },
+            { project_key: 'p1', user_id: 'ghost', role: 'admin' }, // email won't resolve
+          ],
+          error: null,
+        },
+      },
+    })
+    stubEmails({ owner1: 'owner1@x.com' })
+
+    const projects = await listProjectsWithComments()
+    expect(projects).toEqual([
+      {
+        publicKey: 'p2',
+        name: 'Two',
+        createdAt: '2025-12-02T00:00:00Z',
+        commentCount: 1,
+        latestCommentAt: '2026-05-01T00:00:00Z',
+        claimed: false,
+        owners: [],
+      },
+      {
+        publicKey: 'p1',
+        name: 'One',
+        createdAt: '2025-12-01T00:00:00Z',
+        commentCount: 3,
+        latestCommentAt: '2026-01-03T00:00:00Z',
+        claimed: true,
+        owners: ['owner1@x.com'],
+      },
+    ])
+  })
+
+  it('returns [] when no project has comments', async () => {
+    buildClient({ tables: { comments: { data: [{ project_id: null, created_at: '2026-01-01T00:00:00Z' }], error: null } } })
+    expect(await listProjectsWithComments()).toEqual([])
+  })
+
+  it('throws when the comments query errors', async () => {
+    buildClient({ tables: { comments: { data: null, error: { message: 'c down' } } } })
+    await expect(listProjectsWithComments()).rejects.toThrow('c down')
+  })
+
+  it('throws when the projects query errors', async () => {
+    buildClient({
+      tables: {
+        comments: { data: [{ project_id: 'p1', created_at: '2026-01-01T00:00:00Z' }], error: null },
+        projects: { data: null, error: { message: 'p down' } },
+      },
+    })
+    await expect(listProjectsWithComments()).rejects.toThrow('p down')
+  })
+
+  it('throws when the members query errors', async () => {
+    buildClient({
+      tables: {
+        comments: { data: [{ project_id: 'p1', created_at: '2026-01-01T00:00:00Z' }], error: null },
+        projects: { data: [{ public_key: 'p1', name: 'One', claimable: false, created_at: '2025-12-01T00:00:00Z' }], error: null },
+        project_members: { data: null, error: { message: 'm down' } },
+      },
+    })
+    await expect(listProjectsWithComments()).rejects.toThrow('m down')
+  })
+})

--- a/api/_lib/store.admin.test.ts
+++ b/api/_lib/store.admin.test.ts
@@ -15,20 +15,31 @@ function qb(result: { data: unknown; error: unknown }) {
 }
 
 type Tables = {
-  comments?: { data: unknown; error: unknown }
-  projects?: { data: unknown; error: unknown }
   project_members?: { data: unknown; error: unknown }
 }
 
-function buildClient(opts: { listUsers?: unknown; tables?: Tables }) {
-  vi.mocked(getServiceSupabase).mockReturnValue({
+type Rpcs = {
+  admin_user_project_counts?: { data: unknown; error: unknown }
+  admin_projects_with_comments?: { data: unknown; error: unknown }
+}
+
+function buildClient(opts: { listUsers?: unknown; tables?: Tables; rpcs?: Rpcs }) {
+  const rpc = vi.fn(async (name: string) => {
+    const r = opts.rpcs?.[name as keyof Rpcs]
+    if (!r) throw new Error(`Unmocked rpc ${name}`)
+    return r
+  })
+  const client = {
     auth: { admin: { listUsers: opts.listUsers ?? vi.fn() } },
     from: vi.fn((table: string) => {
       const t = opts.tables?.[table as keyof Tables]
       if (!t) throw new Error(`Unmocked table ${table}`)
       return qb(t)
     }),
-  } as never)
+    rpc,
+  }
+  vi.mocked(getServiceSupabase).mockReturnValue(client as never)
+  return { rpc }
 }
 
 beforeEach(() => {
@@ -52,9 +63,9 @@ describe('listAllUsers', () => {
       },
       error: null,
     })
-    buildClient({
+    const { rpc } = buildClient({
       listUsers,
-      tables: { project_members: { data: [{ user_id: 'a' }, { user_id: 'a' }], error: null } },
+      rpcs: { admin_user_project_counts: { data: [{ user_id: 'a', project_count: 2 }], error: null } },
     })
 
     const users = await listAllUsers()
@@ -63,6 +74,7 @@ describe('listAllUsers', () => {
       { id: 'a', email: 'a@x.com', createdAt: '2026-01-01T00:00:00Z', projectCount: 2 },
     ])
     expect(listUsers).toHaveBeenCalledWith({ page: 1, perPage: 200 })
+    expect(rpc).toHaveBeenCalledWith('admin_user_project_counts')
   })
 
   it('pages through the admin API until a short batch', async () => {
@@ -75,7 +87,7 @@ describe('listAllUsers', () => {
       .fn()
       .mockResolvedValueOnce({ data: { users: fullPage }, error: null })
       .mockResolvedValueOnce({ data: { users: [{ id: 'last', email: 'l@x.com', created_at: '2026-02-01T00:00:00Z' }] }, error: null })
-    buildClient({ listUsers, tables: { project_members: { data: [], error: null } } })
+    buildClient({ listUsers, rpcs: { admin_user_project_counts: { data: [], error: null } } })
 
     const users = await listAllUsers()
     expect(users).toHaveLength(201)
@@ -89,15 +101,15 @@ describe('listAllUsers', () => {
     await expect(listAllUsers()).rejects.toThrow('auth down')
   })
 
-  it('throws when the membership query errors', async () => {
+  it('throws when the project-count RPC errors', async () => {
     const listUsers = vi.fn().mockResolvedValue({ data: { users: [] }, error: null })
-    buildClient({ listUsers, tables: { project_members: { data: null, error: { message: 'db down' } } } })
+    buildClient({ listUsers, rpcs: { admin_user_project_counts: { data: null, error: { message: 'db down' } } } })
     await expect(listAllUsers()).rejects.toThrow('db down')
   })
 
-  it('tolerates null data from both queries', async () => {
+  it('tolerates null data from both sources', async () => {
     const listUsers = vi.fn().mockResolvedValue({ data: null, error: null })
-    buildClient({ listUsers, tables: { project_members: { data: null, error: null } } })
+    buildClient({ listUsers, rpcs: { admin_user_project_counts: { data: null, error: null } } })
     expect(await listAllUsers()).toEqual([])
   })
 })
@@ -115,26 +127,31 @@ describe('listProjectsWithComments', () => {
     )
   }
 
-  it('aggregates comments per project, resolves members with roles, sorts by latest comment', async () => {
-    buildClient({
+  // The RPC returns rows already aggregated (count + latest) and ordered by
+  // latest-comment desc; the store maps them and resolves member emails.
+  const PROJECT_ROWS = [
+    {
+      public_key: 'p2',
+      name: 'Two',
+      claimable: true,
+      created_at: '2025-12-02T00:00:00Z',
+      comment_count: 1,
+      latest_comment_at: '2026-05-01T00:00:00Z',
+    },
+    {
+      public_key: 'p1',
+      name: 'One',
+      claimable: false,
+      created_at: '2025-12-01T00:00:00Z',
+      comment_count: 3,
+      latest_comment_at: '2026-01-03T00:00:00Z',
+    },
+  ]
+
+  it('maps aggregated rows and resolves members with roles, bounded by p_limit', async () => {
+    const { rpc } = buildClient({
+      rpcs: { admin_projects_with_comments: { data: PROJECT_ROWS, error: null } },
       tables: {
-        comments: {
-          data: [
-            { project_id: null, created_at: '2026-01-01T00:00:00Z' }, // orphan, skipped
-            { project_id: 'p1', created_at: '2026-01-01T00:00:00Z' },
-            { project_id: 'p1', created_at: '2026-01-03T00:00:00Z' }, // newer → updates latest
-            { project_id: 'p1', created_at: '2026-01-02T00:00:00Z' }, // older → no update
-            { project_id: 'p2', created_at: '2026-05-01T00:00:00Z' },
-          ],
-          error: null,
-        },
-        projects: {
-          data: [
-            { public_key: 'p1', name: 'One', claimable: false, created_at: '2025-12-01T00:00:00Z' },
-            { public_key: 'p2', name: 'Two', claimable: true, created_at: '2025-12-02T00:00:00Z' },
-          ],
-          error: null,
-        },
         project_members: {
           data: [
             { project_key: 'p1', user_id: 'owner1', role: 'admin' },
@@ -171,52 +188,38 @@ describe('listProjectsWithComments', () => {
         ],
       },
     ])
+    expect(rpc).toHaveBeenCalledWith('admin_projects_with_comments', { p_limit: 100 })
   })
 
   it('returns [] when no project has comments', async () => {
-    buildClient({ tables: { comments: { data: [{ project_id: null, created_at: '2026-01-01T00:00:00Z' }], error: null } } })
+    buildClient({ rpcs: { admin_projects_with_comments: { data: [], error: null } } })
     expect(await listProjectsWithComments()).toEqual([])
   })
 
-  it('throws when the comments query errors', async () => {
-    buildClient({ tables: { comments: { data: null, error: { message: 'c down' } } } })
-    await expect(listProjectsWithComments()).rejects.toThrow('c down')
-  })
-
-  it('throws when the projects query errors', async () => {
-    buildClient({
-      tables: {
-        comments: { data: [{ project_id: 'p1', created_at: '2026-01-01T00:00:00Z' }], error: null },
-        projects: { data: null, error: { message: 'p down' } },
-      },
-    })
+  it('throws when the projects RPC errors', async () => {
+    buildClient({ rpcs: { admin_projects_with_comments: { data: null, error: { message: 'p down' } } } })
     await expect(listProjectsWithComments()).rejects.toThrow('p down')
   })
 
   it('throws when the members query errors', async () => {
     buildClient({
-      tables: {
-        comments: { data: [{ project_id: 'p1', created_at: '2026-01-01T00:00:00Z' }], error: null },
-        projects: { data: [{ public_key: 'p1', name: 'One', claimable: false, created_at: '2025-12-01T00:00:00Z' }], error: null },
-        project_members: { data: null, error: { message: 'm down' } },
-      },
+      rpcs: { admin_projects_with_comments: { data: PROJECT_ROWS, error: null } },
+      tables: { project_members: { data: null, error: { message: 'm down' } } },
     })
     await expect(listProjectsWithComments()).rejects.toThrow('m down')
   })
 
-  it('returns [] when the comments query yields null data', async () => {
-    buildClient({ tables: { comments: { data: null, error: null } } })
+  it('returns [] when the projects RPC yields null data', async () => {
+    buildClient({ rpcs: { admin_projects_with_comments: { data: null, error: null } } })
     expect(await listProjectsWithComments()).toEqual([])
   })
 
-  it('tolerates null data from the project and member queries', async () => {
+  it('tolerates null member data', async () => {
     buildClient({
-      tables: {
-        comments: { data: [{ project_id: 'p1', created_at: '2026-01-01T00:00:00Z' }], error: null },
-        projects: { data: null, error: null },
-        project_members: { data: null, error: null },
-      },
+      rpcs: { admin_projects_with_comments: { data: PROJECT_ROWS, error: null } },
+      tables: { project_members: { data: null, error: null } },
     })
-    expect(await listProjectsWithComments()).toEqual([])
+    const projects = await listProjectsWithComments()
+    expect(projects.map((p) => p.members)).toEqual([[], []])
   })
 })

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -356,6 +356,11 @@ export async function listAllUsers(): Promise<AdminUser[]> {
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
 }
 
+export type AdminProjectMember = {
+  email: string
+  role: 'admin' | 'member'
+}
+
 export type AdminProject = {
   publicKey: string
   name: string
@@ -363,14 +368,15 @@ export type AdminProject = {
   commentCount: number
   latestCommentAt: string
   claimed: boolean
-  owners: string[]
+  members: AdminProjectMember[]
 }
 
 /**
  * Super-admin view: every project that has received at least one comment,
  * ordered by most-recent comment. Per project: comment count, latest comment
- * time, whether it's been claimed (`claimable === false`), and the resolved
- * emails of its admin members (the owners). Comment stats are aggregated
+ * time, whether it's been claimed (`claimable === false`), and every member
+ * with their role + resolved email (admins are the owners; this also lets the
+ * dashboard scope projects to any member). Comment stats are aggregated
  * in-process so a single scan of `comments` drives the project set.
  */
 export async function listProjectsWithComments(): Promise<AdminProject[]> {
@@ -406,26 +412,25 @@ export async function listProjectsWithComments(): Promise<AdminProject[]> {
     .from('project_members')
     .select('project_key, user_id, role')
     .in('project_key', keys)
-    .eq('role', 'admin')
   if (memberError) throw new Error(memberError.message)
 
-  const ownersByProject = new Map<string, string[]>()
-  const userIds: string[] = []
-  for (const row of (memberRows || []) as { project_key: string; user_id: string }[]) {
-    userIds.push(row.user_id)
-    const list = ownersByProject.get(row.project_key) ?? []
-    list.push(row.user_id)
-    ownersByProject.set(row.project_key, list)
+  type MemberRow = { project_key: string; user_id: string; role: 'admin' | 'member' }
+  const rows = (memberRows || []) as MemberRow[]
+  const membersByProject = new Map<string, MemberRow[]>()
+  for (const row of rows) {
+    const list = membersByProject.get(row.project_key) ?? []
+    list.push(row)
+    membersByProject.set(row.project_key, list)
   }
-  const emails = await getUserEmailsByIds(userIds)
+  const emails = await getUserEmailsByIds(rows.map((r) => r.user_id))
 
   type AdminProjectRow = { public_key: string; name: string; claimable: boolean; created_at: string }
   return ((projectRows || []) as AdminProjectRow[])
     .map((row) => {
       const stat = stats.get(row.public_key) as { count: number; latest: string }
-      const owners = (ownersByProject.get(row.public_key) ?? [])
-        .map((id) => emails[id])
-        .filter((email): email is string => Boolean(email))
+      const members = (membersByProject.get(row.public_key) ?? [])
+        .map((m) => ({ email: emails[m.user_id], role: m.role }))
+        .filter((m): m is AdminProjectMember => Boolean(m.email))
       return {
         publicKey: row.public_key,
         name: row.name,
@@ -433,7 +438,7 @@ export async function listProjectsWithComments(): Promise<AdminProject[]> {
         commentCount: stat.count,
         latestCommentAt: stat.latest,
         claimed: row.claimable === false,
-        owners,
+        members,
       }
     })
     .sort((a, b) => b.latestCommentAt.localeCompare(a.latestCommentAt))

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -307,6 +307,138 @@ export async function getUserEmailsByIds(ids: string[]): Promise<Record<string, 
   return result
 }
 
+export type AdminUser = {
+  id: string
+  email: string | null
+  createdAt: string
+  projectCount: number
+}
+
+/**
+ * Super-admin view: every auth user, newest first, with how many projects each
+ * belongs to. Users come from the auth admin API (paged); project counts are
+ * tallied in-process from `project_members`.
+ */
+export async function listAllUsers(): Promise<AdminUser[]> {
+  const supabase = getSupabase()
+
+  const users: { id: string; email: string | null; created_at: string }[] = []
+  const perPage = 200
+  let page = 1
+  for (;;) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage })
+    if (error) throw new Error(error.message)
+    const batch = data?.users ?? []
+    for (const u of batch) {
+      users.push({ id: u.id, email: u.email ?? null, created_at: u.created_at })
+    }
+    if (batch.length < perPage) break
+    page += 1
+  }
+
+  const { data: memberRows, error: memberError } = await supabase
+    .from('project_members')
+    .select('user_id')
+  if (memberError) throw new Error(memberError.message)
+
+  const counts = new Map<string, number>()
+  for (const row of (memberRows || []) as { user_id: string }[]) {
+    counts.set(row.user_id, (counts.get(row.user_id) ?? 0) + 1)
+  }
+
+  return users
+    .map((u) => ({
+      id: u.id,
+      email: u.email,
+      createdAt: u.created_at,
+      projectCount: counts.get(u.id) ?? 0,
+    }))
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+}
+
+export type AdminProject = {
+  publicKey: string
+  name: string
+  createdAt: string
+  commentCount: number
+  latestCommentAt: string
+  claimed: boolean
+  owners: string[]
+}
+
+/**
+ * Super-admin view: every project that has received at least one comment,
+ * ordered by most-recent comment. Per project: comment count, latest comment
+ * time, whether it's been claimed (`claimable === false`), and the resolved
+ * emails of its admin members (the owners). Comment stats are aggregated
+ * in-process so a single scan of `comments` drives the project set.
+ */
+export async function listProjectsWithComments(): Promise<AdminProject[]> {
+  const supabase = getSupabase()
+
+  const { data: commentRows, error: commentError } = await supabase
+    .from('comments')
+    .select('project_id, created_at')
+  if (commentError) throw new Error(commentError.message)
+
+  const stats = new Map<string, { count: number; latest: string }>()
+  for (const row of (commentRows || []) as { project_id: string | null; created_at: string }[]) {
+    if (!row.project_id) continue
+    const cur = stats.get(row.project_id)
+    if (!cur) {
+      stats.set(row.project_id, { count: 1, latest: row.created_at })
+    } else {
+      cur.count += 1
+      if (row.created_at > cur.latest) cur.latest = row.created_at
+    }
+  }
+
+  const keys = Array.from(stats.keys())
+  if (keys.length === 0) return []
+
+  const { data: projectRows, error: projectError } = await supabase
+    .from('projects')
+    .select('public_key, name, claimable, created_at')
+    .in('public_key', keys)
+  if (projectError) throw new Error(projectError.message)
+
+  const { data: memberRows, error: memberError } = await supabase
+    .from('project_members')
+    .select('project_key, user_id, role')
+    .in('project_key', keys)
+    .eq('role', 'admin')
+  if (memberError) throw new Error(memberError.message)
+
+  const ownersByProject = new Map<string, string[]>()
+  const userIds: string[] = []
+  for (const row of (memberRows || []) as { project_key: string; user_id: string }[]) {
+    userIds.push(row.user_id)
+    const list = ownersByProject.get(row.project_key) ?? []
+    list.push(row.user_id)
+    ownersByProject.set(row.project_key, list)
+  }
+  const emails = await getUserEmailsByIds(userIds)
+
+  type AdminProjectRow = { public_key: string; name: string; claimable: boolean; created_at: string }
+  return ((projectRows || []) as AdminProjectRow[])
+    .map((row) => {
+      const stat = stats.get(row.public_key) as { count: number; latest: string }
+      const owners = (ownersByProject.get(row.public_key) ?? [])
+        .map((id) => emails[id])
+        .filter((email): email is string => Boolean(email))
+      return {
+        publicKey: row.public_key,
+        name: row.name,
+        createdAt: row.created_at,
+        commentCount: stat.count,
+        latestCommentAt: stat.latest,
+        claimed: row.claimable === false,
+        owners,
+      }
+    })
+    .sort((a, b) => b.latestCommentAt.localeCompare(a.latestCommentAt))
+}
+
 /**
  * Take ownership of a project. Two ways in:
  *  - Existing unclaimed project (widget-made): a conditional UPDATE flips

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -316,8 +316,10 @@ export type AdminUser = {
 
 /**
  * Super-admin view: every auth user, newest first, with how many projects each
- * belongs to. Users come from the auth admin API (paged); project counts are
- * tallied in-process from `project_members`.
+ * belongs to. Users come from the auth admin API (paged); project counts come
+ * from the `admin_user_project_counts` RPC (migration 0007), which aggregates
+ * `project_members` in the DB so a large membership table can't be truncated by
+ * PostgREST's row cap and miscount.
  */
 export async function listAllUsers(): Promise<AdminUser[]> {
   const supabase = getSupabase()
@@ -336,14 +338,12 @@ export async function listAllUsers(): Promise<AdminUser[]> {
     page += 1
   }
 
-  const { data: memberRows, error: memberError } = await supabase
-    .from('project_members')
-    .select('user_id')
-  if (memberError) throw new Error(memberError.message)
+  const { data: countRows, error: countError } = await supabase.rpc('admin_user_project_counts')
+  if (countError) throw new Error(countError.message)
 
   const counts = new Map<string, number>()
-  for (const row of (memberRows || []) as { user_id: string }[]) {
-    counts.set(row.user_id, (counts.get(row.user_id) ?? 0) + 1)
+  for (const row of (countRows || []) as { user_id: string; project_count: number }[]) {
+    counts.set(row.user_id, Number(row.project_count))
   }
 
   return users
@@ -371,42 +371,43 @@ export type AdminProject = {
   members: AdminProjectMember[]
 }
 
+// Upper bound on projects returned by the super-admin overview. Keeps the
+// result set bounded (and the RPC's underlying scan capped) as comments grow.
+const ADMIN_PROJECT_LIMIT = 100
+
 /**
  * Super-admin view: every project that has received at least one comment,
- * ordered by most-recent comment. Per project: comment count, latest comment
- * time, whether it's been claimed (`claimable === false`), and every member
- * with their role + resolved email (admins are the owners; this also lets the
- * dashboard scope projects to any member). Comment stats are aggregated
- * in-process so a single scan of `comments` drives the project set.
+ * ordered by most-recent comment, capped at `ADMIN_PROJECT_LIMIT`. Per project:
+ * comment count, latest comment time, whether it's been claimed
+ * (`claimable === false`), and every member with their role + resolved email
+ * (admins are the owners; this also lets the dashboard scope projects to any
+ * member).
+ *
+ * Comment count + latest-per-project are aggregated by the
+ * `admin_projects_with_comments` RPC (migration 0007) rather than scanning the
+ * whole `comments` table in Node, so a large table can't be truncated by
+ * PostgREST's row cap and yield wrong counts / a partial project set.
  */
 export async function listProjectsWithComments(): Promise<AdminProject[]> {
   const supabase = getSupabase()
 
-  const { data: commentRows, error: commentError } = await supabase
-    .from('comments')
-    .select('project_id, created_at')
-  if (commentError) throw new Error(commentError.message)
-
-  const stats = new Map<string, { count: number; latest: string }>()
-  for (const row of (commentRows || []) as { project_id: string | null; created_at: string }[]) {
-    if (!row.project_id) continue
-    const cur = stats.get(row.project_id)
-    if (!cur) {
-      stats.set(row.project_id, { count: 1, latest: row.created_at })
-    } else {
-      cur.count += 1
-      if (row.created_at > cur.latest) cur.latest = row.created_at
-    }
+  type AdminProjectRow = {
+    public_key: string
+    name: string
+    claimable: boolean
+    created_at: string
+    comment_count: number
+    latest_comment_at: string
   }
-
-  const keys = Array.from(stats.keys())
-  if (keys.length === 0) return []
-
-  const { data: projectRows, error: projectError } = await supabase
-    .from('projects')
-    .select('public_key, name, claimable, created_at')
-    .in('public_key', keys)
+  const { data: projectRows, error: projectError } = await supabase.rpc(
+    'admin_projects_with_comments',
+    { p_limit: ADMIN_PROJECT_LIMIT },
+  )
   if (projectError) throw new Error(projectError.message)
+
+  const projects = (projectRows || []) as AdminProjectRow[]
+  if (projects.length === 0) return []
+  const keys = projects.map((p) => p.public_key)
 
   const { data: memberRows, error: memberError } = await supabase
     .from('project_members')
@@ -424,24 +425,20 @@ export async function listProjectsWithComments(): Promise<AdminProject[]> {
   }
   const emails = await getUserEmailsByIds(rows.map((r) => r.user_id))
 
-  type AdminProjectRow = { public_key: string; name: string; claimable: boolean; created_at: string }
-  return ((projectRows || []) as AdminProjectRow[])
-    .map((row) => {
-      const stat = stats.get(row.public_key) as { count: number; latest: string }
-      const members = (membersByProject.get(row.public_key) ?? [])
-        .map((m) => ({ email: emails[m.user_id], role: m.role }))
-        .filter((m): m is AdminProjectMember => Boolean(m.email))
-      return {
-        publicKey: row.public_key,
-        name: row.name,
-        createdAt: row.created_at,
-        commentCount: stat.count,
-        latestCommentAt: stat.latest,
-        claimed: row.claimable === false,
-        members,
-      }
-    })
-    .sort((a, b) => b.latestCommentAt.localeCompare(a.latestCommentAt))
+  return projects.map((row) => {
+    const members = (membersByProject.get(row.public_key) ?? [])
+      .map((m) => ({ email: emails[m.user_id], role: m.role }))
+      .filter((m): m is AdminProjectMember => Boolean(m.email))
+    return {
+      publicKey: row.public_key,
+      name: row.name,
+      createdAt: row.created_at,
+      commentCount: Number(row.comment_count),
+      latestCommentAt: row.latest_comment_at,
+      claimed: row.claimable === false,
+      members,
+    }
+  })
 }
 
 /**

--- a/api/v1/admin/me.test.ts
+++ b/api/v1/admin/me.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireUser: vi.fn(), isSuperAdmin: vi.fn() }))
+
+import handler from './me.js'
+import { isSuperAdmin, requireUser } from '../../_lib/auth.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireUser).mockReset()
+  vi.mocked(isSuperAdmin).mockReset()
+})
+
+describe('api/v1/admin/me', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('returns 405 for non-GET', async () => {
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+  })
+
+  it('returns 401 when requireUser rejects', async () => {
+    vi.mocked(requireUser).mockImplementation(async (_req, res) => {
+      res.status(401).json({ error: 'Unauthorized' })
+      return null
+    })
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('reports super-admin status for authenticated users', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    vi.mocked(isSuperAdmin).mockResolvedValueOnce(true)
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ isSuperAdmin: true })
+    expect(isSuperAdmin).toHaveBeenCalledWith('u')
+
+    vi.mocked(isSuperAdmin).mockResolvedValueOnce(false)
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.body).toEqual({ isSuperAdmin: false })
+  })
+
+  it('returns 500 when the check throws', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(isSuperAdmin).mockRejectedValueOnce(new Error('boom'))
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/admin/me.ts
+++ b/api/v1/admin/me.ts
@@ -1,0 +1,23 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { isSuperAdmin, requireUser } from '../../_lib/auth.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+// Reports whether the authenticated caller is a super admin. Returns 200 with
+// `{ isSuperAdmin: false }` for ordinary users (rather than 403) so the
+// dashboard can decide whether to surface the Super Admin UI — the real gate is
+// `requireSuperAdmin` on the data endpoints.
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireUser(req, res)
+  if (!user) return
+
+  try {
+    const superAdmin = await isSuperAdmin(user.userId)
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json({ isSuperAdmin: superAdmin })
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/admin/projects.test.ts
+++ b/api/v1/admin/projects.test.ts
@@ -53,7 +53,7 @@ describe('api/v1/admin/projects', () => {
   it('returns the project list, 500 on store throw', async () => {
     vi.mocked(requireSuperAdmin).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
 
-    const row = { publicKey: 'p1', name: 'One', createdAt: 't', commentCount: 3, latestCommentAt: 't2', claimed: true, owners: ['o@x.com'] }
+    const row = { publicKey: 'p1', name: 'One', createdAt: 't', commentCount: 3, latestCommentAt: 't2', claimed: true, members: [{ email: 'o@x.com', role: 'admin' as const }] }
     vi.mocked(listProjectsWithComments).mockResolvedValueOnce([row])
     let res = mockRes()
     await call({ method: 'GET', query: {}, headers: {} }, res)

--- a/api/v1/admin/projects.test.ts
+++ b/api/v1/admin/projects.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireSuperAdmin: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({ listProjectsWithComments: vi.fn() }))
+
+import handler from './projects.js'
+import { requireSuperAdmin } from '../../_lib/auth.js'
+import { listProjectsWithComments } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireSuperAdmin).mockReset()
+  vi.mocked(listProjectsWithComments).mockReset()
+})
+
+describe('api/v1/admin/projects', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('returns 405 for non-GET', async () => {
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+  })
+
+  it('returns 403 when not a super admin', async () => {
+    vi.mocked(requireSuperAdmin).mockImplementation(async (_req, res) => {
+      res.status(403).json({ error: 'Forbidden' })
+      return null
+    })
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+    expect(listProjectsWithComments).not.toHaveBeenCalled()
+  })
+
+  it('returns the project list, 500 on store throw', async () => {
+    vi.mocked(requireSuperAdmin).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    const row = { publicKey: 'p1', name: 'One', createdAt: 't', commentCount: 3, latestCommentAt: 't2', claimed: true, owners: ['o@x.com'] }
+    vi.mocked(listProjectsWithComments).mockResolvedValueOnce([row])
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual([row])
+
+    vi.mocked(listProjectsWithComments).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/admin/projects.ts
+++ b/api/v1/admin/projects.ts
@@ -1,0 +1,22 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireSuperAdmin } from '../../_lib/auth.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+import { listProjectsWithComments } from '../../_lib/store.js'
+
+// Super-admin only: every project that has received a comment, ordered by most
+// recent comment, with counts, claim state, and owner emails.
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireSuperAdmin(req, res)
+  if (!user) return
+
+  try {
+    const projects = await listProjectsWithComments()
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json(projects)
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/admin/users.test.ts
+++ b/api/v1/admin/users.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/auth.js', () => ({ requireSuperAdmin: vi.fn() }))
+vi.mock('../../_lib/store.js', () => ({ listAllUsers: vi.fn() }))
+
+import handler from './users.js'
+import { requireSuperAdmin } from '../../_lib/auth.js'
+import { listAllUsers } from '../../_lib/store.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(requireSuperAdmin).mockReset()
+  vi.mocked(listAllUsers).mockReset()
+})
+
+describe('api/v1/admin/users', () => {
+  it('handles preflight OPTIONS', async () => {
+    const res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('returns 405 for non-GET', async () => {
+    const res = mockRes()
+    await call({ method: 'POST', query: {}, body: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+  })
+
+  it('returns 403 when not a super admin', async () => {
+    vi.mocked(requireSuperAdmin).mockImplementation(async (_req, res) => {
+      res.status(403).json({ error: 'Forbidden' })
+      return null
+    })
+    const res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+    expect(listAllUsers).not.toHaveBeenCalled()
+  })
+
+  it('returns the user list, 500 on store throw', async () => {
+    vi.mocked(requireSuperAdmin).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    vi.mocked(listAllUsers).mockResolvedValueOnce([{ id: 'u', email: 'a@b.c', createdAt: 't', projectCount: 1 }])
+    let res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual([{ id: 'u', email: 'a@b.c', createdAt: 't', projectCount: 1 }])
+
+    vi.mocked(listAllUsers).mockRejectedValueOnce(new Error('boom'))
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/admin/users.ts
+++ b/api/v1/admin/users.ts
@@ -1,0 +1,21 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { requireSuperAdmin } from '../../_lib/auth.js'
+import { handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+import { listAllUsers } from '../../_lib/store.js'
+
+// Super-admin only: every auth user, newest first, with project counts.
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+  const user = await requireSuperAdmin(req, res)
+  if (!user) return
+
+  try {
+    const users = await listAllUsers()
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json(users)
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -4,6 +4,7 @@ import { useProjects } from './hooks/useProjects'
 import { useComments } from './hooks/useComments'
 import { useAgentSession } from './hooks/useAgentSession'
 import { useAuth } from './hooks/useAuth'
+import { useSuperAdmin } from './hooks/useSuperAdmin'
 import { getDisplayStatus, isInactive, mapServerComment } from './lib/comment'
 import { relPath } from './lib/routes'
 import { AGENTS, type Comment, type ImplStatus, type ReviewStatus, type StatusFilter } from './lib/types'
@@ -18,6 +19,7 @@ import { ResetPasswordPage } from './components/ResetPasswordPage'
 import { WelcomeScreen } from './components/WelcomeScreen'
 import { AddProjectPopover } from './components/AddProjectPopover'
 import { ProjectSettings } from './components/ProjectSettings'
+import { SuperAdminPanel } from './components/SuperAdminPanel'
 import { Spinner } from './components/primitives'
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'https://crrt.ai/api'
@@ -71,8 +73,9 @@ export function App() {
 
 function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: string; user: import('@supabase/supabase-js').User; onSignOut: () => void }) {
   const { projects, loading: projectsLoading, error: projectsError, claimProject, checkAvailability, refresh: refreshProjects } = useProjects(API_BASE, accessToken)
+  const { superadmin } = useSuperAdmin(API_BASE, accessToken)
   const [selectedProject, setSelectedProject] = useState<string>('')
-  const [view, setView] = useState<'feedback' | 'settings'>('feedback')
+  const [view, setView] = useState<'feedback' | 'settings' | 'super-admin'>('feedback')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const [selectedCommentId, setSelectedCommentId] = useState<string>('')
   const { comments: serverComments, loading: commentsLoading, error: commentsError, refresh: refreshComments } = useComments(API_BASE, accessToken, selectedProject || null)
@@ -395,9 +398,14 @@ function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: strin
         toggleTheme={() => setTheme((t) => t === 'light' ? 'dark' : 'light')}
         user={user}
         onSignOut={onSignOut}
+        superadmin={superadmin}
+        superAdminActive={view === 'super-admin'}
+        onOpenSuperAdmin={() => setView((v) => (v === 'super-admin' ? 'feedback' : 'super-admin'))}
       />
 
-      {view === 'settings' && activeProject ? (
+      {view === 'super-admin' && superadmin ? (
+        <SuperAdminPanel apiBase={API_BASE} accessToken={accessToken} />
+      ) : view === 'settings' && activeProject ? (
         <ProjectSettings
           project={activeProject}
           apiBase={API_BASE}

--- a/apps/dashboard/api.ts
+++ b/apps/dashboard/api.ts
@@ -138,6 +138,43 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   }
 }
 
+export interface AdminUser {
+  id: string
+  email: string | null
+  createdAt: string
+  projectCount: number
+}
+
+export interface AdminProject {
+  publicKey: string
+  name: string
+  createdAt: string
+  commentCount: number
+  latestCommentAt: string
+  claimed: boolean
+  owners: string[]
+}
+
+// Whether the current user may see the Super Admin section. The server makes
+// the real decision on every /v1/admin/* call; this only drives UI visibility.
+export function getSuperAdminStatus(apiBase: string, accessToken: string) {
+  return requestJson<{ isSuperAdmin: boolean }>(`${apiBase}/v1/admin/me`, {
+    headers: { ...authHeaders(accessToken) },
+  })
+}
+
+export function listAdminUsers(apiBase: string, accessToken: string) {
+  return requestJson<AdminUser[]>(`${apiBase}/v1/admin/users`, {
+    headers: { ...authHeaders(accessToken) },
+  })
+}
+
+export function listAdminProjects(apiBase: string, accessToken: string) {
+  return requestJson<AdminProject[]>(`${apiBase}/v1/admin/projects`, {
+    headers: { ...authHeaders(accessToken) },
+  })
+}
+
 export function listProjects(apiBase: string, accessToken: string) {
   return requestJson<Project[]>(`${apiBase}/v1/projects`, {
     headers: {

--- a/apps/dashboard/api.ts
+++ b/apps/dashboard/api.ts
@@ -145,6 +145,11 @@ export interface AdminUser {
   projectCount: number
 }
 
+export interface AdminProjectMember {
+  email: string
+  role: 'admin' | 'member'
+}
+
 export interface AdminProject {
   publicKey: string
   name: string
@@ -152,7 +157,7 @@ export interface AdminProject {
   commentCount: number
   latestCommentAt: string
   claimed: boolean
-  owners: string[]
+  members: AdminProjectMember[]
 }
 
 // Whether the current user may see the Super Admin section. The server makes

--- a/apps/dashboard/components/Header.tsx
+++ b/apps/dashboard/components/Header.tsx
@@ -3,7 +3,7 @@ import { cn } from '../lib/utils'
 import { asset } from '../lib/routes'
 import type { Project, ProjectKeyAvailability } from '../api'
 import type { StatusFilter } from '../lib/types'
-import { MoonIcon, PlusIcon, SearchIcon, SettingsIcon, SunIcon } from './icons'
+import { MoonIcon, PlusIcon, SearchIcon, SettingsIcon, ShieldIcon, SunIcon } from './icons'
 import { Spinner } from './primitives'
 import { AddProjectPopover } from './AddProjectPopover'
 import { NotificationBell } from './NotificationBell'
@@ -35,6 +35,9 @@ interface HeaderProps {
   toggleTheme: () => void
   user: User
   onSignOut: () => void
+  superadmin: boolean
+  superAdminActive: boolean
+  onOpenSuperAdmin: () => void
 }
 
 export function Header({
@@ -63,6 +66,9 @@ export function Header({
   toggleTheme,
   user,
   onSignOut,
+  superadmin,
+  superAdminActive,
+  onOpenSuperAdmin,
 }: HeaderProps) {
   return (
     <header className="flex items-center gap-3 px-5 h-[60px] shrink-0 border-b border-border bg-card">
@@ -168,6 +174,20 @@ export function Header({
           userId={user.id}
           onProjectsChanged={onProjectsChanged}
         />
+        {superadmin && (
+          <button
+            onClick={onOpenSuperAdmin}
+            title="Super admin"
+            aria-label="Super admin"
+            aria-pressed={superAdminActive}
+            className={cn(
+              'w-7 h-7 rounded-md flex items-center justify-center transition-colors',
+              superAdminActive ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-accent',
+            )}
+          >
+            <ShieldIcon size={15} />
+          </button>
+        )}
         {selectedProject && (
           <button
             onClick={onOpenSettings}

--- a/apps/dashboard/components/SuperAdminPanel.tsx
+++ b/apps/dashboard/components/SuperAdminPanel.tsx
@@ -43,13 +43,12 @@ function ColumnState({ loading, error, empty, emptyLabel }: { loading: boolean; 
 export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) {
   const { users, projects, loading, error } = useAdminData(apiBase, accessToken)
 
-  // Click a user to scope the projects column to the ones they own (their
-  // email appears in a project's owners). Click again, or hit the clear chip,
-  // to drop the filter.
+  // Click a user to scope the projects column to the ones they belong to (as
+  // admin or member). Click again, or hit the clear chip, to drop the filter.
   const [filterEmail, setFilterEmail] = useState<string | null>(null)
 
   const filteredProjects = useMemo(
-    () => (filterEmail ? projects.filter((p) => p.owners.includes(filterEmail)) : projects),
+    () => (filterEmail ? projects.filter((p) => p.members.some((m) => m.email === filterEmail)) : projects),
     [projects, filterEmail],
   )
 
@@ -116,7 +115,7 @@ export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) 
               )}
             </div>
             <p className="text-[11px] text-muted-foreground">
-              {filterEmail ? `${filteredProjects.length} owned by this user` : 'Latest comment first'}
+              {filterEmail ? `${filteredProjects.length} with this user` : 'Latest comment first'}
             </p>
           </div>
           <div className="flex-1 overflow-y-auto">
@@ -124,33 +123,50 @@ export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) 
               loading={loading}
               error={error}
               empty={filteredProjects.length === 0}
-              emptyLabel={filterEmail ? 'This user owns no projects with comments.' : 'No projects have received comments yet.'}
+              emptyLabel={filterEmail ? 'This user is not in any projects with comments.' : 'No projects have received comments yet.'}
             />
-            {!loading && !error && filteredProjects.map((p) => (
-              <div key={p.publicKey} className="px-4 py-3 border-b border-border/50">
-                <div className="flex items-center justify-between gap-2 mb-1">
-                  <span className="text-[13px] font-bold text-foreground truncate">{p.name}</span>
-                  <span
-                    className={cn(
-                      'text-[10px] font-semibold px-1.5 py-0.5 rounded-full shrink-0',
-                      p.claimed ? 'bg-status-accepted-bg text-status-accepted' : 'bg-muted text-muted-foreground',
-                    )}
-                  >
-                    {p.claimed ? 'Claimed' : 'Unclaimed'}
-                  </span>
+            {!loading && !error && filteredProjects.map((p) => {
+              const owners = p.members.filter((m) => m.role === 'admin').map((m) => m.email)
+              // While filtering by a user, surface that user's role in this project.
+              const filterRole = filterEmail ? p.members.find((m) => m.email === filterEmail)?.role : undefined
+              return (
+                <div key={p.publicKey} className="px-4 py-3 border-b border-border/50">
+                  <div className="flex items-center justify-between gap-2 mb-1">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="text-[13px] font-bold text-foreground truncate">{p.name}</span>
+                      {filterRole && (
+                        <span
+                          className={cn(
+                            'text-[10px] font-semibold px-1.5 py-0.5 rounded-full shrink-0 uppercase tracking-wide',
+                            filterRole === 'admin' ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground',
+                          )}
+                        >
+                          {filterRole}
+                        </span>
+                      )}
+                    </div>
+                    <span
+                      className={cn(
+                        'text-[10px] font-semibold px-1.5 py-0.5 rounded-full shrink-0',
+                        p.claimed ? 'bg-status-accepted-bg text-status-accepted' : 'bg-muted text-muted-foreground',
+                      )}
+                    >
+                      {p.claimed ? 'Claimed' : 'Unclaimed'}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+                    <span className="font-mono">{p.publicKey}</span>
+                    <span>{p.commentCount} {p.commentCount === 1 ? 'comment' : 'comments'}</span>
+                    <span>latest {timeAgo(p.latestCommentAt)}</span>
+                  </div>
+                  {owners.length > 0 && (
+                    <p className="text-[11px] text-muted-foreground/70 mt-0.5 truncate">
+                      owners: {owners.join(', ')}
+                    </p>
+                  )}
                 </div>
-                <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
-                  <span className="font-mono">{p.publicKey}</span>
-                  <span>{p.commentCount} {p.commentCount === 1 ? 'comment' : 'comments'}</span>
-                  <span>latest {timeAgo(p.latestCommentAt)}</span>
-                </div>
-                {p.owners.length > 0 && (
-                  <p className="text-[11px] text-muted-foreground/70 mt-0.5 truncate">
-                    owners: {p.owners.join(', ')}
-                  </p>
-                )}
-              </div>
-            ))}
+              )
+            })}
           </div>
         </div>
       </div>

--- a/apps/dashboard/components/SuperAdminPanel.tsx
+++ b/apps/dashboard/components/SuperAdminPanel.tsx
@@ -1,7 +1,8 @@
+import { useMemo, useState } from 'react'
 import { cn } from '../lib/utils'
 import { timeAgo } from '../lib/format'
 import { useAdminData } from '../hooks/useAdminData'
-import { ShieldIcon } from './icons'
+import { ShieldIcon, XIcon } from './icons'
 import { Spinner } from './primitives'
 
 interface SuperAdminPanelProps {
@@ -42,6 +43,16 @@ function ColumnState({ loading, error, empty, emptyLabel }: { loading: boolean; 
 export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) {
   const { users, projects, loading, error } = useAdminData(apiBase, accessToken)
 
+  // Click a user to scope the projects column to the ones they own (their
+  // email appears in a project's owners). Click again, or hit the clear chip,
+  // to drop the filter.
+  const [filterEmail, setFilterEmail] = useState<string | null>(null)
+
+  const filteredProjects = useMemo(
+    () => (filterEmail ? projects.filter((p) => p.owners.includes(filterEmail)) : projects),
+    [projects, filterEmail],
+  )
+
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
       <div className="flex items-center gap-2 px-5 h-11 shrink-0 border-b border-border bg-card">
@@ -61,29 +72,61 @@ export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) 
           </div>
           <div className="flex-1 overflow-y-auto">
             <ColumnState loading={loading} error={error} empty={users.length === 0} emptyLabel="No users yet." />
-            {!loading && !error && users.map((u) => (
-              <div key={u.id} className="px-4 py-3 border-b border-border/50">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-[13px] font-bold text-foreground truncate">{u.email ?? u.id}</span>
-                  <span className="text-[10px] text-muted-foreground/60 shrink-0">{timeAgo(u.createdAt)}</span>
-                </div>
-                <p className="text-[11px] text-muted-foreground mt-0.5">
-                  {u.projectCount} {u.projectCount === 1 ? 'project' : 'projects'}
-                </p>
-              </div>
-            ))}
+            {!loading && !error && users.map((u) => {
+              const active = u.email !== null && u.email === filterEmail
+              return (
+                <button
+                  key={u.id}
+                  type="button"
+                  disabled={u.email === null}
+                  onClick={() => setFilterEmail((cur) => (cur === u.email ? null : u.email))}
+                  className={cn(
+                    'w-full text-left px-4 py-3 border-b border-border/50 border-l-[3px] transition-colors',
+                    active ? 'border-l-primary bg-white/[0.04]' : 'border-l-transparent',
+                    u.email === null ? 'cursor-default' : 'hover:bg-white/[0.02]',
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-[13px] font-bold text-foreground truncate">{u.email ?? u.id}</span>
+                    <span className="text-[10px] text-muted-foreground/60 shrink-0">{timeAgo(u.createdAt)}</span>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground mt-0.5">
+                    {u.projectCount} {u.projectCount === 1 ? 'project' : 'projects'}
+                  </p>
+                </button>
+              )
+            })}
           </div>
         </div>
 
         {/* Projects with comments — latest comment first */}
         <div className="flex-1 flex flex-col bg-background overflow-hidden">
           <div className={SECTION_HEADER}>
-            <h2 className="text-base font-bold text-foreground tracking-tight">Projects with comments</h2>
-            <p className="text-[11px] text-muted-foreground">Latest comment first</p>
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="text-base font-bold text-foreground tracking-tight">Projects with comments</h2>
+              {filterEmail && (
+                <button
+                  type="button"
+                  onClick={() => setFilterEmail(null)}
+                  className="flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-full bg-primary/15 text-primary hover:bg-primary/25 transition-colors max-w-[220px]"
+                >
+                  <span className="truncate">{filterEmail}</span>
+                  <XIcon size={11} />
+                </button>
+              )}
+            </div>
+            <p className="text-[11px] text-muted-foreground">
+              {filterEmail ? `${filteredProjects.length} owned by this user` : 'Latest comment first'}
+            </p>
           </div>
           <div className="flex-1 overflow-y-auto">
-            <ColumnState loading={loading} error={error} empty={projects.length === 0} emptyLabel="No projects have received comments yet." />
-            {!loading && !error && projects.map((p) => (
+            <ColumnState
+              loading={loading}
+              error={error}
+              empty={filteredProjects.length === 0}
+              emptyLabel={filterEmail ? 'This user owns no projects with comments.' : 'No projects have received comments yet.'}
+            />
+            {!loading && !error && filteredProjects.map((p) => (
               <div key={p.publicKey} className="px-4 py-3 border-b border-border/50">
                 <div className="flex items-center justify-between gap-2 mb-1">
                   <span className="text-[13px] font-bold text-foreground truncate">{p.name}</span>

--- a/apps/dashboard/components/SuperAdminPanel.tsx
+++ b/apps/dashboard/components/SuperAdminPanel.tsx
@@ -1,0 +1,116 @@
+import { cn } from '../lib/utils'
+import { timeAgo } from '../lib/format'
+import { useAdminData } from '../hooks/useAdminData'
+import { ShieldIcon } from './icons'
+import { Spinner } from './primitives'
+
+interface SuperAdminPanelProps {
+  apiBase: string
+  accessToken: string
+}
+
+const SECTION_HEADER = 'px-4 pt-4 pb-2.5 border-b border-border'
+const CRT_LABEL = { fontFamily: 'var(--crrt-font-crt)', fontSize: 11, letterSpacing: '0.08em' } as const
+
+function ColumnState({ loading, error, empty, emptyLabel }: { loading: boolean; error: string | null; empty: boolean; emptyLabel: string }) {
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-center px-8 gap-3">
+        <Spinner />
+        <p className="text-xs text-muted-foreground">Loading…</p>
+      </div>
+    )
+  }
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-center px-8">
+        <p className="text-sm font-semibold text-status-rejected mb-1">Failed to load</p>
+        <p className="text-xs text-muted-foreground">{error}</p>
+      </div>
+    )
+  }
+  if (empty) {
+    return (
+      <div className="flex items-center justify-center h-full text-center px-8">
+        <p className="text-xs text-muted-foreground">{emptyLabel}</p>
+      </div>
+    )
+  }
+  return null
+}
+
+export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) {
+  const { users, projects, loading, error } = useAdminData(apiBase, accessToken)
+
+  return (
+    <div className="flex flex-col flex-1 overflow-hidden">
+      <div className="flex items-center gap-2 px-5 h-11 shrink-0 border-b border-border bg-card">
+        <ShieldIcon size={14} className="text-primary" />
+        <span className="text-foreground" style={CRT_LABEL}>SUPER ADMIN</span>
+        <span className="text-[11px] text-muted-foreground ml-2">
+          {users.length} users · {projects.length} projects with comments
+        </span>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Users — newest first */}
+        <div className="w-[380px] shrink-0 flex flex-col border-r border-border bg-card">
+          <div className={SECTION_HEADER}>
+            <h2 className="text-base font-bold text-foreground tracking-tight">Users</h2>
+            <p className="text-[11px] text-muted-foreground">Newest first</p>
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            <ColumnState loading={loading} error={error} empty={users.length === 0} emptyLabel="No users yet." />
+            {!loading && !error && users.map((u) => (
+              <div key={u.id} className="px-4 py-3 border-b border-border/50">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-[13px] font-bold text-foreground truncate">{u.email ?? u.id}</span>
+                  <span className="text-[10px] text-muted-foreground/60 shrink-0">{timeAgo(u.createdAt)}</span>
+                </div>
+                <p className="text-[11px] text-muted-foreground mt-0.5">
+                  {u.projectCount} {u.projectCount === 1 ? 'project' : 'projects'}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Projects with comments — latest comment first */}
+        <div className="flex-1 flex flex-col bg-background overflow-hidden">
+          <div className={SECTION_HEADER}>
+            <h2 className="text-base font-bold text-foreground tracking-tight">Projects with comments</h2>
+            <p className="text-[11px] text-muted-foreground">Latest comment first</p>
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            <ColumnState loading={loading} error={error} empty={projects.length === 0} emptyLabel="No projects have received comments yet." />
+            {!loading && !error && projects.map((p) => (
+              <div key={p.publicKey} className="px-4 py-3 border-b border-border/50">
+                <div className="flex items-center justify-between gap-2 mb-1">
+                  <span className="text-[13px] font-bold text-foreground truncate">{p.name}</span>
+                  <span
+                    className={cn(
+                      'text-[10px] font-semibold px-1.5 py-0.5 rounded-full shrink-0',
+                      p.claimed ? 'bg-status-accepted-bg text-status-accepted' : 'bg-muted text-muted-foreground',
+                    )}
+                  >
+                    {p.claimed ? 'Claimed' : 'Unclaimed'}
+                  </span>
+                </div>
+                <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+                  <span className="font-mono">{p.publicKey}</span>
+                  <span>{p.commentCount} {p.commentCount === 1 ? 'comment' : 'comments'}</span>
+                  <span>latest {timeAgo(p.latestCommentAt)}</span>
+                </div>
+                {p.owners.length > 0 && (
+                  <p className="text-[11px] text-muted-foreground/70 mt-0.5 truncate">
+                    owners: {p.owners.join(', ')}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/components/icons.tsx
+++ b/apps/dashboard/components/icons.tsx
@@ -10,6 +10,10 @@ export function CheckIcon({ size = 16 }: { size?: number }) {
   return <SvgIcon d="M5 12l5 5L20 7" size={size} />
 }
 
+export function ShieldIcon({ size = 15, className }: { size?: number; className?: string }) {
+  return <SvgIcon d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" size={size} className={className} />
+}
+
 export function XIcon({ size = 16 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/apps/dashboard/hooks/useAdminData.ts
+++ b/apps/dashboard/hooks/useAdminData.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react'
+import { listAdminProjects, listAdminUsers, type AdminProject, type AdminUser } from '../api'
+
+interface UseAdminDataResult {
+  users: AdminUser[]
+  projects: AdminProject[]
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+}
+
+/**
+ * Loads the super-admin overview (all users + all projects with comments) in
+ * one shot. Mirrors `useProjects`' loading/error/refresh shape. Only mounted
+ * once the user is confirmed to be a super admin.
+ */
+export function useAdminData(apiBase: string, accessToken: string): UseAdminDataResult {
+  const [users, setUsers] = useState<AdminUser[]>([])
+  const [projects, setProjects] = useState<AdminProject[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [u, p] = await Promise.all([
+        listAdminUsers(apiBase, accessToken),
+        listAdminProjects(apiBase, accessToken),
+      ])
+      setUsers(u)
+      setProjects(p)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load admin data')
+    } finally {
+      setLoading(false)
+    }
+  }, [apiBase, accessToken])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  return { users, projects, loading, error, refresh }
+}

--- a/apps/dashboard/hooks/useSuperAdmin.ts
+++ b/apps/dashboard/hooks/useSuperAdmin.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import { getSuperAdminStatus } from '../api'
+import { mocksEnabled } from '../lib/mocks'
+
+export interface UseSuperAdminResult {
+  superadmin: boolean
+  loading: boolean
+}
+
+/**
+ * Resolves whether the signed-in user is a super admin via /v1/admin/me. This
+ * only gates UI visibility — every admin data endpoint re-checks server-side,
+ * so a forged `true` here grants nothing. Fails closed (false) on any error.
+ */
+export function useSuperAdmin(apiBase: string, accessToken: string): UseSuperAdminResult {
+  const [superadmin, setSuperadmin] = useState(false)
+  const [loading, setLoading] = useState(!mocksEnabled)
+
+  useEffect(() => {
+    if (mocksEnabled) return
+    let cancelled = false
+    getSuperAdminStatus(apiBase, accessToken)
+      .then((res) => { if (!cancelled) setSuperadmin(res.isSuperAdmin) })
+      .catch(() => { if (!cancelled) setSuperadmin(false) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [apiBase, accessToken])
+
+  return { superadmin, loading }
+}

--- a/db/migrations/0006_calm_the_professor.sql
+++ b/db/migrations/0006_calm_the_professor.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "super_admins" (
+	"user_id" uuid PRIMARY KEY NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "super_admins" ADD CONSTRAINT "super_admins_user_id_auth_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "super_admins" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "super_admins" FORCE ROW LEVEL SECURITY;

--- a/db/migrations/0007_admin_aggregate_rpcs.sql
+++ b/db/migrations/0007_admin_aggregate_rpcs.sql
@@ -1,0 +1,52 @@
+-- Super-admin aggregate RPCs.
+--
+-- Replaces two full-table scans that were aggregated in Node:
+--   * listAllUsers() pulled every `project_members` row and counted per user.
+--   * listProjectsWithComments() pulled every `comments` row and aggregated
+--     count + latest-per-project.
+-- Both are vulnerable to PostgREST's max-rows cap silently truncating the
+-- result, which would make counts/the project set incomplete. Aggregating in
+-- the DB keeps the work where the data is and the transferred rows bounded.
+--
+-- Both run via the service-role client, which bypasses RLS (same as the rest
+-- of api/). Mirrors the existing remove_project_member RPC (migration 0003).
+
+-- Comment count + latest comment per project, joined to project metadata,
+-- newest-comment-first, bounded by p_limit. Inner join => only projects that
+-- have received at least one comment, matching the previous behaviour.
+create or replace function admin_projects_with_comments(p_limit int default 100)
+returns table (
+  public_key text,
+  name text,
+  claimable boolean,
+  created_at timestamptz,
+  comment_count bigint,
+  latest_comment_at timestamptz
+)
+language sql
+stable
+as $$
+  select p.public_key, p.name, p.claimable, p.created_at,
+         count(c.id) as comment_count,
+         max(c.created_at) as latest_comment_at
+  from projects p
+  join comments c on c.project_id = p.public_key
+  group by p.public_key, p.name, p.claimable, p.created_at
+  order by latest_comment_at desc
+  limit p_limit;
+$$;
+
+-- One row per user that belongs to at least one project. Bounded by the number
+-- of users, not the number of memberships.
+create or replace function admin_user_project_counts()
+returns table (
+  user_id uuid,
+  project_count bigint
+)
+language sql
+stable
+as $$
+  select user_id, count(*) as project_count
+  from project_members
+  group by user_id;
+$$;

--- a/db/migrations/meta/0006_snapshot.json
+++ b/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1141 @@
+{
+  "id": "55c42354-64a8-425f-8db3-b9d0e4162698",
+  "prevId": "4ec64d25-9c05-424e-b8ed-451d44e145ed",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_presence_share_seen_idx": {
+          "name": "agent_presence_share_seen_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_presence_share_id_feedback_shares_id_fk": {
+          "name": "agent_presence_share_id_feedback_shares_id_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_presence_share_id_agent_id_pk": {
+          "name": "agent_presence_share_id_agent_id_pk",
+          "columns": [
+            "share_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "implementation_status": {
+          "name": "implementation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unassigned'"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'element_point'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_project_created_idx": {
+          "name": "comments_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_project_url_idx": {
+          "name": "comments_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_project_status_idx": {
+          "name": "comments_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "implementation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_events": {
+      "name": "feedback_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feedback_events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_events_share_id_idx": {
+          "name": "feedback_events_share_id_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_events_share_id_feedback_shares_id_fk": {
+          "name": "feedback_events_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_events",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_events_comment_id_comments_id_fk": {
+          "name": "feedback_events_comment_id_comments_id_fk",
+          "tableFrom": "feedback_events",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_operation_keys": {
+      "name": "feedback_operation_keys",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_event_id": {
+          "name": "feedback_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_operation_keys_share_id_feedback_shares_id_fk": {
+          "name": "feedback_operation_keys_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_operation_keys_feedback_event_id_feedback_events_id_fk": {
+          "name": "feedback_operation_keys_feedback_event_id_feedback_events_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "tableTo": "feedback_events",
+          "columnsFrom": [
+            "feedback_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_operation_keys_share_id_agent_id_idempotency_key_pk": {
+          "name": "feedback_operation_keys_share_id_agent_id_idempotency_key_pk",
+          "columns": [
+            "share_id",
+            "agent_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_share_items": {
+      "name": "feedback_share_items",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_share_items_share_id_feedback_shares_id_fk": {
+          "name": "feedback_share_items_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_share_items",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_share_items_comment_id_comments_id_fk": {
+          "name": "feedback_share_items_comment_id_comments_id_fk",
+          "tableFrom": "feedback_share_items",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_share_items_share_id_comment_id_pk": {
+          "name": "feedback_share_items_share_id_comment_id_pk",
+          "columns": [
+            "share_id",
+            "comment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_shares": {
+      "name": "feedback_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_page_url": {
+          "name": "scope_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_shares_one_project_scope_per_project": {
+          "name": "feedback_shares_one_project_scope_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "scope_type = 'project' and revoked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_shares_project_id_projects_public_key_fk": {
+          "name": "feedback_shares_project_id_projects_public_key_fk",
+          "tableFrom": "feedback_shares",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_shares_slug_unique": {
+          "name": "feedback_shares_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feedback_shares_scope_type_check": {
+          "name": "feedback_shares_scope_type_check",
+          "value": "\"feedback_shares\".\"scope_type\" in ('page', 'selection', 'project')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_kind_check": {
+          "name": "notifications_kind_check",
+          "value": "\"notifications\".\"kind\" in ('invite.received', 'invite.accepted', 'invite.declined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_invites": {
+      "name": "project_invites",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invites_email_idx": {
+          "name": "project_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invites_project_key_projects_public_key_fk": {
+          "name": "project_invites_project_key_projects_public_key_fk",
+          "tableFrom": "project_invites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_invites_project_key_email_pk": {
+          "name": "project_invites_project_key_email_pk",
+          "columns": [
+            "project_key",
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_invites_role_check": {
+          "name": "project_invites_role_check",
+          "value": "\"project_invites\".\"role\" in ('admin', 'member')"
+        },
+        "project_invites_email_lower_check": {
+          "name": "project_invites_email_lower_check",
+          "value": "\"project_invites\".\"email\" = lower(\"project_invites\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_key_projects_public_key_fk": {
+          "name": "project_members_project_key_projects_public_key_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_key_user_id_pk": {
+          "name": "project_members_project_key_user_id_pk",
+          "columns": [
+            "project_key",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_members_role_check": {
+          "name": "project_members_role_check",
+          "value": "\"project_members\".\"role\" in ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_repo_configs": {
+      "name": "project_repo_configs",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_command": {
+          "name": "dev_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command": {
+          "name": "build_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instructions": {
+          "name": "agent_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_repo_configs_project_key_projects_public_key_fk": {
+          "name": "project_repo_configs_project_key_projects_public_key_fk",
+          "tableFrom": "project_repo_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claimable": {
+          "name": "claimable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.super_admins": {
+      "name": "super_admins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/0007_snapshot.json
+++ b/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1141 @@
+{
+  "id": "9ddbb920-ed6a-426e-8179-0919d4d5df23",
+  "prevId": "55c42354-64a8-425f-8db3-b9d0e4162698",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_presence_share_seen_idx": {
+          "name": "agent_presence_share_seen_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_presence_share_id_feedback_shares_id_fk": {
+          "name": "agent_presence_share_id_feedback_shares_id_fk",
+          "tableFrom": "agent_presence",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_presence_share_id_agent_id_pk": {
+          "name": "agent_presence_share_id_agent_id_pk",
+          "columns": [
+            "share_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "implementation_status": {
+          "name": "implementation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unassigned'"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'element_point'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_project_created_idx": {
+          "name": "comments_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "comments_project_url_idx": {
+          "name": "comments_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "comments_project_status_idx": {
+          "name": "comments_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "implementation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_events": {
+      "name": "feedback_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "feedback_events_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_events_share_id_idx": {
+          "name": "feedback_events_share_id_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_events_share_id_feedback_shares_id_fk": {
+          "name": "feedback_events_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_events",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_events_comment_id_comments_id_fk": {
+          "name": "feedback_events_comment_id_comments_id_fk",
+          "tableFrom": "feedback_events",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_operation_keys": {
+      "name": "feedback_operation_keys",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_event_id": {
+          "name": "feedback_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_operation_keys_share_id_feedback_shares_id_fk": {
+          "name": "feedback_operation_keys_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_operation_keys_feedback_event_id_feedback_events_id_fk": {
+          "name": "feedback_operation_keys_feedback_event_id_feedback_events_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "columnsFrom": [
+            "feedback_event_id"
+          ],
+          "tableTo": "feedback_events",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_operation_keys_share_id_agent_id_idempotency_key_pk": {
+          "name": "feedback_operation_keys_share_id_agent_id_idempotency_key_pk",
+          "columns": [
+            "share_id",
+            "agent_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_share_items": {
+      "name": "feedback_share_items",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_share_items_share_id_feedback_shares_id_fk": {
+          "name": "feedback_share_items_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_share_items",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "tableTo": "feedback_shares",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feedback_share_items_comment_id_comments_id_fk": {
+          "name": "feedback_share_items_comment_id_comments_id_fk",
+          "tableFrom": "feedback_share_items",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_share_items_share_id_comment_id_pk": {
+          "name": "feedback_share_items_share_id_comment_id_pk",
+          "columns": [
+            "share_id",
+            "comment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_shares": {
+      "name": "feedback_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_page_url": {
+          "name": "scope_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_shares_one_project_scope_per_project": {
+          "name": "feedback_shares_one_project_scope_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "scope_type = 'project' and revoked_at is null",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feedback_shares_project_id_projects_public_key_fk": {
+          "name": "feedback_shares_project_id_projects_public_key_fk",
+          "tableFrom": "feedback_shares",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_shares_slug_unique": {
+          "name": "feedback_shares_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feedback_shares_scope_type_check": {
+          "name": "feedback_shares_scope_type_check",
+          "value": "\"feedback_shares\".\"scope_type\" in ('page', 'selection', 'project')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_kind_check": {
+          "name": "notifications_kind_check",
+          "value": "\"notifications\".\"kind\" in ('invite.received', 'invite.accepted', 'invite.declined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_invites": {
+      "name": "project_invites",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invites_email_idx": {
+          "name": "project_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "project_invites_project_key_projects_public_key_fk": {
+          "name": "project_invites_project_key_projects_public_key_fk",
+          "tableFrom": "project_invites",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_invites_project_key_email_pk": {
+          "name": "project_invites_project_key_email_pk",
+          "columns": [
+            "project_key",
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_invites_role_check": {
+          "name": "project_invites_role_check",
+          "value": "\"project_invites\".\"role\" in ('admin', 'member')"
+        },
+        "project_invites_email_lower_check": {
+          "name": "project_invites_email_lower_check",
+          "value": "\"project_invites\".\"email\" = lower(\"project_invites\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_key_projects_public_key_fk": {
+          "name": "project_members_project_key_projects_public_key_fk",
+          "tableFrom": "project_members",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_key_user_id_pk": {
+          "name": "project_members_project_key_user_id_pk",
+          "columns": [
+            "project_key",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_members_role_check": {
+          "name": "project_members_role_check",
+          "value": "\"project_members\".\"role\" in ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_repo_configs": {
+      "name": "project_repo_configs",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_command": {
+          "name": "dev_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command": {
+          "name": "build_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instructions": {
+          "name": "agent_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_repo_configs_project_key_projects_public_key_fk": {
+          "name": "project_repo_configs_project_key_projects_public_key_fk",
+          "tableFrom": "project_repo_configs",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "public_key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claimable": {
+          "name": "claimable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.super_admins": {
+      "name": "super_admins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1781287117627,
       "tag": "0005_remarkable_snowbird",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1781594640274,
+      "tag": "0006_calm_the_professor",
+      "breakpoints": true
     }
   ]
 }

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781594640274,
       "tag": "0006_calm_the_professor",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1781690028223,
+      "tag": "0007_admin_aggregate_rpcs",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -53,6 +53,15 @@ export const projectMembers = pgTable(
   }),
 )
 
+// Global super-admin allowlist. Membership grants cross-tenant read access
+// through the `/api/v1/admin/*` endpoints. `user_id` references auth.users(id);
+// as with project_members, Drizzle can't model the auth schema so that FK is
+// added by hand in the migration SQL. Grant by inserting a row.
+export const superAdmins = pgTable('super_admins', {
+  userId: uuid('user_id').primaryKey(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+})
+
 export const projectInvites = pgTable(
   'project_invites',
   {


### PR DESCRIPTION
- Stack 3 of 3 — base `super-admin/backend-data` (#142).
- Add a Super Admin view to the dashboard, opened from a shield button shown only to super admins.
- Show all users newest-first with their project counts.
- Show all projects that received feedback, ordered by latest comment, with counts, a claimed/unclaimed badge, and owner emails.
- Drive visibility from a server-resolved flag so the UI grants nothing on its own — every admin endpoint re-checks server-side.