### PR TITLE
Add GitHub-backed agent eligibility

### DIFF
--- a/api/v1/agent/eligibility.test.ts
+++ b/api/v1/agent/eligibility.test.ts
@@ -66,6 +66,14 @@ describe('api/v1/agent/eligibility', () => {
     expect((res.body as { loginUrl: string }).loginUrl).toContain('/api/v1/widget/github/login')
     expect((res.body as { loginUrl: string }).loginUrl).toContain('projectKey=p')
 
+    res = mockRes()
+    await call({
+      method: 'GET',
+      query: { project_id: 'p' },
+      headers: { origin: ['https://first.example', 'https://second.example'] },
+    }, res)
+    expect((res.body as { loginUrl: string }).loginUrl).toContain('origin=https%3A%2F%2Ffirst.example')
+
     vi.mocked(verifyWidgetAuthToken).mockReturnValueOnce(null)
     res = mockRes()
     await call({

--- a/api/v1/agent/eligibility.test.ts
+++ b/api/v1/agent/eligibility.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../_lib/store.js', () => ({ getRepoConfig: vi.fn() }))
+vi.mock('../../_lib/widget-github-auth.js', () => ({ verifyWidgetAuthToken: vi.fn() }))
+
+import handler from './eligibility.js'
+import { getRepoConfig } from '../../_lib/store.js'
+import { verifyWidgetAuthToken } from '../../_lib/widget-github-auth.js'
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this },
+    json(data: unknown) { this.body = data; return this },
+    end() { return this },
+    setHeader(key: string, value: string) { this.headers[key] = value },
+  }
+}
+const call = (req: unknown, res: unknown) =>
+  (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, res)
+
+beforeEach(() => {
+  vi.mocked(getRepoConfig).mockReset()
+  vi.mocked(verifyWidgetAuthToken).mockReset()
+})
+
+describe('api/v1/agent/eligibility', () => {
+  it('handles options, method validation, and missing project id', async () => {
+    let res = mockRes()
+    await call({ method: 'OPTIONS', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(204)
+
+    res = mockRes()
+    await call({ method: 'POST', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(405)
+
+    res = mockRes()
+    await call({ method: 'GET', query: {}, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('reports repo_not_configured without requiring login', async () => {
+    vi.mocked(getRepoConfig).mockResolvedValueOnce({ githubOwner: null, githubRepo: null } as never)
+    const res = mockRes()
+    await call({ method: 'GET', query: { project_id: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      canRequest: false,
+      mustLogin: false,
+      reason: 'repo_not_configured',
+    })
+  })
+
+  it('returns a login URL when the widget token is missing or invalid', async () => {
+    vi.mocked(getRepoConfig).mockResolvedValue({ githubOwner: 'acme', githubRepo: 'widgets' } as never)
+
+    let res = mockRes()
+    await call({
+      method: 'GET',
+      query: { project_id: 'p' },
+      headers: { origin: 'https://app.example' },
+    }, res)
+    expect(res.body).toMatchObject({ canRequest: false, mustLogin: true, reason: 'login_required' })
+    expect((res.body as { loginUrl: string }).loginUrl).toContain('/api/v1/widget/github/login')
+    expect((res.body as { loginUrl: string }).loginUrl).toContain('projectKey=p')
+
+    vi.mocked(verifyWidgetAuthToken).mockReturnValueOnce(null)
+    res = mockRes()
+    await call({
+      method: 'GET',
+      query: { project_id: 'p' },
+      headers: { authorization: 'Bearer bad', host: 'crrt.test', 'x-forwarded-proto': 'https' },
+    }, res)
+    expect(res.body).toMatchObject({ canRequest: false, reason: 'invalid_token' })
+  })
+
+  it('rejects tokens for another project or stale repo config', async () => {
+    vi.mocked(getRepoConfig).mockResolvedValue({ githubOwner: 'acme', githubRepo: 'widgets' } as never)
+    vi.mocked(verifyWidgetAuthToken).mockReturnValueOnce({
+      projectKey: 'other',
+      githubUserId: '1',
+      githubLogin: 'octo',
+      githubOwner: 'acme',
+      githubRepo: 'widgets',
+      iat: 1,
+      exp: 2,
+    })
+    let res = mockRes()
+    await call({ method: 'GET', query: { project_id: 'p' }, headers: { authorization: 'Bearer tok' } }, res)
+    expect(res.body).toMatchObject({ canRequest: false, reason: 'invalid_token' })
+
+    vi.mocked(verifyWidgetAuthToken).mockReturnValueOnce({
+      projectKey: 'p',
+      githubUserId: '1',
+      githubLogin: 'octo',
+      githubOwner: 'acme',
+      githubRepo: 'old',
+      iat: 1,
+      exp: 2,
+    })
+    res = mockRes()
+    await call({ method: 'GET', query: { project_id: 'p' }, headers: { authorization: 'Bearer tok' } }, res)
+    expect(res.body).toMatchObject({ canRequest: false, reason: 'invalid_token' })
+  })
+
+  it('allows matching widget auth tokens and 500s on store errors', async () => {
+    vi.mocked(getRepoConfig).mockResolvedValueOnce({ githubOwner: 'acme', githubRepo: 'widgets' } as never)
+    vi.mocked(verifyWidgetAuthToken).mockReturnValueOnce({
+      projectKey: 'p',
+      githubUserId: '1',
+      githubLogin: 'octo',
+      githubOwner: 'acme',
+      githubRepo: 'widgets',
+      iat: 1,
+      exp: 2,
+    })
+    let res = mockRes()
+    await call({ method: 'GET', query: { project_id: 'p' }, headers: { authorization: 'Bearer tok' } }, res)
+    expect(res.body).toMatchObject({
+      canRequest: true,
+      mustLogin: false,
+      githubLogin: 'octo',
+    })
+
+    vi.mocked(getRepoConfig).mockRejectedValueOnce(new Error('db down'))
+    res = mockRes()
+    await call({ method: 'GET', query: { project_id: 'p' }, headers: {} }, res)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/api/v1/agent/eligibility.ts
+++ b/api/v1/agent/eligibility.ts
@@ -1,0 +1,73 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { getRepoConfig } from '../../_lib/store.js'
+import { verifyWidgetAuthToken } from '../../_lib/widget-github-auth.js'
+import { getAppUrl, getBearerToken, getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
+
+function buildLoginUrl(req: VercelRequest, projectKey: string) {
+  const originHeader = Array.isArray(req.headers.origin) ? req.headers.origin[0] : req.headers.origin
+  const origin = originHeader || getStringQuery(req.query.origin) || getAppUrl(req)
+  const url = new URL(`${getAppUrl(req)}/api/v1/widget/github/login`)
+  url.searchParams.set('projectKey', projectKey)
+  url.searchParams.set('origin', origin)
+  return url.toString()
+}
+
+function unauthenticated(req: VercelRequest, projectKey: string, reason = 'login_required') {
+  return {
+    canRequest: false,
+    mustLogin: true,
+    mustSignUp: true,
+    isProjectMember: false,
+    reason,
+    loginUrl: buildLoginUrl(req, projectKey),
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (handleOptions(req, res, ['GET', 'OPTIONS'])) return
+  if (req.method !== 'GET') return methodNotAllowed(req, res, ['GET', 'OPTIONS'])
+
+  const projectKey = getStringQuery(req.query.project_id)
+  if (!projectKey) return jsonError(req, res, 400, 'Missing project_id')
+
+  try {
+    const config = await getRepoConfig(projectKey)
+    if (!config?.githubOwner || !config.githubRepo) {
+      setCors(req, res, ['GET', 'OPTIONS'])
+      return res.status(200).json({
+        canRequest: false,
+        mustLogin: false,
+        mustSignUp: false,
+        isProjectMember: false,
+        reason: 'repo_not_configured',
+      })
+    }
+
+    const token = getBearerToken(req)
+    if (!token) {
+      setCors(req, res, ['GET', 'OPTIONS'])
+      return res.status(200).json(unauthenticated(req, projectKey))
+    }
+
+    const payload = verifyWidgetAuthToken(token)
+    const matchesRepo = payload?.projectKey === projectKey
+      && payload.githubOwner === config.githubOwner
+      && payload.githubRepo === config.githubRepo
+    if (!payload || !matchesRepo) {
+      setCors(req, res, ['GET', 'OPTIONS'])
+      return res.status(200).json(unauthenticated(req, projectKey, 'invalid_token'))
+    }
+
+    setCors(req, res, ['GET', 'OPTIONS'])
+    return res.status(200).json({
+      canRequest: true,
+      mustLogin: false,
+      mustSignUp: false,
+      isProjectMember: true,
+      githubLogin: payload.githubLogin,
+    })
+  } catch (error) {
+    console.error(error)
+    return jsonError(req, res, 500, 'Internal server error')
+  }
+}

--- a/api/v1/widget/github/callback.test.ts
+++ b/api/v1/widget/github/callback.test.ts
@@ -83,6 +83,12 @@ describe('api/v1/widget/github/callback', () => {
     await call({ method: 'GET', query: { code: 'c', state: 's' }, headers: {} }, res)
     expect(res.statusCode).toBe(200)
     expect(String(res.body)).toContain('github_repo_inaccessible')
+
+    vi.mocked(getRepoConfig).mockResolvedValueOnce({ githubOwner: 'acme', githubRepo: 'widgets' } as never)
+    vi.mocked(exchangeGitHubCode).mockRejectedValueOnce(new Error('surprise'))
+    res = mockRes()
+    await call({ method: 'GET', query: { code: 'c', state: 's' }, headers: {} }, res)
+    expect(String(res.body)).toContain('github_auth_failed')
   })
 
   it('maps unexpected GitHub failures to a generic popup error', async () => {


### PR DESCRIPTION
- Add an eligibility endpoint that reports whether a widget visitor can request agent work.
- Return a GitHub login URL when a configured project does not have a valid widget auth token.
- Reject tokens for stale repo configuration or the wrong project.
- Allow matching GitHub-authenticated visitors through with their GitHub login.
- Cover the unauthenticated, invalid token, success, and store error paths.