### PR TITLE
docs: add /rules directory and agent read-order index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage/
 .vercel
 *.tgz
 pr/
+AUDIT.md
 
 # Claude Code skill artifacts (local-only, per-developer)
 .superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,12 @@
+## Read order for agents
+
+These instructions apply to any coding agent working in this repo, including Claude Code, Codex, and Cursor.
+
+- Any change -> read `rules/engineering.md`.
+- UI or design changes -> read `rules/ux.md` and `branding/CRRT-DESIGN-SYSTEM.md`.
+- Data, schema, or API changes -> read `rules/security.md` and `db/DRIZZLE-GUIDE.md`.
+- Product or copy decisions -> read `rules/business.md`.
+
 # Repo notes for AI agents
 
 ## Database changes

--- a/rules/business.md
+++ b/rules/business.md
@@ -1,0 +1,36 @@
+# Business Rules
+
+## Product Priority
+
+Source: `docs/context.md:7-16`, `docs/context.md:34-36`, `docs/context.md:56-70`, `docs/context.md:112-121`.
+
+- Position the product as visual feedback that becomes working code changes.
+- Sell shipped fixes, not feedback collection.
+- Optimize onboarding for the first shipped fix in the first session.
+- Ladder product decisions to fixes shipped per active user per week.
+- Track time from pin to merged fix, first-session activation, and week-four retention as secondary metrics.
+
+## Voice And Tone
+
+Source: `docs/context.md:84-99`, `docs/context.md:163-165`.
+
+- Use confident, premium, calm language.
+- Speak to users as competent peers.
+- Use active voice.
+- Prefer specific language over general language.
+- Do not say "AI-powered"; show the outcome instead.
+- Be honest that AI agents draft fixes and humans review before merging.
+- Explain "agent" and "prompt" in user language until proven otherwise.
+
+## Product Boundaries
+
+Source: `docs/context.md:101-110`, `docs/context.md:167-174`.
+
+- Do not position CRRT as a bug tracker, user research tool, survey tool, voice-of-customer platform, community feedback board, code review tool, or no-code builder.
+- Do not sell horizontal AI features; keep the product framed as taste shipped.
+- Do not compete horizontally with Notion, Linear, or Asana; stay vertical on feedback to action.
+- Do not gamify the product.
+- Do not add user research, surveys, or polls in v1.
+- Do not promise determinism; frame outputs as drafts to review.
+- Do not roadmap publicly too early.
+

--- a/rules/engineering.md
+++ b/rules/engineering.md
@@ -1,0 +1,39 @@
+# Engineering Rules
+
+## Schema Changes
+
+Source: `AGENTS.md:5-9`; `db/DRIZZLE-GUIDE.md:3-11`, `db/DRIZZLE-GUIDE.md:27-43`.
+
+- Route every schema change through `db/schema.ts`; do not hand-write schema SQL as the source of truth.
+- Before editing schema, read `db/DRIZZLE-GUIDE.md`.
+- Generate migrations with `bun run db:generate`, then read the generated SQL before committing it.
+- Commit `db/schema.ts`, the generated migration SQL, `db/migrations/meta/_journal.json`, and the new snapshot together.
+- Treat applied migrations as immutable; do not edit or delete applied migration files.
+- Keep migrations backwards-compatible; for renames, replace drop-and-add SQL with `ALTER TABLE ... RENAME COLUMN ...`.
+- Do not run `db:push` against production or shared development databases.
+- Keep `@supabase/supabase-js` as the runtime query layer; do not migrate `api/` query call sites to Drizzle's query builder.
+
+## Legacy SQL
+
+Source: `AGENTS.md:11-13`; `db/DRIZZLE-GUIDE.md:41`.
+
+- Treat `supabase/legacy/` as a frozen historical record.
+- Do not add new files under `supabase/legacy/`.
+- Do not run legacy SQL files against any environment.
+
+## Dashboard Routing
+
+Source: `AGENTS.md:15-17`.
+
+- The dashboard ships under `/dashboard/`; make in-app routes, links, and public assets base-aware.
+- Use `route()` and `asset()` from `apps/dashboard/lib/routes.ts`.
+- Do not hardcode absolute `/foo` paths in dashboard routes, links, or asset references.
+
+## Diff Coverage
+
+Source: `AGENTS.md:19-21`; `.claude/skills/diff-coverage/SKILL.md:1-24`.
+
+- After any code change, invoke the repo-local `$diff-coverage` skill before handing work back.
+- Require 100% diff line coverage vs `trunk`.
+- Require 100% diff branch coverage vs `trunk`.
+

--- a/rules/security.md
+++ b/rules/security.md
@@ -1,0 +1,32 @@
+# Security Rules
+
+## Agent API Workflow
+
+Source: `api/_lib/prompts.ts:54-83`; `apps/landing/public/skill.md:101-110`.
+
+- Announce agent presence before reading state.
+- Read share state before starting work.
+- Work only on comments whose `reviewStatus` is `accepted`.
+- Claim a comment before editing it.
+- Report `comment.start`, `comment.complete`, or `comment.block` as work proceeds.
+- Keep presence fresh whenever status changes.
+- Never change `reviewStatus`; humans own review status and agents own implementation status.
+- For `text_range` comments, treat `anchor.selectedText`, `anchor.prefix`, `anchor.suffix`, and `anchor.containerSelector` as the target context, not the pin coordinates alone.
+- Refresh share state before starting the next item.
+- If blocked, call `comment.block` with a short summary and the specific decision or access needed.
+
+## Agent API Access
+
+Source: `api/_lib/prompts.ts:54-58`, `api/_lib/prompts.ts:72-74`.
+
+- Use the share token as `Authorization: Bearer <token>`, `X-Share-Token: <token>`, or `?token=<token>` when calling agent share endpoints.
+- Include `X-Agent-Id` with a stable agent id when reporting presence or operations.
+- If the API fails in a surprising way, report the failure with a short summary, raw request/response, and request IDs when available.
+
+## Data Access
+
+Source: `db/DRIZZLE-GUIDE.md:42`; `AGENTS.md:9`.
+
+- Do not put `DATABASE_URL` behind a `VITE_` prefix; it must never reach the browser bundle.
+- Keep runtime API queries on `@supabase/supabase-js`; Drizzle is for schema and migrations only.
+

--- a/rules/ux.md
+++ b/rules/ux.md
@@ -1,0 +1,49 @@
+# UX Rules
+
+## Design Tokens
+
+Source: `branding/CRRT-DESIGN-SYSTEM.md:3-6`, `branding/CRRT-DESIGN-SYSTEM.md:24-190`.
+
+- Treat `branding/CRRT-DESIGN-SYSTEM.md` as the design source of truth.
+- Use the CRRT token values from `branding/crrt/tokens.css`; never deviate from them.
+- Add new tokens to the token source before using them in implementation.
+- Use the semantic color mapping for theme variables; dark theme is default and light theme is opt-in via `[data-theme="light"]`.
+- Keep typography within its defined roles: Inter for display/body/UI, JetBrains Mono for code/specs/install commands, and VT323 for CRT voice moments.
+- Use the 8-point spacing scale plus the 2px micro step for pixel-aligned details.
+- Use the defined radius, elevation, and motion tokens instead of raw ad hoc values.
+- Render pixel-art images with the documented pixelated/crisp image-rendering settings.
+
+## UI Feedback Handling
+
+Source: `apps/landing/public/skill.md:3-31`, `apps/landing/public/skill.md:43-55`, `apps/landing/public/skill.md:74-110`.
+
+- Use this skill only for UI, visual hierarchy, layout, copy clarity, interaction polish, or product experience feedback.
+- For non-UI work, follow the CRRT handoff prompt, local repo conventions, and the smallest relevant verification.
+- For ambiguous feedback, make the smallest reversible change or ask when risk is high.
+- Preserve the product's existing design system when changing UI.
+- Reuse existing components, tokens, variants, spacing rules, and nearby page patterns before creating new visual patterns.
+- Do not redesign surrounding screens unless the feedback asks for it.
+- Reuse existing components before creating new ones.
+- Reuse existing tokens before adding raw colors, spacing, shadows, or radii.
+- Keep product UI dense, practical, and scannable.
+- Keep landing UI brand-led and specific to the product.
+- Use icons for tool actions when an icon exists; prefer lucide icons when the project already uses lucide.
+- Do not nest cards inside cards.
+- Do not add decorative gradients, blobs, or generic hero art unless the page already uses that language.
+- Do not introduce oversized hero typography inside dashboards, settings, panels, modals, or tool surfaces.
+- Make sure text does not overflow buttons, tabs, table cells, cards, or mobile layouts.
+- Check mobile behavior when changing layout, navigation, tables, code blocks, or toolbars.
+- Before reporting UI work complete, verify the accepted feedback is addressed, nearby UI still matches the local design system, a relevant check ran, and the report says what changed and what was verified.
+- If blocked, call `comment.block` with a short summary and the specific decision or access needed.
+
+## Component Specs
+
+Source: `branding/AGENTIC-DESIGN-SYSTEM.md:3-5`, `branding/AGENTIC-DESIGN-SYSTEM.md:34-55`, `branding/AGENTIC-DESIGN-SYSTEM.md:160-207`.
+
+- Convention (rollout in progress): place a `<ComponentName>.meta.ts` file next to each component implementation.
+- Convention (rollout in progress): export one named `meta` constant per meta file; do not use default exports.
+- Convention (rollout in progress): make the meta filename match the component name and end in `.meta.ts`.
+- Convention (rollout in progress): document identity, usage guidance, API props/events/slots, design tokens, composition, behavior/a11y, motion, and examples.
+- Convention (rollout in progress): keep descriptions to one sentence, make `whenToUse` bullets imperative, name alternatives in `whenNotToUse`, list every consumed token, match every prop to the actual component API, and make examples compile.
+- Convention (rollout in progress): when using component meta, filter deprecated and experimental components unless the user opts in, confirm fit from `whenToUse` and `whenNotToUse`, start from the first example, and walk internal dependencies.
+


### PR DESCRIPTION
Adds rules/{engineering,ux,security,business}.md derived from existing repo rules (sources cited inline per section), adds AUDIT.md to .gitignore, and adds a 'Read order for agents' index at the top of AGENTS.md, so any coding agent (Claude Code, Codex, Cursor) knows which rules to read before which type of change. Docs-only — no code, config, test, or landing changes.