### PR TITLE
Bump package version to 0.3.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thedesignproject/crrt",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "CRRT 🥕 visual feedback capture for React apps",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
# Bump package version to 0.3.15

- Raise the npm package version from 0.3.14 to 0.3.15.
- Prepare the package metadata for the next publish.
- Keep the release bump isolated to the root package manifest.
- Leave tagging and publishing for after this branch lands.
