### PR TITLE
Update super admin analytics frontend

### DIFF
--- a/apps/dashboard/api.ts
+++ b/apps/dashboard/api.ts
@@ -142,7 +142,11 @@ export interface AdminUser {
   id: string
   email: string | null
   createdAt: string
-  projectCount: number
+  lastSignInAt: string | null
+  emailConfirmedAt: string | null
+  projectsAsAdminCount: number
+  projectsAsMemberCount: number
+  superAdmin: boolean
 }
 
 export interface AdminProjectMember {
@@ -155,9 +159,44 @@ export interface AdminProject {
   name: string
   createdAt: string
   commentCount: number
-  latestCommentAt: string
+  commentStatusCounts: { pending: number; accepted: number; rejected: number }
+  implementationStatusCounts: {
+    unassigned: number
+    claimed: number
+    inProgress: number
+    blocked: number
+    done: number
+  }
+  feedbackShareCount: number
+  commentedUrlCount: number
+  firstCommentAt: string
+  lastCommentAt: string
   claimed: boolean
   members: AdminProjectMember[]
+}
+
+export interface AdminPage<T> {
+  items: T[]
+  nextCursor: string | null
+  hasMore: boolean
+}
+
+export type AdminProjectSort =
+  | 'lastCommentAt'
+  | 'createdAt'
+  | 'commentCount'
+  | 'feedbackShareCount'
+  | 'commentedUrlCount'
+
+export type AdminSortDirection = 'asc' | 'desc'
+
+export interface AdminStats {
+  accounts: number
+  projects: number
+  comments: number
+  shares: number
+  activeAgentPresence: number
+  signups: { last24Hours: number; last7Days: number; last30Days: number }
 }
 
 // Whether the current user may see the Super Admin section. The server makes
@@ -168,14 +207,35 @@ export function getSuperAdminStatus(apiBase: string, accessToken: string) {
   })
 }
 
-export function listAdminUsers(apiBase: string, accessToken: string) {
-  return requestJson<AdminUser[]>(`${apiBase}/v1/admin/users`, {
+export function listAdminUsers(apiBase: string, accessToken: string, opts: { cursor?: string | null; limit?: number } = {}) {
+  const query = new URLSearchParams()
+  if (opts.limit) query.set('limit', String(opts.limit))
+  if (opts.cursor) query.set('cursor', opts.cursor)
+  const suffix = query.toString() ? `?${query.toString()}` : ''
+  return requestJson<AdminPage<AdminUser>>(`${apiBase}/v1/admin/users${suffix}`, {
     headers: { ...authHeaders(accessToken) },
   })
 }
 
-export function listAdminProjects(apiBase: string, accessToken: string) {
-  return requestJson<AdminProject[]>(`${apiBase}/v1/admin/projects`, {
+export function listAdminProjects(apiBase: string, accessToken: string, opts: {
+  cursor?: string | null
+  limit?: number
+  sort?: AdminProjectSort
+  direction?: AdminSortDirection
+} = {}) {
+  const query = new URLSearchParams()
+  if (opts.limit) query.set('limit', String(opts.limit))
+  if (opts.cursor) query.set('cursor', opts.cursor)
+  if (opts.sort) query.set('sort', opts.sort)
+  if (opts.direction) query.set('direction', opts.direction)
+  const suffix = query.toString() ? `?${query.toString()}` : ''
+  return requestJson<AdminPage<AdminProject>>(`${apiBase}/v1/admin/projects${suffix}`, {
+    headers: { ...authHeaders(accessToken) },
+  })
+}
+
+export function getAdminStats(apiBase: string, accessToken: string) {
+  return requestJson<AdminStats>(`${apiBase}/v1/admin/stats`, {
     headers: { ...authHeaders(accessToken) },
   })
 }

--- a/apps/dashboard/components/SuperAdminPanel.tsx
+++ b/apps/dashboard/components/SuperAdminPanel.tsx
@@ -321,7 +321,21 @@ function QuietMetric({ label, value, detail, tone }: { label: string; value: num
   )
 }
 
-function ProjectListView({ title, subtitle, projects }: { title: string; subtitle: string; projects: AdminProject[] }) {
+function ProjectListView({
+  title,
+  subtitle,
+  projects,
+  hasMore,
+  loadingMore,
+  onLoadMore,
+}: {
+  title: string
+  subtitle: string
+  projects: AdminProject[]
+  hasMore: boolean
+  loadingMore: boolean
+  onLoadMore: () => void
+}) {
   return (
     <div className="border-b border-border px-5 py-5">
       <div className="mb-3">
@@ -346,6 +360,7 @@ function ProjectListView({ title, subtitle, projects }: { title: string; subtitl
           </div>
         ))}
       </div>
+      <LoadMore visible={hasMore} busy={loadingMore} onClick={onLoadMore} label="Load more projects" />
     </div>
   )
 }
@@ -618,6 +633,9 @@ export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) 
             title="Projects"
             subtitle="ranked by product signal"
             projects={topProjects}
+            hasMore={projectsHasMore}
+            loadingMore={projectsLoadingMore}
+            onLoadMore={loadMoreProjects}
           />
         )}
         {!loading && !error && activeView === 'comments' && (
@@ -625,6 +643,9 @@ export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) 
             title="Comment Load"
             subtitle="highest pending or rejected volume"
             projects={attentionProjects}
+            hasMore={projectsHasMore}
+            loadingMore={projectsLoadingMore}
+            onLoadMore={loadMoreProjects}
           />
         )}
         {!loading && !error && activeView === 'shares' && (
@@ -632,6 +653,9 @@ export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) 
             title="Share Loops"
             subtitle="projects with strongest feedback sharing"
             projects={shareProjects}
+            hasMore={projectsHasMore}
+            loadingMore={projectsLoadingMore}
+            onLoadMore={loadMoreProjects}
           />
         )}
       </div>

--- a/apps/dashboard/components/SuperAdminPanel.tsx
+++ b/apps/dashboard/components/SuperAdminPanel.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
+import type { AdminProject, AdminProjectSort, AdminStats, AdminUser } from '../api'
 import { cn } from '../lib/utils'
 import { timeAgo } from '../lib/format'
 import { useAdminData } from '../hooks/useAdminData'
-import { ShieldIcon, XIcon } from './icons'
+import { CheckIcon, ChevronDownIcon, ShieldIcon } from './icons'
 import { Spinner } from './primitives'
 
 interface SuperAdminPanelProps {
@@ -10,10 +11,83 @@ interface SuperAdminPanelProps {
   accessToken: string
 }
 
+const countFmt = new Intl.NumberFormat('en-US')
 const SECTION_HEADER = 'px-4 pt-4 pb-2.5 border-b border-border'
 const CRT_LABEL = { fontFamily: 'var(--crrt-font-crt)', fontSize: 11, letterSpacing: '0.08em' } as const
+const DAY_MS = 24 * 60 * 60 * 1000
+type AdminView = 'overview' | 'accounts' | 'projects' | 'comments' | 'shares'
 
-function ColumnState({ loading, error, empty, emptyLabel }: { loading: boolean; error: string | null; empty: boolean; emptyLabel: string }) {
+function count(value: number | null | undefined) {
+  return countFmt.format(value ?? 0)
+}
+
+function daysSince(iso: string) {
+  return Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / DAY_MS))
+}
+
+function memberCount(project: AdminProject) {
+  return new Set(project.members.map((m) => m.email)).size
+}
+
+function potentialScore(project: AdminProject) {
+  const recency = Math.max(0, 20 - daysSince(project.lastCommentAt))
+  return Math.round(
+    project.commentCount * 1.4 +
+    project.feedbackShareCount * 8 +
+    project.commentedUrlCount * 3 +
+    memberCount(project) * 6 +
+    project.commentStatusCounts.accepted * 2 +
+    project.implementationStatusCounts.done * 1.5 +
+    recency -
+    project.commentStatusCounts.rejected,
+  )
+}
+
+function StatTile({ label, value, view, activeView, tone, onClick }: {
+  label: string
+  value: ReactNode
+  view: AdminView
+  activeView: AdminView
+  tone?: 'hot' | 'live'
+  onClick: (view: AdminView) => void
+}) {
+  const active = activeView === view
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(view)}
+      className={cn(
+        'min-w-0 border-r border-border px-4 py-2.5 text-left transition-colors last:border-r-0',
+        'hover:bg-white/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
+        active && 'bg-card',
+      )}
+      aria-pressed={active}
+    >
+      <div className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground truncate">{label}</div>
+      <div className={cn(
+        'mt-1 font-mono text-lg tabular-nums text-foreground truncate',
+        tone === 'hot' && active && 'text-primary',
+        tone === 'live' && active && 'text-agent-active',
+      )}>
+        {value}
+      </div>
+    </button>
+  )
+}
+
+function StatsStrip({ stats, activeView, onViewChange }: { stats: AdminStats | null; activeView: AdminView; onViewChange: (view: AdminView) => void }) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 border-b border-border bg-card">
+      <StatTile label="Overview" view="overview" activeView={activeView} onClick={onViewChange} value="View" tone="hot" />
+      <StatTile label="Accounts" view="accounts" activeView={activeView} onClick={onViewChange} value={count(stats?.accounts)} />
+      <StatTile label="Projects" view="projects" activeView={activeView} onClick={onViewChange} value={count(stats?.projects)} />
+      <StatTile label="Comments" view="comments" activeView={activeView} onClick={onViewChange} value={count(stats?.comments)} />
+      <StatTile label="Shares" view="shares" activeView={activeView} onClick={onViewChange} value={count(stats?.shares)} />
+    </div>
+  )
+}
+
+function PanelState({ loading, error, empty, emptyLabel }: { loading: boolean; error: string | null; empty: boolean; emptyLabel: string }) {
   if (loading) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-center px-8 gap-3">
@@ -24,9 +98,9 @@ function ColumnState({ loading, error, empty, emptyLabel }: { loading: boolean; 
   }
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-center px-8">
-        <p className="text-sm font-semibold text-status-rejected mb-1">Failed to load</p>
-        <p className="text-xs text-muted-foreground">{error}</p>
+      <div className="flex flex-col items-center justify-center h-full text-center px-8" role="alert">
+        <p className="text-sm font-semibold text-status-rejected mb-1">Load failed</p>
+        <p className="text-xs text-muted-foreground break-words">{error}</p>
       </div>
     )
   }
@@ -40,136 +114,527 @@ function ColumnState({ loading, error, empty, emptyLabel }: { loading: boolean; 
   return null
 }
 
-export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) {
-  const { users, projects, loading, error } = useAdminData(apiBase, accessToken)
-
-  // Click a user to scope the projects column to the ones they belong to (as
-  // admin or member). Click again, or hit the clear chip, to drop the filter.
-  const [filterEmail, setFilterEmail] = useState<string | null>(null)
-
-  const filteredProjects = useMemo(
-    () => (filterEmail ? projects.filter((p) => p.members.some((m) => m.email === filterEmail)) : projects),
-    [projects, filterEmail],
-  )
-
+function LoadMore({ visible, busy, onClick, label }: { visible: boolean; busy: boolean; onClick: () => void; label: string }) {
+  if (!visible) return null
   return (
-    <div className="flex flex-col flex-1 overflow-hidden">
-      <div className="flex items-center gap-2 px-5 h-11 shrink-0 border-b border-border bg-card">
-        <ShieldIcon size={14} className="text-primary" />
-        <span className="text-foreground" style={CRT_LABEL}>SUPER ADMIN</span>
-        <span className="text-[11px] text-muted-foreground ml-2">
-          {users.length} users · {projects.length} projects with comments
-        </span>
+    <div className="p-3">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={busy}
+        className="w-full h-8 rounded-md border border-border bg-card text-xs font-semibold text-muted-foreground hover:text-foreground hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 transition-colors"
+      >
+        {busy ? 'Loading…' : label}
+      </button>
+    </div>
+  )
+}
+
+function RoleBadge({ children, active }: { children: ReactNode; active?: boolean }) {
+  return (
+    <span className={cn(
+      'inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+      active ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground',
+    )}>
+      {children}
+    </span>
+  )
+}
+
+function UserRow({ user, active, onClick }: { user: AdminUser; active: boolean; onClick: () => void }) {
+  const adminCount = user.projectsAsAdminCount
+  const memberCount = user.projectsAsMemberCount
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'w-full text-left px-4 py-3 border-b border-border/50 border-l-[3px] transition-colors',
+        'hover:bg-white/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
+        active ? 'border-l-primary bg-white/[0.04]' : 'border-l-transparent',
+      )}
+    >
+      <div className="flex items-center justify-between gap-2 min-w-0">
+        <span className="text-[13px] font-bold text-foreground truncate">{user.email ?? user.id}</span>
+        {user.superAdmin && <RoleBadge active>super</RoleBadge>}
       </div>
+      <div className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">
+        <span>{adminCount} admin</span>
+        <span>{memberCount} member</span>
+        <span className="ml-auto shrink-0">{user.lastSignInAt ? `seen ${timeAgo(user.lastSignInAt)}` : 'never seen'}</span>
+      </div>
+    </button>
+  )
+}
 
-      <div className="flex flex-1 overflow-hidden">
-        {/* Users — newest first */}
-        <div className="w-[380px] shrink-0 flex flex-col border-r border-border bg-card">
-          <div className={SECTION_HEADER}>
-            <h2 className="text-base font-bold text-foreground tracking-tight">Users</h2>
-            <p className="text-[11px] text-muted-foreground">Newest first</p>
-          </div>
-          <div className="flex-1 overflow-y-auto">
-            <ColumnState loading={loading} error={error} empty={users.length === 0} emptyLabel="No users yet." />
-            {!loading && !error && users.map((u) => {
-              const active = u.email !== null && u.email === filterEmail
-              return (
-                <button
-                  key={u.id}
-                  type="button"
-                  disabled={u.email === null}
-                  onClick={() => setFilterEmail((cur) => (cur === u.email ? null : u.email))}
-                  className={cn(
-                    'w-full text-left px-4 py-3 border-b border-border/50 border-l-[3px] transition-colors',
-                    active ? 'border-l-primary bg-white/[0.04]' : 'border-l-transparent',
-                    u.email === null ? 'cursor-default' : 'hover:bg-white/[0.02]',
-                  )}
-                >
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-[13px] font-bold text-foreground truncate">{u.email ?? u.id}</span>
-                    <span className="text-[10px] text-muted-foreground/60 shrink-0">{timeAgo(u.createdAt)}</span>
-                  </div>
-                  <p className="text-[11px] text-muted-foreground mt-0.5">
-                    {u.projectCount} {u.projectCount === 1 ? 'project' : 'projects'}
-                  </p>
-                </button>
-              )
-            })}
-          </div>
-        </div>
+function SortButton({ sort, active, direction, onClick, children }: {
+  sort: AdminProjectSort
+  active: boolean
+  direction: 'asc' | 'desc'
+  onClick: (sort: AdminProjectSort) => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(sort)}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-semibold transition-colors',
+        'hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        active ? 'bg-primary/15 text-primary' : 'text-muted-foreground',
+      )}
+      aria-pressed={active}
+    >
+      {children}
+      {active && (
+        <span aria-hidden="true">
+          <ChevronDownIcon size={12} className={direction === 'asc' ? 'rotate-180' : ''} />
+        </span>
+      )}
+    </button>
+  )
+}
 
-        {/* Projects with comments — latest comment first */}
-        <div className="flex-1 flex flex-col bg-background overflow-hidden">
-          <div className={SECTION_HEADER}>
-            <div className="flex items-center justify-between gap-2">
-              <h2 className="text-base font-bold text-foreground tracking-tight">Projects with comments</h2>
-              {filterEmail && (
-                <button
-                  type="button"
-                  onClick={() => setFilterEmail(null)}
-                  className="flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-full bg-primary/15 text-primary hover:bg-primary/25 transition-colors max-w-[220px]"
-                >
-                  <span className="truncate">{filterEmail}</span>
-                  <XIcon size={11} />
-                </button>
-              )}
-            </div>
-            <p className="text-[11px] text-muted-foreground">
-              {filterEmail ? `${filteredProjects.length} with this user` : 'Latest comment first'}
-            </p>
-          </div>
-          <div className="flex-1 overflow-y-auto">
-            <ColumnState
-              loading={loading}
-              error={error}
-              empty={filteredProjects.length === 0}
-              emptyLabel={filterEmail ? 'This user is not in any projects with comments.' : 'No projects have received comments yet.'}
-            />
-            {!loading && !error && filteredProjects.map((p) => {
-              const owners = p.members.filter((m) => m.role === 'admin').map((m) => m.email)
-              // While filtering by a user, surface that user's role in this project.
-              const filterRole = filterEmail ? p.members.find((m) => m.email === filterEmail)?.role : undefined
-              return (
-                <div key={p.publicKey} className="px-4 py-3 border-b border-border/50">
-                  <div className="flex items-center justify-between gap-2 mb-1">
-                    <div className="flex items-center gap-2 min-w-0">
-                      <span className="text-[13px] font-bold text-foreground truncate">{p.name}</span>
-                      {filterRole && (
-                        <span
-                          className={cn(
-                            'text-[10px] font-semibold px-1.5 py-0.5 rounded-full shrink-0 uppercase tracking-wide',
-                            filterRole === 'admin' ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground',
-                          )}
-                        >
-                          {filterRole}
-                        </span>
-                      )}
-                    </div>
-                    <span
-                      className={cn(
-                        'text-[10px] font-semibold px-1.5 py-0.5 rounded-full shrink-0',
-                        p.claimed ? 'bg-status-accepted-bg text-status-accepted' : 'bg-muted text-muted-foreground',
-                      )}
-                    >
-                      {p.claimed ? 'Claimed' : 'Unclaimed'}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
-                    <span className="font-mono">{p.publicKey}</span>
-                    <span>{p.commentCount} {p.commentCount === 1 ? 'comment' : 'comments'}</span>
-                    <span>latest {timeAgo(p.latestCommentAt)}</span>
-                  </div>
-                  {owners.length > 0 && (
-                    <p className="text-[11px] text-muted-foreground/70 mt-0.5 truncate">
-                      owners: {owners.join(', ')}
-                    </p>
-                  )}
-                </div>
-              )
-            })}
-          </div>
-        </div>
+function TinyMetric({ label, value, tone }: { label: string; value: number; tone?: 'ready' | 'done' | 'reject' | 'agent' }) {
+  return (
+    <span className={cn(
+      'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold tabular-nums',
+      tone === 'ready' && 'bg-status-accepted-bg text-status-accepted',
+      tone === 'done' && 'bg-status-done-bg text-status-done',
+      tone === 'reject' && 'bg-status-rejected-bg text-status-rejected',
+      tone === 'agent' && 'bg-agent-active/10 text-agent-active',
+      !tone && 'bg-muted text-muted-foreground',
+    )}>
+      <span>{label}</span>
+      <span>{count(value)}</span>
+    </span>
+  )
+}
+
+interface IntelligenceSummary {
+  loadedComments: number
+  pendingComments: number
+  readyComments: number
+  doneComments: number
+  shareLoops: number
+  activeProjects: number
+  teamProjects: number
+  attentionProjects: number
+  topProjects: AdminProject[]
+  topProject: AdminProject | null
+}
+
+function buildIntelligence(projects: AdminProject[]): IntelligenceSummary {
+  const loadedComments = projects.reduce((sum, project) => sum + project.commentCount, 0)
+  const pendingComments = projects.reduce((sum, project) => sum + project.commentStatusCounts.pending, 0)
+  const readyComments = projects.reduce((sum, project) => sum + project.commentStatusCounts.accepted, 0)
+  const doneComments = projects.reduce((sum, project) => sum + project.implementationStatusCounts.done, 0)
+  const shareLoops = projects.reduce((sum, project) => sum + project.feedbackShareCount, 0)
+  const activeProjects = projects.filter((project) => daysSince(project.lastCommentAt) <= 7).length
+  const teamProjects = projects.filter((project) => memberCount(project) > 1).length
+  const attentionProjects = projects.filter((project) => project.commentStatusCounts.pending >= 10 || project.commentStatusCounts.rejected >= 5).length
+  const topProjects = [...projects].sort((a, b) => potentialScore(b) - potentialScore(a)).slice(0, 6)
+  return {
+    loadedComments,
+    pendingComments,
+    readyComments,
+    doneComments,
+    shareLoops,
+    activeProjects,
+    teamProjects,
+    attentionProjects,
+    topProjects,
+    topProject: topProjects[0] ?? null,
+  }
+}
+
+function SignalChip({ children, tone }: { children: ReactNode; tone?: 'hot' | 'live' | 'risk' | 'done' }) {
+  return (
+    <span className={cn(
+      'inline-flex border-l pl-2 text-[10px] font-semibold',
+      tone === 'hot' && 'border-primary text-primary',
+      tone === 'live' && 'border-agent-active text-agent-active',
+      tone === 'risk' && 'border-status-rejected text-status-rejected',
+      tone === 'done' && 'border-status-done text-status-done',
+      !tone && 'border-border text-muted-foreground',
+    )}>
+      {children}
+    </span>
+  )
+}
+
+function ProjectSignals({ project }: { project: AdminProject }) {
+  const chips: Array<{ label: string; tone?: 'hot' | 'live' | 'risk' | 'done' }> = []
+  if (daysSince(project.lastCommentAt) <= 2) chips.push({ label: 'fresh', tone: 'live' })
+  if (memberCount(project) > 1) chips.push({ label: 'team' })
+  if (project.feedbackShareCount >= 5) chips.push({ label: 'share loop', tone: 'hot' })
+  if (project.commentStatusCounts.pending >= 10) chips.push({ label: 'review load', tone: 'risk' })
+  if (project.implementationStatusCounts.done >= 5) chips.push({ label: 'shipping', tone: 'done' })
+  return (
+    <div className="mt-2 flex flex-wrap gap-1.5">
+      {chips.slice(0, 4).map((chip) => (
+        <SignalChip key={chip.label} tone={chip.tone}>{chip.label}</SignalChip>
+      ))}
+    </div>
+  )
+}
+
+function OverviewView({ summary, stats }: { summary: IntelligenceSummary; stats: AdminStats | null }) {
+  const top = summary.topProject
+  return (
+    <div className="border-b border-border px-5 py-6">
+      <div className="max-w-4xl">
+        <div className="text-[10px] uppercase tracking-[0.08em] text-primary">Product potential</div>
+        <h2 className="mt-2 text-2xl font-bold leading-tight text-foreground text-balance">
+          {top ? `${top.name} is strongest signal right now` : 'No signal yet'}
+        </h2>
+        <p className="mt-2 max-w-2xl text-[12px] leading-5 text-muted-foreground">
+          {top
+            ? `${count(top.commentCount)} comments, ${count(top.feedbackShareCount)} shares, ${count(memberCount(top))} people, last active ${timeAgo(top.lastCommentAt)}.`
+            : 'Load project activity to see product potential.'}
+        </p>
+      </div>
+      <div className="mt-6 grid max-w-4xl grid-cols-2 gap-x-8 gap-y-4 lg:grid-cols-4">
+        <QuietMetric label="Active projects" value={summary.activeProjects} detail="last 7d" tone="live" />
+        <QuietMetric label="Team use" value={summary.teamProjects} detail="2+ members" />
+        <QuietMetric label="Review load" value={summary.pendingComments} detail="pending" tone={summary.pendingComments > summary.readyComments ? 'risk' : undefined} />
+        <QuietMetric label="Signup pull" value={stats?.signups.last7Days ?? 0} detail="last 7d" tone="hot" />
       </div>
     </div>
+  )
+}
+
+function QuietMetric({ label, value, detail, tone }: { label: string; value: number; detail: string; tone?: 'hot' | 'live' | 'risk' }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground truncate">{label}</div>
+      <div className={cn(
+        'mt-1 font-mono text-xl tabular-nums text-foreground',
+        tone === 'hot' && 'text-primary',
+        tone === 'live' && 'text-agent-active',
+        tone === 'risk' && 'text-status-rejected',
+      )}>
+        {count(value)}
+      </div>
+      <div className="mt-0.5 text-[11px] text-muted-foreground truncate">{detail}</div>
+    </div>
+  )
+}
+
+function ProjectListView({ title, subtitle, projects }: { title: string; subtitle: string; projects: AdminProject[] }) {
+  return (
+    <div className="border-b border-border px-5 py-5">
+      <div className="mb-3">
+        <h2 className="text-base font-bold text-foreground">{title}</h2>
+        <p className="text-[11px] text-muted-foreground">{subtitle}</p>
+      </div>
+      <div className="divide-y divide-border/60 border-y border-border/60">
+        {projects.length === 0 && (
+          <div className="px-1 py-6 text-[12px] text-muted-foreground">No projects.</div>
+        )}
+        {projects.map((project, index) => (
+          <div key={project.publicKey} className="grid grid-cols-[36px_1fr_auto] items-center gap-3 px-1 py-3">
+            <div className="font-mono text-[11px] text-muted-foreground">#{index + 1}</div>
+            <div className="min-w-0">
+              <div className="truncate text-[13px] font-bold text-foreground">{project.name}</div>
+              <div className="mt-1 truncate text-[11px] text-muted-foreground">
+                {count(project.commentCount)} comments · {count(project.feedbackShareCount)} shares · {timeAgo(project.lastCommentAt)}
+              </div>
+              <ProjectSignals project={project} />
+            </div>
+            <div className="font-mono text-lg tabular-nums text-primary">{count(potentialScore(project))}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ProjectTable({ projects }: { projects: AdminProject[] }) {
+  if (projects.length === 0) return null
+  return (
+    <table className="w-full min-w-[980px] border-separate border-spacing-0 text-left">
+      <thead className="sticky top-0 z-10 bg-background/95 backdrop-blur">
+        <tr className="border-b border-border text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+          <th scope="col" className="border-b border-border px-4 py-2.5 font-semibold">Project</th>
+          <th scope="col" className="border-b border-border px-3 py-2.5 font-semibold">Last</th>
+          <th scope="col" className="border-b border-border px-3 py-2.5 text-right font-semibold">Comments</th>
+          <th scope="col" className="border-b border-border px-3 py-2.5 text-right font-semibold">Pending</th>
+          <th scope="col" className="border-b border-border px-3 py-2.5 text-right font-semibold">Ready</th>
+          <th scope="col" className="border-b border-border px-3 py-2.5 text-right font-semibold">Rejected</th>
+          <th scope="col" className="border-b border-border px-3 py-2.5 text-right font-semibold">Done</th>
+          <th scope="col" className="border-b border-border px-3 py-2.5 text-right font-semibold">Shares</th>
+          <th scope="col" className="border-b border-border px-4 py-2.5 text-right font-semibold">URLs</th>
+        </tr>
+      </thead>
+      <tbody>
+        {projects.map((project) => <ProjectTableRow key={project.publicKey} project={project} />)}
+      </tbody>
+    </table>
+  )
+}
+
+function ProjectTableRow({ project }: { project: AdminProject }) {
+  const owners = project.members.filter((m) => m.role === 'admin').map((m) => m.email)
+  return (
+    <tr className="group border-b border-border/50 hover:bg-white/[0.02]">
+      <td className="border-b border-border/50 px-4 py-3">
+        <div className="min-w-0 max-w-[440px]">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-[13px] font-bold text-foreground">{project.name}</span>
+            <span className={cn(
+              'rounded px-1.5 py-0.5 text-[10px] font-semibold shrink-0',
+              project.claimed ? 'bg-status-accepted-bg text-status-accepted' : 'bg-muted text-muted-foreground',
+            )}>
+              {project.claimed ? 'Claimed' : 'Unclaimed'}
+            </span>
+          </div>
+          <div className="mt-1 flex min-w-0 items-center gap-3 text-[11px] text-muted-foreground">
+            <span className="max-w-[160px] truncate font-mono" translate="no">{project.publicKey}</span>
+            {owners.length > 0 && <span className="truncate">owner {owners[0]}</span>}
+          </div>
+        </div>
+      </td>
+      <td className="border-b border-border/50 px-3 py-3 text-[12px] text-muted-foreground tabular-nums">{timeAgo(project.lastCommentAt)}</td>
+      <td className="border-b border-border/50 px-3 py-3 text-right text-[12px] text-foreground tabular-nums">{count(project.commentCount)}</td>
+      <td className="border-b border-border/50 px-3 py-3 text-right text-[12px] text-muted-foreground tabular-nums">{count(project.commentStatusCounts.pending)}</td>
+      <td className="border-b border-border/50 px-3 py-3 text-right text-[12px] text-status-accepted tabular-nums">{count(project.commentStatusCounts.accepted)}</td>
+      <td className="border-b border-border/50 px-3 py-3 text-right text-[12px] text-status-rejected tabular-nums">{count(project.commentStatusCounts.rejected)}</td>
+      <td className="border-b border-border/50 px-3 py-3 text-right text-[12px] text-status-done tabular-nums">{count(project.implementationStatusCounts.done)}</td>
+      <td className="border-b border-border/50 px-3 py-3 text-right text-[12px] text-agent-active tabular-nums">{count(project.feedbackShareCount)}</td>
+      <td className="border-b border-border/50 px-4 py-3 text-right text-[12px] text-muted-foreground tabular-nums">{count(project.commentedUrlCount)}</td>
+    </tr>
+  )
+}
+
+function UserDetail({ user }: { user: AdminUser | null }) {
+  if (!user) {
+    return (
+      <div className="border-t border-border px-4 py-4 text-[11px] text-muted-foreground">
+        Select user.
+      </div>
+    )
+  }
+  return (
+    <div className="border-t border-border px-4 py-4">
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate text-[13px] font-bold text-foreground">{user.email ?? user.id}</div>
+          <div className="mt-1 font-mono text-[10px] text-muted-foreground truncate" translate="no">{user.id}</div>
+        </div>
+        {user.superAdmin && <RoleBadge active>super</RoleBadge>}
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <TinyMetric label="admin" value={user.projectsAsAdminCount} />
+        <TinyMetric label="member" value={user.projectsAsMemberCount} />
+      </div>
+      <div className="mt-3 space-y-1 text-[11px] text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <span aria-hidden="true">
+            <CheckIcon size={12} />
+          </span>
+          <span>{user.emailConfirmedAt ? `confirmed ${timeAgo(user.emailConfirmedAt)}` : 'email unconfirmed'}</span>
+        </div>
+        <div>{user.lastSignInAt ? `last sign in ${timeAgo(user.lastSignInAt)}` : 'no sign in'}</div>
+        <div>joined {timeAgo(user.createdAt)}</div>
+      </div>
+    </div>
+  )
+}
+
+function UsersView({
+  users,
+  filteredUsers,
+  selectedUser,
+  selectedUserId,
+  query,
+  usersHasMore,
+  loadingMore,
+  onQueryChange,
+  onSelectUser,
+  onLoadMore,
+}: {
+  users: AdminUser[]
+  filteredUsers: AdminUser[]
+  selectedUser: AdminUser | null
+  selectedUserId: string | null
+  query: string
+  usersHasMore: boolean
+  loadingMore: boolean
+  onQueryChange: (query: string) => void
+  onSelectUser: (id: string) => void
+  onLoadMore: () => void
+}) {
+  return (
+    <div className="grid min-h-full grid-cols-1 lg:grid-cols-[1fr_360px]">
+      <div className="min-w-0 border-r border-border">
+        <div className={SECTION_HEADER}>
+          <h2 className="text-base font-bold text-foreground tracking-tight">Users</h2>
+          <p className="text-[11px] text-muted-foreground">
+            {count(filteredUsers.length)} shown · {count(users.length)} loaded
+          </p>
+          <input
+            aria-label="Search users"
+            name="admin-user-search"
+            type="search"
+            autoComplete="off"
+            spellCheck={false}
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="Search email…"
+            className="mt-3 h-8 w-full rounded-md border border-border bg-background px-3 text-[12px] text-foreground placeholder:text-muted-foreground/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        </div>
+        <div>
+          <PanelState loading={false} error={null} empty={filteredUsers.length === 0} emptyLabel={users.length === 0 ? 'No users yet.' : 'No users match.'} />
+          {filteredUsers.map((user) => (
+            <UserRow
+              key={user.id}
+              user={user}
+              active={user.id === selectedUserId}
+              onClick={() => onSelectUser(user.id)}
+            />
+          ))}
+          <LoadMore visible={usersHasMore} busy={loadingMore} onClick={onLoadMore} label="Load more users" />
+        </div>
+      </div>
+      <div className="bg-card">
+        <UserDetail user={selectedUser} />
+      </div>
+    </div>
+  )
+}
+
+type ProjectFilter = 'all' | 'claimed' | 'unclaimed'
+
+export function SuperAdminPanel({ apiBase, accessToken }: SuperAdminPanelProps) {
+  const {
+    stats,
+    users,
+    projects,
+    loading,
+    usersLoadingMore,
+    projectsLoadingMore,
+    error,
+    usersHasMore,
+    projectsHasMore,
+    projectSort,
+    projectDirection,
+    refresh,
+    loadMoreUsers,
+    loadMoreProjects,
+    setProjectSort,
+  } = useAdminData(apiBase, accessToken)
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null)
+  const [userQuery, setUserQuery] = useState('')
+  const [projectQuery, setProjectQuery] = useState('')
+  const [projectFilter, setProjectFilter] = useState<ProjectFilter>('all')
+  const [activeView, setActiveView] = useState<AdminView>('overview')
+
+  const selectedUser = useMemo(
+    () => users.find((u) => u.id === selectedUserId) ?? null,
+    [users, selectedUserId],
+  )
+  const filteredUsers = useMemo(() => {
+    const q = userQuery.trim().toLowerCase()
+    if (!q) return users
+    return users.filter((user) => `${user.email ?? ''} ${user.id}`.toLowerCase().includes(q))
+  }, [users, userQuery])
+  const filteredProjects = useMemo(() => {
+    const q = projectQuery.trim().toLowerCase()
+    return projects.filter((project) => {
+      const matchesStatus =
+        projectFilter === 'all' ||
+        (projectFilter === 'claimed' && project.claimed) ||
+        (projectFilter === 'unclaimed' && !project.claimed)
+      if (!matchesStatus) return false
+      if (!q) return true
+      const owners = project.members.map((m) => m.email).join(' ')
+      return `${project.name} ${project.publicKey} ${owners}`.toLowerCase().includes(q)
+    })
+  }, [projects, projectFilter, projectQuery])
+  const intelligence = useMemo(() => buildIntelligence(projects), [projects])
+  const topProjects = useMemo(() => [...projects].sort((a, b) => potentialScore(b) - potentialScore(a)).slice(0, 10), [projects])
+  const attentionProjects = useMemo(() => (
+    [...projects]
+      .filter((project) => project.commentStatusCounts.pending >= 10 || project.commentStatusCounts.rejected >= 5)
+      .sort((a, b) => (
+        (b.commentStatusCounts.pending + b.commentStatusCounts.rejected) -
+        (a.commentStatusCounts.pending + a.commentStatusCounts.rejected)
+      ))
+      .slice(0, 8)
+  ), [projects])
+  const shareProjects = useMemo(() => (
+    [...projects].sort((a, b) => b.feedbackShareCount - a.feedbackShareCount).slice(0, 8)
+  ), [projects])
+
+  return (
+    <section className="flex flex-col flex-1 overflow-hidden" aria-label="Super admin">
+      <div className="flex items-center gap-2 px-5 h-11 shrink-0 border-b border-border bg-card">
+        <span aria-hidden="true">
+          <ShieldIcon size={14} className="text-primary" />
+        </span>
+        <button
+          type="button"
+          onClick={() => setActiveView('overview')}
+          className="text-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          style={CRT_LABEL}
+        >
+          SUPER ADMIN
+        </button>
+        <span className="text-[11px] text-muted-foreground ml-2">
+          {count(stats?.accounts)} accounts · {count(stats?.projects)} projects
+        </span>
+        <button
+          type="button"
+          onClick={refresh}
+          className="ml-auto h-7 rounded-md px-2 text-[11px] font-semibold text-muted-foreground hover:text-foreground hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <StatsStrip stats={stats} activeView={activeView} onViewChange={setActiveView} />
+
+      <div className="flex-1 overflow-y-auto bg-background">
+        <PanelState loading={loading} error={error} empty={projects.length === 0 && activeView !== 'accounts'} emptyLabel="No projects have comments yet." />
+        {!loading && !error && activeView === 'overview' && <OverviewView summary={intelligence} stats={stats} />}
+        {!loading && !error && activeView === 'accounts' && (
+          <UsersView
+            users={users}
+            filteredUsers={filteredUsers}
+            selectedUser={selectedUser}
+            selectedUserId={selectedUserId}
+            query={userQuery}
+            usersHasMore={usersHasMore}
+            loadingMore={usersLoadingMore}
+            onQueryChange={setUserQuery}
+            onSelectUser={(id) => setSelectedUserId((current) => (current === id ? null : id))}
+            onLoadMore={loadMoreUsers}
+          />
+        )}
+        {!loading && !error && activeView === 'projects' && (
+          <ProjectListView
+            title="Projects"
+            subtitle="ranked by product signal"
+            projects={topProjects}
+          />
+        )}
+        {!loading && !error && activeView === 'comments' && (
+          <ProjectListView
+            title="Comment Load"
+            subtitle="highest pending or rejected volume"
+            projects={attentionProjects}
+          />
+        )}
+        {!loading && !error && activeView === 'shares' && (
+          <ProjectListView
+            title="Share Loops"
+            subtitle="projects with strongest feedback sharing"
+            projects={shareProjects}
+          />
+        )}
+      </div>
+    </section>
   )
 }

--- a/apps/dashboard/hooks/useAdminData.ts
+++ b/apps/dashboard/hooks/useAdminData.ts
@@ -1,45 +1,168 @@
 import { useCallback, useEffect, useState } from 'react'
-import { listAdminProjects, listAdminUsers, type AdminProject, type AdminUser } from '../api'
+import {
+  getAdminStats,
+  listAdminProjects,
+  listAdminUsers,
+  type AdminProject,
+  type AdminProjectSort,
+  type AdminSortDirection,
+  type AdminStats,
+  type AdminUser,
+} from '../api'
+import {
+  getMockAdminProjectsPage,
+  getMockAdminStats,
+  getMockAdminUsersPage,
+  mocksEnabled,
+} from '../lib/mocks'
+
+const PAGE_SIZE = 50
 
 interface UseAdminDataResult {
+  stats: AdminStats | null
   users: AdminUser[]
   projects: AdminProject[]
   loading: boolean
+  usersLoadingMore: boolean
+  projectsLoadingMore: boolean
   error: string | null
+  usersHasMore: boolean
+  projectsHasMore: boolean
+  projectSort: AdminProjectSort
+  projectDirection: AdminSortDirection
   refresh: () => Promise<void>
+  loadMoreUsers: () => Promise<void>
+  loadMoreProjects: () => Promise<void>
+  setProjectSort: (sort: AdminProjectSort) => void
 }
 
-/**
- * Loads the super-admin overview (all users + all projects with comments) in
- * one shot. Mirrors `useProjects`' loading/error/refresh shape. Only mounted
- * once the user is confirmed to be a super admin.
- */
 export function useAdminData(apiBase: string, accessToken: string): UseAdminDataResult {
+  const [stats, setStats] = useState<AdminStats | null>(null)
   const [users, setUsers] = useState<AdminUser[]>([])
   const [projects, setProjects] = useState<AdminProject[]>([])
   const [loading, setLoading] = useState(true)
+  const [usersLoadingMore, setUsersLoadingMore] = useState(false)
+  const [projectsLoadingMore, setProjectsLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [usersCursor, setUsersCursor] = useState<string | null>(null)
+  const [projectsCursor, setProjectsCursor] = useState<string | null>(null)
+  const [usersHasMore, setUsersHasMore] = useState(false)
+  const [projectsHasMore, setProjectsHasMore] = useState(false)
+  const [projectSort, setProjectSortState] = useState<AdminProjectSort>('lastCommentAt')
+  const [projectDirection, setProjectDirection] = useState<AdminSortDirection>('desc')
+
+  const fetchUsers = useCallback(async (cursor?: string | null) => {
+    if (mocksEnabled) return getMockAdminUsersPage({ cursor, limit: PAGE_SIZE })
+    return listAdminUsers(apiBase, accessToken, { cursor, limit: PAGE_SIZE })
+  }, [apiBase, accessToken])
+
+  const fetchProjects = useCallback(async (
+    cursor?: string | null,
+    sort: AdminProjectSort = projectSort,
+    direction: AdminSortDirection = projectDirection,
+  ) => {
+    const opts = { cursor, limit: PAGE_SIZE, sort, direction }
+    if (mocksEnabled) return getMockAdminProjectsPage(opts)
+    return listAdminProjects(apiBase, accessToken, opts)
+  }, [apiBase, accessToken, projectSort, projectDirection])
 
   const refresh = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
-      const [u, p] = await Promise.all([
-        listAdminUsers(apiBase, accessToken),
-        listAdminProjects(apiBase, accessToken),
+      if (mocksEnabled) {
+        const usersPage = getMockAdminUsersPage({ limit: PAGE_SIZE })
+        const projectsPage = getMockAdminProjectsPage({ limit: PAGE_SIZE, sort: projectSort, direction: projectDirection })
+        setStats(getMockAdminStats())
+        setUsers(usersPage.items)
+        setProjects(projectsPage.items)
+        setUsersCursor(usersPage.nextCursor)
+        setProjectsCursor(projectsPage.nextCursor)
+        setUsersHasMore(usersPage.hasMore)
+        setProjectsHasMore(projectsPage.hasMore)
+        return
+      }
+      const [nextStats, usersPage, projectsPage] = await Promise.all([
+        getAdminStats(apiBase, accessToken),
+        listAdminUsers(apiBase, accessToken, { limit: PAGE_SIZE }),
+        listAdminProjects(apiBase, accessToken, { limit: PAGE_SIZE, sort: projectSort, direction: projectDirection }),
       ])
-      setUsers(u)
-      setProjects(p)
+      setStats(nextStats)
+      setUsers(usersPage.items)
+      setProjects(projectsPage.items)
+      setUsersCursor(usersPage.nextCursor)
+      setProjectsCursor(projectsPage.nextCursor)
+      setUsersHasMore(usersPage.hasMore)
+      setProjectsHasMore(projectsPage.hasMore)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load admin data')
     } finally {
       setLoading(false)
     }
-  }, [apiBase, accessToken])
+  }, [apiBase, accessToken, projectSort, projectDirection])
+
+  const loadMoreUsers = useCallback(async () => {
+    if (!usersCursor || usersLoadingMore) return
+    setUsersLoadingMore(true)
+    setError(null)
+    try {
+      const page = await fetchUsers(usersCursor)
+      setUsers((prev) => [...prev, ...page.items])
+      setUsersCursor(page.nextCursor)
+      setUsersHasMore(page.hasMore)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load users')
+    } finally {
+      setUsersLoadingMore(false)
+    }
+  }, [fetchUsers, usersCursor, usersLoadingMore])
+
+  const loadMoreProjects = useCallback(async () => {
+    if (!projectsCursor || projectsLoadingMore) return
+    setProjectsLoadingMore(true)
+    setError(null)
+    try {
+      const page = await fetchProjects(projectsCursor)
+      setProjects((prev) => [...prev, ...page.items])
+      setProjectsCursor(page.nextCursor)
+      setProjectsHasMore(page.hasMore)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load projects')
+    } finally {
+      setProjectsLoadingMore(false)
+    }
+  }, [fetchProjects, projectsCursor, projectsLoadingMore])
+
+  const setProjectSort = useCallback((sort: AdminProjectSort) => {
+    setProjectSortState((current) => {
+      if (current === sort) {
+        setProjectDirection((dir) => (dir === 'desc' ? 'asc' : 'desc'))
+        return current
+      }
+      setProjectDirection('desc')
+      return sort
+    })
+  }, [])
 
   useEffect(() => {
     refresh()
   }, [refresh])
 
-  return { users, projects, loading, error, refresh }
+  return {
+    stats,
+    users,
+    projects,
+    loading,
+    usersLoadingMore,
+    projectsLoadingMore,
+    error,
+    usersHasMore,
+    projectsHasMore,
+    projectSort,
+    projectDirection,
+    refresh,
+    loadMoreUsers,
+    loadMoreProjects,
+    setProjectSort,
+  }
 }

--- a/apps/dashboard/hooks/useSuperAdmin.ts
+++ b/apps/dashboard/hooks/useSuperAdmin.ts
@@ -13,7 +13,7 @@ export interface UseSuperAdminResult {
  * so a forged `true` here grants nothing. Fails closed (false) on any error.
  */
 export function useSuperAdmin(apiBase: string, accessToken: string): UseSuperAdminResult {
-  const [superadmin, setSuperadmin] = useState(false)
+  const [superadmin, setSuperadmin] = useState(mocksEnabled)
   const [loading, setLoading] = useState(!mocksEnabled)
 
   useEffect(() => {

--- a/apps/dashboard/lib/mocks.ts
+++ b/apps/dashboard/lib/mocks.ts
@@ -1,4 +1,4 @@
-import type { CommentRecord, Project } from '../api'
+import type { AdminPage, AdminProject, AdminProjectSort, AdminStats, AdminUser, CommentRecord, Project } from '../api'
 
 // VITE_USE_MOCKS:
 //   '1'     → populated fixtures (default mock mode)
@@ -184,4 +184,101 @@ export function getMockProjects(): Project[] {
 export function getMockComments(projectId: string): CommentRecord[] {
   if (mocksEmpty) return []
   return PROJECT_COMMENTS[projectId] ?? []
+}
+
+const ADMIN_NAMES = ['Tomas', 'Pranav', 'Dianne', 'Lara', 'Agustin', 'Cris', 'Alessandro', 'María']
+const ADMIN_DOMAINS = ['tdp.studio', 'client.dev', 'agency.local']
+
+export const MOCK_ADMIN_STATS: AdminStats = {
+  accounts: 86,
+  projects: 34,
+  comments: 418,
+  shares: 47,
+  activeAgentPresence: 3,
+  signups: { last24Hours: 4, last7Days: 19, last30Days: 62 },
+}
+
+export const MOCK_ADMIN_USERS: AdminUser[] = Array.from({ length: 86 }, (_, i) => {
+  const name = ADMIN_NAMES[i % ADMIN_NAMES.length]
+  const email = `${name.toLowerCase()}${i + 1}@${ADMIN_DOMAINS[i % ADMIN_DOMAINS.length]}`
+  return {
+    id: `user_${String(i + 1).padStart(3, '0')}`,
+    email,
+    createdAt: ago(60 * 24 * (i + 1)),
+    lastSignInAt: i % 5 === 0 ? null : ago(45 + i * 18),
+    emailConfirmedAt: i % 7 === 0 ? null : ago(60 * 24 * i),
+    projectsAsAdminCount: i % 4,
+    projectsAsMemberCount: (i + 2) % 6,
+    superAdmin: i < 3,
+  }
+})
+
+export const MOCK_ADMIN_PROJECTS: AdminProject[] = Array.from({ length: 34 }, (_, i) => {
+  const comments = 4 + ((i * 11) % 64)
+  const accepted = Math.floor(comments * 0.38)
+  const rejected = Math.floor(comments * 0.12)
+  const pending = comments - accepted - rejected
+  const done = Math.floor(accepted * 0.42)
+  const inProgress = Math.floor(accepted * 0.18)
+  const claimed = Math.floor(accepted * 0.12)
+  const blocked = i % 9 === 0 ? 1 : 0
+  const unassigned = Math.max(0, comments - done - inProgress - claimed - blocked)
+  const owner = MOCK_ADMIN_USERS[i % MOCK_ADMIN_USERS.length]
+  const member = MOCK_ADMIN_USERS[(i + 7) % MOCK_ADMIN_USERS.length]
+  return {
+    publicKey: `proj_${String(i + 1).padStart(2, '0')}_crrt`,
+    name: `CRRT Client ${i + 1}`,
+    createdAt: ago(60 * 24 * (i + 3)),
+    commentCount: comments,
+    commentStatusCounts: { pending, accepted, rejected },
+    implementationStatusCounts: { unassigned, claimed, inProgress, blocked, done },
+    feedbackShareCount: 1 + (i % 9),
+    commentedUrlCount: 1 + (i % 12),
+    firstCommentAt: ago(60 * 24 * (i + 12)),
+    lastCommentAt: ago(25 + i * 21),
+    claimed: i % 3 !== 0,
+    members: [
+      { email: owner.email ?? owner.id, role: 'admin' },
+      { email: member.email ?? member.id, role: 'member' },
+    ],
+  }
+})
+
+function page<T>(items: T[], cursor?: string | null, limit = 50): AdminPage<T> {
+  const start = cursor ? Number(cursor) : 0
+  const end = start + limit
+  return {
+    items: items.slice(start, end),
+    nextCursor: end < items.length ? String(end) : null,
+    hasMore: end < items.length,
+  }
+}
+
+export function getMockAdminStats(): AdminStats {
+  return mocksEmpty
+    ? { accounts: 0, projects: 0, comments: 0, shares: 0, activeAgentPresence: 0, signups: { last24Hours: 0, last7Days: 0, last30Days: 0 } }
+    : MOCK_ADMIN_STATS
+}
+
+export function getMockAdminUsersPage(opts: { cursor?: string | null; limit?: number } = {}) {
+  return page(mocksEmpty ? [] : MOCK_ADMIN_USERS, opts.cursor, opts.limit)
+}
+
+export function getMockAdminProjectsPage(opts: {
+  cursor?: string | null
+  limit?: number
+  sort?: AdminProjectSort
+  direction?: 'asc' | 'desc'
+} = {}) {
+  const sort = opts.sort ?? 'lastCommentAt'
+  const direction = opts.direction ?? 'desc'
+  const sorted = [...(mocksEmpty ? [] : MOCK_ADMIN_PROJECTS)].sort((a, b) => {
+    const av = a[sort]
+    const bv = b[sort]
+    const cmp = typeof av === 'number' && typeof bv === 'number'
+      ? av - bv
+      : String(av).localeCompare(String(bv))
+    return direction === 'asc' ? cmp : -cmp
+  })
+  return page(sorted, opts.cursor, opts.limit)
 }


### PR DESCRIPTION
## Summary
- update Super Admin frontend for paginated admin users/projects responses
- add global stats support and load-more flows
- redesign Super Admin as clickable product-intelligence views with accounts/projects/comments/shares drilldowns
- add populated mocks for local UI review

## Dependency
Depends on backend PR stack #146, #147, #148, #149. Do not merge this before the backend stack is merged.

## Notes
- "Accounts" currently means user accounts, not customer/company accounts.
- Account/company-level analytics needs a future backend model/endpoint.
- Created-project tracking is not available in the current backend.

## Tests
- bun run typecheck
- bun run build:dashboard
- bun run test