### PR TITLE
Add widget GitHub auth routes

### DIFF
--- a/api/v1/widget/github/callback.test.ts
+++ b/api/v1/widget/github/callback.test.ts
@@ -85,6 +85,28 @@ describe('api/v1/widget/github/callback', () => {
     expect(String(res.body)).toContain('github_repo_inaccessible')
   })
 
+  it('maps unexpected GitHub failures to a generic popup error', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(getRepoConfig).mockResolvedValue({ githubOwner: 'acme', githubRepo: 'widgets' } as never)
+
+    vi.mocked(exchangeGitHubCode).mockRejectedValueOnce(new Error('surprising'))
+    let res = mockRes()
+    await call({ method: 'GET', query: { code: 'c', state: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(String(res.body)).toContain('github_auth_failed')
+    expect(consoleError).toHaveBeenCalled()
+
+    consoleError.mockClear()
+    vi.mocked(exchangeGitHubCode).mockRejectedValueOnce('surprising')
+    res = mockRes()
+    await call({ method: 'GET', query: { code: 'c', state: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(String(res.body)).toContain('github_auth_failed')
+    expect(consoleError).toHaveBeenCalled()
+
+    consoleError.mockRestore()
+  })
+
   it('exchanges the code, checks repo access, and returns a widget token', async () => {
     vi.mocked(getRepoConfig).mockResolvedValueOnce({ githubOwner: 'acme', githubRepo: 'widgets' } as never)
     const res = mockRes()

--- a/api/v1/widget/github/callback.test.ts
+++ b/api/v1/widget/github/callback.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/store.js', () => ({ getRepoConfig: vi.fn() }))
+vi.mock('../../../_lib/widget-github-auth.js', () => ({
+  assertGitHubRepoAccess: vi.fn(),
+  createWidgetAuthToken: vi.fn(() => 'widget-token'),
+  exchangeGitHubCode: vi.fn(() => 'gh-token'),
+  getGitHubUser: vi.fn(() => ({ id: '42', login: 'octo' })),
+  verifyWidgetGithubState: vi.fn(() => ({ projectKey: 'p', origin: 'https://app.example' })),
+  widgetCallbackHtml: vi.fn((origin, message) => `html:${origin}:${JSON.stringify(message)}`),
+}))
+
+import handler from './callback.js'
+import { getRepoConfig } from '../../../_lib/store.js'
+import {
+  assertGitHubRepoAccess,
+  createWidgetAuthToken,
+  exchangeGitHubCode,
+  getGitHubUser,
+  verifyWidgetGithubState,
+} from '../../../_lib/widget-github-auth.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    send(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(getRepoConfig).mockReset()
+  vi.mocked(assertGitHubRepoAccess).mockReset()
+  vi.mocked(createWidgetAuthToken).mockClear()
+  vi.mocked(exchangeGitHubCode).mockReset().mockResolvedValue('gh-token')
+  vi.mocked(getGitHubUser).mockReset().mockResolvedValue({ id: '42', login: 'octo' })
+  vi.mocked(verifyWidgetGithubState).mockReset().mockReturnValue({
+    projectKey: 'p',
+    origin: 'https://app.example',
+    nonce: 'n',
+    iat: 1,
+    exp: 2,
+  })
+})
+
+describe('api/v1/widget/github/callback', () => {
+  it('handles options, method, query validation, and bad state', async () => {
+    let res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    res = mockRes()
+    await call({ method: 'GET', query: { code: 'c' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    vi.mocked(verifyWidgetGithubState).mockReturnValueOnce(null)
+    res = mockRes()
+    await call({ method: 'GET', query: { code: 'c', state: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('returns popup errors for missing repo config and GitHub failures', async () => {
+    vi.mocked(getRepoConfig).mockResolvedValueOnce({ githubOwner: null, githubRepo: null } as never)
+    let res = mockRes()
+    await call({ method: 'GET', query: { code: 'c', state: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(String(res.body)).toContain('repo_not_configured')
+
+    vi.mocked(getRepoConfig).mockResolvedValueOnce({ githubOwner: 'acme', githubRepo: 'widgets' } as never)
+    vi.mocked(assertGitHubRepoAccess).mockRejectedValueOnce(new Error('github_repo_inaccessible'))
+    res = mockRes()
+    await call({ method: 'GET', query: { code: 'c', state: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(String(res.body)).toContain('github_repo_inaccessible')
+  })
+
+  it('exchanges the code, checks repo access, and returns a widget token', async () => {
+    vi.mocked(getRepoConfig).mockResolvedValueOnce({ githubOwner: 'acme', githubRepo: 'widgets' } as never)
+    const res = mockRes()
+    await call({ method: 'GET', query: { code: 'c', state: 's' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8')
+    expect(exchangeGitHubCode).toHaveBeenCalledWith('c')
+    expect(assertGitHubRepoAccess).toHaveBeenCalledWith('gh-token', 'acme', 'widgets')
+    expect(getGitHubUser).toHaveBeenCalledWith('gh-token')
+    expect(createWidgetAuthToken).toHaveBeenCalledWith({
+      projectKey: 'p',
+      githubUserId: '42',
+      githubLogin: 'octo',
+      githubOwner: 'acme',
+      githubRepo: 'widgets',
+    })
+    expect(String(res.body)).toContain('widget-token')
+  })
+})

--- a/api/v1/widget/github/callback.ts
+++ b/api/v1/widget/github/callback.ts
@@ -1,0 +1,70 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { getRepoConfig } from '../../../_lib/store.js'
+import {
+  assertGitHubRepoAccess,
+  createWidgetAuthToken,
+  exchangeGitHubCode,
+  getGitHubUser,
+  verifyWidgetGithubState,
+  widgetCallbackHtml,
+} from '../../../_lib/widget-github-auth.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed } from '../../../_lib/http.js'
+
+function html(res: VercelResponse, body: string) {
+  res.setHeader('Content-Type', 'text/html; charset=utf-8')
+  return res.status(200).send(body)
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+
+  const code = getStringQuery(req.query.code)
+  const state = getStringQuery(req.query.state)
+  if (!code || !state) return jsonError(req, res, 400, 'Missing code or state')
+
+  const verifiedState = verifyWidgetGithubState(state)
+  if (!verifiedState) return jsonError(req, res, 400, 'Invalid or expired state')
+
+  try {
+    const config = await getRepoConfig(verifiedState.projectKey)
+    if (!config?.githubOwner || !config.githubRepo) {
+      return html(res, widgetCallbackHtml(verifiedState.origin, {
+        type: 'crrt:github-auth',
+        ok: false,
+        error: 'repo_not_configured',
+      }))
+    }
+
+    const accessToken = await exchangeGitHubCode(code)
+    await assertGitHubRepoAccess(accessToken, config.githubOwner, config.githubRepo)
+    const user = await getGitHubUser(accessToken)
+    const token = createWidgetAuthToken({
+      projectKey: verifiedState.projectKey,
+      githubUserId: user.id,
+      githubLogin: user.login,
+      githubOwner: config.githubOwner,
+      githubRepo: config.githubRepo,
+    })
+
+    return html(res, widgetCallbackHtml(verifiedState.origin, {
+      type: 'crrt:github-auth',
+      ok: true,
+      token,
+      githubLogin: user.login,
+    }))
+  } catch (error) {
+    const known = error instanceof Error && [
+      'github_code_exchange_failed',
+      'github_user_lookup_failed',
+      'github_repo_inaccessible',
+      'github_repo_lookup_failed',
+    ].includes(error.message)
+    if (!known) console.error(error)
+    return html(res, widgetCallbackHtml(verifiedState.origin, {
+      type: 'crrt:github-auth',
+      ok: false,
+      error: known && error instanceof Error ? error.message : 'github_auth_failed',
+    }))
+  }
+}

--- a/api/v1/widget/github/login.test.ts
+++ b/api/v1/widget/github/login.test.ts
@@ -45,6 +45,10 @@ describe('api/v1/widget/github/login', () => {
     expect(res.statusCode).toBe(400)
 
     res = mockRes()
+    await call({ method: 'GET', query: { projectKey: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    res = mockRes()
     await call({ method: 'GET', query: { projectKey: 'p', origin: '%' }, headers: {} }, res)
     expect(res.statusCode).toBe(400)
   })

--- a/api/v1/widget/github/login.test.ts
+++ b/api/v1/widget/github/login.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../_lib/store.js', () => ({ getRepoConfig: vi.fn() }))
+vi.mock('../../../_lib/widget-github-auth.js', () => ({
+  buildGitHubAuthorizeUrl: vi.fn(() => 'https://github.com/login/oauth/authorize?state=s'),
+  createWidgetGithubState: vi.fn(() => 'state-token'),
+}))
+
+import handler from './login.js'
+import { getRepoConfig } from '../../../_lib/store.js'
+import { buildGitHubAuthorizeUrl, createWidgetGithubState } from '../../../_lib/widget-github-auth.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(getRepoConfig).mockReset()
+  vi.mocked(buildGitHubAuthorizeUrl).mockClear()
+  vi.mocked(createWidgetGithubState).mockClear()
+})
+
+describe('api/v1/widget/github/login', () => {
+  it('handles options, method, and query validation', async () => {
+    let res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    res = mockRes()
+    await call({ method: 'GET', query: { origin: 'https://app.example/path' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+
+    res = mockRes()
+    await call({ method: 'GET', query: { projectKey: 'p', origin: '%' }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('requires a configured GitHub repo and redirects to GitHub', async () => {
+    vi.mocked(getRepoConfig).mockResolvedValueOnce({ githubOwner: null, githubRepo: null } as never)
+    let res = mockRes()
+    await call({ method: 'GET', query: { projectKey: 'p', origin: 'https://app.example/path' }, headers: {} }, res)
+    expect(res.statusCode).toBe(409)
+
+    vi.mocked(getRepoConfig).mockResolvedValueOnce({ githubOwner: 'acme', githubRepo: 'widgets' } as never)
+    res = mockRes()
+    await call({ method: 'GET', query: { projectKey: 'p', origin: 'https://app.example/path' }, headers: {} }, res)
+    expect(res.statusCode).toBe(302)
+    expect(createWidgetGithubState).toHaveBeenCalledWith({ projectKey: 'p', origin: 'https://app.example' })
+    expect(buildGitHubAuthorizeUrl).toHaveBeenCalledWith('state-token')
+    expect(res.headers.Location).toBe('https://github.com/login/oauth/authorize?state=s')
+  })
+
+  it('returns 500 on unexpected errors', async () => {
+    vi.mocked(getRepoConfig).mockRejectedValueOnce(new Error('db down'))
+    const res = mockRes()
+    await call({ method: 'GET', query: { projectKey: 'p', origin: 'https://app.example' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/widget/github/login.ts
+++ b/api/v1/widget/github/login.ts
@@ -1,0 +1,37 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { getRepoConfig } from '../../../_lib/store.js'
+import { buildGitHubAuthorizeUrl, createWidgetGithubState } from '../../../_lib/widget-github-auth.js'
+import { getStringQuery, handleOptions, jsonError, methodNotAllowed } from '../../../_lib/http.js'
+
+function parseOrigin(value: string | undefined) {
+  if (!value) return null
+  try {
+    return new URL(value).origin
+  } catch {
+    return null
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+
+  const projectKey = getStringQuery(req.query.projectKey)
+  const origin = parseOrigin(getStringQuery(req.query.origin))
+  if (!projectKey) return jsonError(req, res, 400, 'Missing projectKey')
+  if (!origin) return jsonError(req, res, 400, 'Missing or invalid origin')
+
+  try {
+    const config = await getRepoConfig(projectKey)
+    if (!config?.githubOwner || !config.githubRepo) {
+      return jsonError(req, res, 409, 'GitHub repo is not configured')
+    }
+
+    const state = createWidgetGithubState({ projectKey, origin })
+    res.setHeader('Location', buildGitHubAuthorizeUrl(state))
+    return res.status(302).end()
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}


### PR DESCRIPTION
- Add widget login and callback endpoints for the GitHub OAuth handoff.
- Redirect configured projects to GitHub with signed popup state.
- Exchange callback codes for GitHub user identity and repo access checks.
- Return signed widget auth tokens to the opener window after a successful callback.
- Cover the route validation, missing configuration, GitHub failure, and success paths.