### PR TITLE
Make CRRT widget safe to render on the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thedesignproject/crrt",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "CRRT 🥕 visual feedback capture for React apps",
   "license": "Apache-2.0",
   "repository": {

--- a/src/__tests__/FeedbackWidget.ssr.test.tsx
+++ b/src/__tests__/FeedbackWidget.ssr.test.tsx
@@ -1,0 +1,14 @@
+// @vitest-environment node
+
+import { createElement } from 'react'
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { FeedbackWidget } from '../components/FeedbackWidget'
+
+describe('FeedbackWidget SSR', () => {
+  it('renders without accessing browser globals', () => {
+    expect(() => renderToString(
+      createElement(FeedbackWidget, { projectId: 'project-test' }),
+    )).not.toThrow()
+  })
+})

--- a/src/__tests__/FeedbackWidget.test.tsx
+++ b/src/__tests__/FeedbackWidget.test.tsx
@@ -1691,6 +1691,19 @@ describe('<FeedbackWidget />', () => {
         expect(pathSpan).toBeDefined()
       })
     })
+
+    it('falls back to the root path when the browser pathname is empty', async () => {
+      vi.spyOn(window.location, 'pathname', 'get').mockReturnValue('')
+      mockFetch()
+      render(<FeedbackWidget projectId="proj" apiBase="https://x.example/api" />)
+      const { textarea } = await enterCommentingMode()
+      fireEvent.change(textarea, { target: { value: 'path fallback test' } })
+
+      await waitFor(() => {
+        const spans = Array.from(document.querySelectorAll<HTMLSpanElement>('[data-fw] span'))
+        expect(spans.some((span) => span.textContent === '/')).toBe(true)
+      })
+    })
   })
 
   describe('screenshot remove button (lines 766-767)', () => {

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -743,7 +743,7 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
 
   const pathDisplay = typeof window === 'undefined'
     ? '/'
-    : (window.location.pathname || '/').slice(0, 28) || '/'
+    : window.location.pathname.slice(0, 28) || '/'
   const avatarInitial = authorName ? (getInitials(authorName) ?? authorName[0]?.toUpperCase() ?? 'U') : 'U'
   const badgeAnimation = badgeAnim ? 'fw-badge-pop 0.4s ease' : 'crrt-pulse 2.4s ease-in-out infinite'
 

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -235,7 +235,9 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
   // Track current URL for SPA navigation (pins scoped to page).
   // Poll location.href because some routers (e.g. Next.js App Router) cache
   // history.pushState at module load and bypass any wrapper we install.
-  const [currentUrl, setCurrentUrl] = useState(() => window.location.href.split('#')[0])
+  const [currentUrl, setCurrentUrl] = useState(() => (
+    typeof window === 'undefined' ? '' : window.location.href.split('#')[0]
+  ))
   useEffect(() => {
     const id = window.setInterval(() => {
       const next = window.location.href.split('#')[0]
@@ -739,7 +741,9 @@ function FeedbackWidgetInner({ projectId, apiBase = 'https://crrt.ai/api' }: Omi
   // commenting flow, or persisted pins. Gating keeps idle pages cheap.
   needsPositionSyncRef.current = selectedPin !== null || mode !== 'idle' || !!target || (pinsVisible && filteredComments.length > 0)
 
-  const pathDisplay = (window.location.pathname || '/').slice(0, 28) || '/'
+  const pathDisplay = typeof window === 'undefined'
+    ? '/'
+    : (window.location.pathname || '/').slice(0, 28) || '/'
   const avatarInitial = authorName ? (getInitials(authorName) ?? authorName[0]?.toUpperCase() ?? 'U') : 'U'
   const badgeAnimation = badgeAnim ? 'fw-badge-pop 0.4s ease' : 'crrt-pulse 2.4s ease-in-out infinite'
 


### PR DESCRIPTION
- Prevent server rendering from reading browser-only globals during initial widget setup.
- Preserve client-side URL tracking once the widget mounts in the browser.
- Provide a stable fallback path while server-rendered markup is generated.
- Keep existing browser behavior unchanged after hydration.
- Bump the package to `0.3.14`; publishing this version is required for npm consumers to receive the SSR fix.