### PR TITLE
feat: project agent instructions — writable repo-config field + prompt section + settings editor

### DIFF
--- a/api/_lib/prompts.test.ts
+++ b/api/_lib/prompts.test.ts
@@ -16,4 +16,57 @@ describe('buildPrompt', () => {
     expect(prompt).toContain('Comments with targetType "text_range" anchor to selected text')
     expect(prompt).toContain('anchor.selectedText is the exact quote')
   })
+
+  const REPO_CONFIG = {
+    repoUrl: 'https://github.com/acme/widgets',
+    localPath: null,
+    defaultBranch: 'main',
+    installCommand: null,
+    devCommand: null,
+    testCommand: null,
+    buildCommand: null,
+    agentInstructions: null as string | null,
+  }
+
+  const baseInput = {
+    appUrl: 'https://crrt.ai/',
+    slug: 'share-slug',
+    token: 'share-token',
+    pageUrl: null,
+    projectKey: 'demo-project',
+    projectName: 'Demo',
+  }
+
+  it('renders agent instructions as a labeled section, verbatim', () => {
+    const prompt = buildPrompt('claude-code', {
+      ...baseInput,
+      repoConfig: { ...REPO_CONFIG, agentInstructions: 'Read AGENTS.md first and follow its read order before any change.' },
+    })
+
+    expect(prompt).toContain(
+      '## Project instructions (from the team)\n\nRead AGENTS.md first and follow its read order before any change.',
+    )
+    // The legacy terse rendering is gone.
+    expect(prompt).not.toContain('- Extra:')
+    // The rest of the prompt is not reordered: instructions come after the repo block.
+    expect(prompt.indexOf('Project + repo:')).toBeLessThan(prompt.indexOf('## Project instructions'))
+  })
+
+  it('omits the instructions section when none are set', () => {
+    for (const repoConfig of [null, REPO_CONFIG]) {
+      const prompt = buildPrompt('generic', { ...baseInput, repoConfig })
+      expect(prompt).not.toContain('## Project instructions')
+      expect(prompt).not.toContain('- Extra:')
+    }
+  })
+
+  it('keeps markdown structure (headers, lists) intact', () => {
+    const markdown = '## Read order\n\n1. PRODUCT.md\n2. DESIGN.md\n\n- Never invent tokens\n- Cite rules by `id`'
+    const prompt = buildPrompt('codex', {
+      ...baseInput,
+      repoConfig: { ...REPO_CONFIG, agentInstructions: markdown },
+    })
+
+    expect(prompt).toContain(markdown)
+  })
 })

--- a/api/_lib/prompts.ts
+++ b/api/_lib/prompts.ts
@@ -38,12 +38,17 @@ function buildBody(input: PromptInput) {
     if (input.repoConfig?.devCommand) repoLines.push(`- Dev: ${input.repoConfig.devCommand}`)
     if (input.repoConfig?.testCommand) repoLines.push(`- Test: ${input.repoConfig.testCommand}`)
     if (input.repoConfig?.buildCommand) repoLines.push(`- Build: ${input.repoConfig.buildCommand}`)
-    if (input.repoConfig?.agentInstructions) repoLines.push(`- Extra: ${input.repoConfig.agentInstructions}`)
     if (input.pageUrl) repoLines.push(`- Scoped page: ${input.pageUrl}`)
   } else {
     repoLines.push(`Project: ${input.projectName} (${input.projectKey})`)
     if (input.pageUrl) repoLines.push(`Scoped page: ${input.pageUrl}`)
   }
+
+  // Team-authored, rendered verbatim (markdown intact) as its own labeled
+  // section so agents weight it as project policy, not repo metadata.
+  const instructionLines = input.repoConfig?.agentInstructions
+    ? ['', '## Project instructions (from the team)', '', input.repoConfig.agentInstructions]
+    : []
 
   return [
     'CRRT 🥕 is a visual feedback system: humans drop comments pinned to real pixels on live pages, and you implement the accepted ones.',
@@ -83,6 +88,7 @@ function buildBody(input: PromptInput) {
     '- Refresh /state before starting the next item.',
     '',
     repoLines.join('\n'),
+    ...instructionLines,
   ].join('\n')
 }
 

--- a/api/_lib/store.settings.test.ts
+++ b/api/_lib/store.settings.test.ts
@@ -186,6 +186,57 @@ describe('updateRepoConfig', () => {
     }) as never)
     await expect(updateRepoConfig('p', { repoUrl: 'acme/widgets' })).rejects.toThrow('boom')
   })
+
+  it('writes only the provided fields — absent keys never reach the upsert', async () => {
+    // Chain variant that records upsert payloads so partial-patch semantics
+    // are assertable (the shared `chain` stub discards arguments).
+    const row = {
+      project_key: 'p',
+      repo_url: 'https://github.com/acme/widgets',
+      github_owner: 'acme',
+      github_repo: 'widgets',
+      local_path: '/srv/widgets',
+      default_branch: 'main',
+      install_command: null,
+      dev_command: 'bun dev',
+      test_command: 'bun test',
+      build_command: null,
+      agent_instructions: 'Read AGENTS.md first and follow its read order.',
+    }
+    const upserts: unknown[] = []
+    const p: Record<string, unknown> = {}
+    const self = () => p
+    for (const m of ['select', 'eq']) p[m] = self
+    p.upsert = (payload: unknown) => { upserts.push(payload); return p }
+    p.single = () => Promise.resolve({ data: row, error: null })
+    vi.mocked(getServiceSupabase).mockReturnValue({ from: vi.fn(() => p) } as never)
+
+    const out = await updateRepoConfig('p', {
+      agentInstructions: 'Read AGENTS.md first and follow its read order.',
+      localPath: '/srv/widgets',
+      devCommand: 'bun dev',
+      testCommand: 'bun test',
+    })
+    const payload = upserts[0] as Record<string, unknown>
+    expect(payload).toMatchObject({
+      project_key: 'p',
+      agent_instructions: 'Read AGENTS.md first and follow its read order.',
+      local_path: '/srv/widgets',
+      dev_command: 'bun dev',
+      test_command: 'bun test',
+    })
+    // repoUrl was not in the patch: its columns must not be touched.
+    expect('repo_url' in payload).toBe(false)
+    expect('github_owner' in payload).toBe(false)
+    expect(out).toMatchObject({ agentInstructions: 'Read AGENTS.md first and follow its read order.' })
+
+    // null clears: the column is written as null, others stay absent.
+    const out2 = await updateRepoConfig('p', { agentInstructions: null })
+    const payload2 = upserts[1] as Record<string, unknown>
+    expect(payload2.agent_instructions).toBeNull()
+    expect('local_path' in payload2).toBe(false)
+    expect(out2).not.toBeNull()
+  })
 })
 
 describe('listProjectMembers', () => {

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -888,20 +888,35 @@ export function normalizeGitHubRepoUrl(value: string): {
   }
 }
 
-export async function updateRepoConfig(projectKey: string, patch: {
-  repoUrl: string | null
-}) {
-  const supabase = getSupabase()
-  const normalized = patch.repoUrl === null ? null : normalizeGitHubRepoUrl(patch.repoUrl)
-  if (patch.repoUrl !== null && !normalized) throw new Error('invalid_github_repo')
+export type RepoConfigPatch = {
+  repoUrl?: string | null
+  localPath?: string | null
+  devCommand?: string | null
+  testCommand?: string | null
+  agentInstructions?: string | null
+}
 
-  const update = {
+export async function updateRepoConfig(projectKey: string, patch: RepoConfigPatch) {
+  const supabase = getSupabase()
+  // Only touch the columns the caller provided: `undefined` leaves a field
+  // as-is, `null` clears it. The upsert's ON CONFLICT UPDATE only sets the
+  // supplied columns, so unrelated fields survive partial patches.
+  const update: Record<string, unknown> = {
     project_key: projectKey,
-    repo_url: normalized?.repoUrl ?? null,
-    github_owner: normalized?.githubOwner ?? null,
-    github_repo: normalized?.githubRepo ?? null,
     updated_at: new Date().toISOString(),
   }
+
+  if (patch.repoUrl !== undefined) {
+    const normalized = patch.repoUrl === null ? null : normalizeGitHubRepoUrl(patch.repoUrl)
+    if (patch.repoUrl !== null && !normalized) throw new Error('invalid_github_repo')
+    update.repo_url = normalized?.repoUrl ?? null
+    update.github_owner = normalized?.githubOwner ?? null
+    update.github_repo = normalized?.githubRepo ?? null
+  }
+  if (patch.localPath !== undefined) update.local_path = patch.localPath
+  if (patch.devCommand !== undefined) update.dev_command = patch.devCommand
+  if (patch.testCommand !== undefined) update.test_command = patch.testCommand
+  if (patch.agentInstructions !== undefined) update.agent_instructions = patch.agentInstructions
 
   const { data, error } = await supabase
     .from('project_repo_configs')

--- a/api/v1/projects/[projectId]/repo-config.test.ts
+++ b/api/v1/projects/[projectId]/repo-config.test.ts
@@ -117,4 +117,90 @@ describe('api/v1/projects/[projectId]/repo-config', () => {
     await call({ method: 'PATCH', query: { projectId: 'p' }, body: { repoUrl: null }, headers: {} }, res)
     expect(res.statusCode).toBe(500)
   })
+
+  it('accepts agentInstructions: trims edges, keeps inner markdown verbatim', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
+    vi.mocked(updateRepoConfig).mockResolvedValueOnce({ agentInstructions: 'set' } as never)
+
+    const markdown = '  ## Read order\n\n- Read AGENTS.md **first**\n- Then `/rules`  '
+    const res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { agentInstructions: markdown }, headers: {} }, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(updateRepoConfig).toHaveBeenCalledWith('p', {
+      agentInstructions: '## Read order\n\n- Read AGENTS.md **first**\n- Then `/rules`',
+    })
+  })
+
+  it('clears agentInstructions on empty/whitespace string and on null', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
+    vi.mocked(updateRepoConfig).mockResolvedValue({ agentInstructions: null } as never)
+
+    let res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { agentInstructions: '   ' }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(updateRepoConfig).toHaveBeenLastCalledWith('p', { agentInstructions: null })
+
+    res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { agentInstructions: null }, headers: {} }, res)
+    expect(res.statusCode).toBe(200)
+    expect(updateRepoConfig).toHaveBeenLastCalledWith('p', { agentInstructions: null })
+  })
+
+  it('rejects over-cap and non-string agentInstructions without touching the store', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
+
+    let res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { agentInstructions: 'x'.repeat(4001) }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({ error: 'agentInstructions must be 4000 characters or fewer' })
+
+    res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { agentInstructions: 42 }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({ error: 'agentInstructions must be a string or null' })
+
+    expect(updateRepoConfig).not.toHaveBeenCalled()
+  })
+
+  it('accepts the co-located fields and forwards a combined patch', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+    vi.mocked(getProjectMember).mockResolvedValue({ role: 'admin' })
+    vi.mocked(updateRepoConfig).mockResolvedValueOnce({} as never)
+
+    const res = mockRes()
+    await call({
+      method: 'PATCH',
+      query: { projectId: 'p' },
+      body: { repoUrl: 'acme/widgets', localPath: ' /srv/widgets ', devCommand: 'bun dev', testCommand: '' },
+      headers: {},
+    }, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(updateRepoConfig).toHaveBeenCalledWith('p', {
+      repoUrl: 'acme/widgets',
+      localPath: '/srv/widgets',
+      devCommand: 'bun dev',
+      testCommand: null,
+    })
+  })
+
+  it('rejects a patch with no supported fields, and PATCH stays admin-gated', async () => {
+    vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
+
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'admin' })
+    let res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { unrelated: true }, headers: {} }, res)
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({ error: 'No supported fields to update' })
+
+    vi.mocked(getProjectMember).mockResolvedValueOnce({ role: 'member' })
+    res = mockRes()
+    await call({ method: 'PATCH', query: { projectId: 'p' }, body: { agentInstructions: 'x' }, headers: {} }, res)
+    expect(res.statusCode).toBe(403)
+    expect(updateRepoConfig).not.toHaveBeenCalled()
+  })
 })

--- a/api/v1/projects/[projectId]/repo-config.ts
+++ b/api/v1/projects/[projectId]/repo-config.ts
@@ -1,7 +1,16 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { requireUser } from '../../../_lib/auth.js'
-import { getProjectMember, getRepoConfig, updateRepoConfig } from '../../../_lib/store.js'
+import { getProjectMember, getRepoConfig, updateRepoConfig, type RepoConfigPatch } from '../../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
+
+export const AGENT_INSTRUCTIONS_MAX = 4000
+
+const TEXT_FIELDS = [
+  { key: 'agentInstructions', max: AGENT_INSTRUCTIONS_MAX },
+  { key: 'localPath', max: 400 },
+  { key: 'devCommand', max: 400 },
+  { key: 'testCommand', max: 400 },
+] as const satisfies ReadonlyArray<{ key: keyof RepoConfigPatch; max: number }>
 
 async function requireProjectAdmin(userId: string, projectKey: string) {
   const membership = await getProjectMember(userId, projectKey)
@@ -31,12 +40,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(200).json(config)
     }
 
-    const body = (req.body ?? {}) as { repoUrl?: unknown }
-    if (body.repoUrl !== null && typeof body.repoUrl !== 'string') {
-      return jsonError(req, res, 400, 'repoUrl must be a GitHub URL, owner/repo, or null')
+    const body = (req.body ?? {}) as Record<string, unknown>
+    const patch: RepoConfigPatch = {}
+
+    if ('repoUrl' in body) {
+      if (body.repoUrl !== null && typeof body.repoUrl !== 'string') {
+        return jsonError(req, res, 400, 'repoUrl must be a GitHub URL, owner/repo, or null')
+      }
+      patch.repoUrl = body.repoUrl as string | null
     }
 
-    const config = await updateRepoConfig(projectKey, { repoUrl: body.repoUrl })
+    // Free-text fields: a string sets the value (trimmed at the edges only —
+    // inner markdown survives verbatim; '' clears), null clears, an absent
+    // key leaves the stored value untouched.
+    for (const field of TEXT_FIELDS) {
+      if (!(field.key in body)) continue
+      const value = body[field.key]
+      if (value !== null && typeof value !== 'string') {
+        return jsonError(req, res, 400, `${field.key} must be a string or null`)
+      }
+      const trimmed = value === null ? null : (value as string).trim()
+      if (trimmed !== null && trimmed.length > field.max) {
+        return jsonError(req, res, 400, `${field.key} must be ${field.max} characters or fewer`)
+      }
+      patch[field.key] = trimmed === '' ? null : trimmed
+    }
+
+    if (Object.keys(patch).length === 0) {
+      return jsonError(req, res, 400, 'No supported fields to update')
+    }
+
+    const config = await updateRepoConfig(projectKey, patch)
     setCors(req, res, ['GET', 'PATCH', 'OPTIONS'])
     return res.status(200).json(config)
   } catch (error) {

--- a/apps/dashboard/App.tsx
+++ b/apps/dashboard/App.tsx
@@ -440,6 +440,7 @@ function AuthenticatedApp({ accessToken, user, onSignOut }: { accessToken: strin
         <SuperAdminPanel apiBase={API_BASE} accessToken={accessToken} />
       ) : view === 'settings' && activeProject ? (
         <ProjectSettings
+          key={activeProject.publicKey}
           project={activeProject}
           apiBase={API_BASE}
           accessToken={accessToken}

--- a/apps/dashboard/api.ts
+++ b/apps/dashboard/api.ts
@@ -308,6 +308,46 @@ export function removeProjectMember(apiBase: string, accessToken: string, projec
   )
 }
 
+export interface RepoConfig {
+  projectKey: string
+  repoUrl: string | null
+  githubOwner: string | null
+  githubRepo: string | null
+  localPath: string | null
+  defaultBranch: string | null
+  installCommand: string | null
+  devCommand: string | null
+  testCommand: string | null
+  buildCommand: string | null
+  agentInstructions: string | null
+}
+
+// Server-side cap for agentInstructions (mirrored from
+// api/v1/projects/[projectId]/repo-config.ts AGENT_INSTRUCTIONS_MAX).
+export const AGENT_INSTRUCTIONS_MAX = 4000
+
+// Repo config is admin-gated server-side; GET returns null when the project
+// has no config row yet.
+export function getProjectRepoConfig(apiBase: string, accessToken: string, projectKey: string) {
+  return requestJson<RepoConfig | null>(`${apiBase}/v1/projects/${encodeURIComponent(projectKey)}/repo-config`, {
+    headers: { ...authHeaders(accessToken) },
+  })
+}
+
+// Partial patch: absent keys stay untouched, null (or '') clears a field.
+export function updateProjectRepoConfig(
+  apiBase: string,
+  accessToken: string,
+  projectKey: string,
+  patch: Partial<Pick<RepoConfig, 'repoUrl' | 'localPath' | 'devCommand' | 'testCommand' | 'agentInstructions'>>,
+) {
+  return requestJson<RepoConfig | null>(`${apiBase}/v1/projects/${encodeURIComponent(projectKey)}/repo-config`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(accessToken) },
+    body: JSON.stringify(patch),
+  })
+}
+
 // Rename a project (display name only — public key/slug are immutable).
 export function renameProject(apiBase: string, accessToken: string, projectKey: string, name: string) {
   return requestJson<Project>(`${apiBase}/v1/projects/${encodeURIComponent(projectKey)}`, {

--- a/apps/dashboard/components/ProjectSettings.tsx
+++ b/apps/dashboard/components/ProjectSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import type { Project } from '../api'
+import { AGENT_INSTRUCTIONS_MAX, type Project } from '../api'
 import { useProjectSettings } from '../hooks/useProjectSettings'
 import { cn } from '../lib/utils'
 import { ChevronLeftIcon, TrashIcon } from './icons'
@@ -36,10 +36,14 @@ export function ProjectSettings({ project, apiBase, accessToken, currentUserId, 
   const [domains, setDomains] = useState<string[]>(project.allowedOrigins)
   const [domainInput, setDomainInput] = useState('')
   const [domainBusy, setDomainBusy] = useState(false)
+  const [instructions, setInstructions] = useState('')
+  const [instructionsBusy, setInstructionsBusy] = useState(false)
 
   // Re-sync the name field when switching to a different project.
   useEffect(() => { setName(project.name) }, [project.publicKey, project.name])
   useEffect(() => { setDomains(project.allowedOrigins) }, [project.publicKey, project.allowedOrigins])
+  // Repo config loads async (and re-loads per project): sync when it lands.
+  useEffect(() => { setInstructions(settings.repoConfig?.agentInstructions ?? '') }, [project.publicKey, settings.repoConfig])
 
   const adminCount = members.filter((m) => m.role === 'admin').length
   const nameChanged = name.trim() !== '' && name.trim() !== project.name
@@ -88,6 +92,20 @@ export function ProjectSettings({ project, apiBase, accessToken, currentUserId, 
       setActionError(err instanceof Error ? err.message : 'Failed to update allowed domains')
     } finally {
       setDomainBusy(false)
+    }
+  }
+
+  const instructionsChanged = instructions.trim() !== (settings.repoConfig?.agentInstructions ?? '')
+  async function saveInstructions() {
+    if (!instructionsChanged || instructionsBusy) return
+    setActionError(null)
+    setInstructionsBusy(true)
+    try {
+      await settings.saveAgentInstructions(instructions.trim())
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to save agent instructions')
+    } finally {
+      setInstructionsBusy(false)
     }
   }
 
@@ -227,6 +245,41 @@ export function ProjectSettings({ project, apiBase, accessToken, currentUserId, 
             </form>
           )}
         </section>
+
+        {/* Agent instructions */}
+        {isAdmin && (
+          <section className="mt-8">
+            <h2 className={sectionTitle}>Agent instructions</h2>
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Injected into every agent handoff prompt for this project — e.g. &ldquo;Read AGENTS.md first and follow its read order.&rdquo;
+            </p>
+            <div className={cn(card, 'mt-3 p-4')}>
+              <textarea
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                disabled={instructionsBusy}
+                maxLength={AGENT_INSTRUCTIONS_MAX}
+                rows={5}
+                placeholder="Read AGENTS.md first and follow its read order before any change."
+                aria-label="Agent instructions"
+                className="w-full px-3 py-2 rounded-md border border-border bg-background text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-colors disabled:opacity-60 resize-y min-h-[96px]"
+                spellCheck={false}
+              />
+              <div className="mt-2 flex items-center justify-between">
+                <span className="text-[11px] text-muted-foreground tabular-nums">
+                  {instructions.length}/{AGENT_INSTRUCTIONS_MAX}
+                </span>
+                <button
+                  onClick={saveInstructions}
+                  disabled={!instructionsChanged || instructionsBusy}
+                  className={submitBtn(instructionsChanged && !instructionsBusy)}
+                >
+                  {instructionsBusy ? 'Saving…' : 'Save'}
+                </button>
+              </div>
+            </div>
+          </section>
+        )}
 
         {/* Team */}
         <section className="mt-8">

--- a/apps/dashboard/components/ProjectSettings.tsx
+++ b/apps/dashboard/components/ProjectSettings.tsx
@@ -96,8 +96,9 @@ export function ProjectSettings({ project, apiBase, accessToken, currentUserId, 
   }
 
   const instructionsChanged = instructions.trim() !== (settings.repoConfig?.agentInstructions ?? '')
+  const instructionsUnavailable = loading || settings.repoConfigError !== null
   async function saveInstructions() {
-    if (!instructionsChanged || instructionsBusy) return
+    if (!instructionsChanged || instructionsBusy || instructionsUnavailable) return
     setActionError(null)
     setInstructionsBusy(true)
     try {
@@ -253,11 +254,16 @@ export function ProjectSettings({ project, apiBase, accessToken, currentUserId, 
             <p className="mt-1 text-[11px] text-muted-foreground">
               Injected into every agent handoff prompt for this project — e.g. &ldquo;Read AGENTS.md first and follow its read order.&rdquo;
             </p>
+            {settings.repoConfigError && (
+              <p className="mt-2 text-[11px] text-status-rejected" role="alert">
+                Agent instructions couldn&rsquo;t be loaded. Refresh to try again.
+              </p>
+            )}
             <div className={cn(card, 'mt-3 p-4')}>
               <textarea
                 value={instructions}
                 onChange={(e) => setInstructions(e.target.value)}
-                disabled={instructionsBusy}
+                disabled={instructionsBusy || instructionsUnavailable}
                 maxLength={AGENT_INSTRUCTIONS_MAX}
                 rows={5}
                 placeholder="Read AGENTS.md first and follow its read order before any change."
@@ -271,8 +277,8 @@ export function ProjectSettings({ project, apiBase, accessToken, currentUserId, 
                 </span>
                 <button
                   onClick={saveInstructions}
-                  disabled={!instructionsChanged || instructionsBusy}
-                  className={submitBtn(instructionsChanged && !instructionsBusy)}
+                  disabled={!instructionsChanged || instructionsBusy || instructionsUnavailable}
+                  className={submitBtn(instructionsChanged && !instructionsBusy && !instructionsUnavailable)}
                 >
                   {instructionsBusy ? 'Saving…' : 'Save'}
                 </button>

--- a/apps/dashboard/hooks/useProjectSettings.test.tsx
+++ b/apps/dashboard/hooks/useProjectSettings.test.tsx
@@ -1,0 +1,127 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/mocks', () => ({ mocksEnabled: false }))
+vi.mock('../api', () => ({
+  cancelProjectInvite: vi.fn(),
+  getProjectRepoConfig: vi.fn(),
+  inviteProjectMember: vi.fn(),
+  listProjectInvites: vi.fn(),
+  listProjectMembers: vi.fn(),
+  removeProjectMember: vi.fn(),
+  renameProject: vi.fn(),
+  updateProjectAllowedOrigins: vi.fn(),
+  updateProjectRepoConfig: vi.fn(),
+}))
+
+import {
+  getProjectRepoConfig,
+  listProjectInvites,
+  listProjectMembers,
+  updateProjectRepoConfig,
+  type ProjectMember,
+  type RepoConfig,
+} from '../api'
+import { useProjectSettings } from './useProjectSettings'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => { resolve = res })
+  return { promise, resolve }
+}
+
+function admin(projectKey: string): ProjectMember {
+  return {
+    userId: `admin-${projectKey}`,
+    email: `${projectKey}@example.com`,
+    role: 'admin',
+    createdAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+function repoConfig(projectKey: string, agentInstructions: string): RepoConfig {
+  return {
+    projectKey,
+    repoUrl: null,
+    githubOwner: null,
+    githubRepo: null,
+    localPath: null,
+    defaultBranch: 'main',
+    installCommand: null,
+    devCommand: null,
+    testCommand: null,
+    buildCommand: null,
+    agentInstructions,
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(listProjectMembers).mockReset()
+  vi.mocked(listProjectInvites).mockReset().mockResolvedValue([])
+  vi.mocked(getProjectRepoConfig).mockReset()
+  vi.mocked(updateProjectRepoConfig).mockReset()
+})
+
+describe('useProjectSettings repo config', () => {
+  it('ignores a stale response after switching projects', async () => {
+    const projectA = deferred<ProjectMember[]>()
+    vi.mocked(listProjectMembers).mockImplementation((_api, _token, projectKey) => (
+      projectKey === 'a' ? projectA.promise : Promise.resolve([admin('b')])
+    ))
+    vi.mocked(getProjectRepoConfig).mockImplementation((_api, _token, projectKey) => (
+      Promise.resolve(repoConfig(projectKey, `instructions-${projectKey}`))
+    ))
+
+    const { result, rerender } = renderHook(
+      ({ projectKey, userId }) => useProjectSettings('/api', 'token', projectKey, userId),
+      { initialProps: { projectKey: 'a', userId: 'admin-a' } },
+    )
+    await waitFor(() => expect(listProjectMembers).toHaveBeenCalledWith('/api', 'token', 'a'))
+
+    rerender({ projectKey: 'b', userId: 'admin-b' })
+    await waitFor(() => expect(result.current.repoConfig?.agentInstructions).toBe('instructions-b'))
+
+    await act(async () => { projectA.resolve([admin('a')]); await projectA.promise })
+    expect(result.current.repoConfig?.projectKey).toBe('b')
+    expect(result.current.members).toEqual([admin('b')])
+  })
+
+  it('exposes an admin repo-config load failure instead of treating it as empty', async () => {
+    vi.mocked(listProjectMembers).mockResolvedValue([admin('a')])
+    vi.mocked(getProjectRepoConfig).mockRejectedValue(new Error('repo config unavailable'))
+
+    const { result } = renderHook(() => useProjectSettings('/api', 'token', 'a', 'admin-a'))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.isAdmin).toBe(true)
+    expect(result.current.repoConfig).toBeNull()
+    expect(result.current.repoConfigError).toBe('repo config unavailable')
+  })
+
+  it('does not apply a completed save to a different project', async () => {
+    const saveA = deferred<RepoConfig | null>()
+    vi.mocked(listProjectMembers).mockImplementation((_api, _token, projectKey) => (
+      Promise.resolve([admin(projectKey)])
+    ))
+    vi.mocked(getProjectRepoConfig).mockImplementation((_api, _token, projectKey) => (
+      Promise.resolve(repoConfig(projectKey, `instructions-${projectKey}`))
+    ))
+    vi.mocked(updateProjectRepoConfig).mockImplementation((_api, _token, projectKey) => (
+      projectKey === 'a' ? saveA.promise : Promise.resolve(repoConfig('b', 'saved-b'))
+    ))
+
+    const { result, rerender } = renderHook(
+      ({ projectKey, userId }) => useProjectSettings('/api', 'token', projectKey, userId),
+      { initialProps: { projectKey: 'a', userId: 'admin-a' } },
+    )
+    await waitFor(() => expect(result.current.repoConfig?.projectKey).toBe('a'))
+
+    const pendingSave = result.current.saveAgentInstructions('saved-a')
+    rerender({ projectKey: 'b', userId: 'admin-b' })
+    await waitFor(() => expect(result.current.repoConfig?.projectKey).toBe('b'))
+
+    await act(async () => { saveA.resolve(repoConfig('a', 'saved-a')); await pendingSave })
+    expect(result.current.repoConfig?.projectKey).toBe('b')
+    expect(result.current.repoConfig?.agentInstructions).toBe('instructions-b')
+  })
+})

--- a/apps/dashboard/hooks/useProjectSettings.ts
+++ b/apps/dashboard/hooks/useProjectSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   cancelProjectInvite as apiCancelInvite,
   getProjectRepoConfig,
@@ -20,6 +20,7 @@ export interface UseProjectSettingsResult {
   members: ProjectMember[]
   invites: ProjectInvite[]
   repoConfig: RepoConfig | null
+  repoConfigError: string | null
   loading: boolean
   error: string | null
   isAdmin: boolean
@@ -48,41 +49,68 @@ export function useProjectSettings(
   const [members, setMembers] = useState<ProjectMember[]>([])
   const [invites, setInvites] = useState<ProjectInvite[]>([])
   const [repoConfig, setRepoConfig] = useState<RepoConfig | null>(null)
+  const [repoConfigError, setRepoConfigError] = useState<string | null>(null)
+  const [loadedProjectKey, setLoadedProjectKey] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const currentProjectKey = useRef(projectKey)
+  const refreshSequence = useRef(0)
+  currentProjectKey.current = projectKey
 
   const refresh = useCallback(async () => {
     if (!projectKey) return
+    const sequence = ++refreshSequence.current
+    const isCurrent = () => currentProjectKey.current === projectKey && refreshSequence.current === sequence
     setLoading(true)
     setError(null)
+    setRepoConfigError(null)
     if (mocksEnabled) {
+      if (!isCurrent()) return
       setMembers([{ userId: currentUserId, email: 'you@example.com', role: 'admin', createdAt: new Date().toISOString() }])
       setInvites([])
       setRepoConfig(null)
+      setLoadedProjectKey(projectKey)
       setLoading(false)
       return
     }
     try {
-      // Repo config is admin-gated (403 for members): degrade to null rather
-      // than failing the whole settings panel, same as invites.
-      const [m, i, rc] = await Promise.all([
+      const [m, i] = await Promise.all([
         listProjectMembers(apiBase, accessToken, projectKey),
         listProjectInvites(apiBase, accessToken, projectKey).catch(() => [] as ProjectInvite[]),
-        getProjectRepoConfig(apiBase, accessToken, projectKey).catch(() => null),
       ])
+      if (!isCurrent()) return
+
+      let rc: RepoConfig | null = null
+      let rcError: string | null = null
+      const isProjectAdmin = m.some((member) => member.userId === currentUserId && member.role === 'admin')
+      if (isProjectAdmin) {
+        try {
+          rc = await getProjectRepoConfig(apiBase, accessToken, projectKey)
+        } catch (err) {
+          rcError = err instanceof Error ? err.message : 'Failed to load repository configuration'
+        }
+      }
+      if (!isCurrent()) return
+
       setMembers(m)
       setInvites(i)
       setRepoConfig(rc)
+      setRepoConfigError(rcError)
+      setLoadedProjectKey(projectKey)
     } catch (err) {
+      if (!isCurrent()) return
+      setMembers([])
+      setInvites([])
+      setRepoConfig(null)
+      setRepoConfigError(null)
+      setLoadedProjectKey(projectKey)
       setError(err instanceof Error ? err.message : 'Failed to load project settings')
     } finally {
-      setLoading(false)
+      if (isCurrent()) setLoading(false)
     }
   }, [apiBase, accessToken, projectKey, currentUserId])
 
   useEffect(() => { refresh() }, [refresh])
-
-  const isAdmin = members.some((m) => m.userId === currentUserId && m.role === 'admin')
 
   const rename = useCallback(async (name: string) => {
     const project = await apiRename(apiBase, accessToken, projectKey, name)
@@ -99,7 +127,11 @@ export function useProjectSettings(
   const saveAgentInstructions = useCallback(async (value: string) => {
     // '' clears the field server-side; the response is the fresh config.
     const config = await updateProjectRepoConfig(apiBase, accessToken, projectKey, { agentInstructions: value })
-    setRepoConfig(config)
+    if (currentProjectKey.current === projectKey) {
+      setRepoConfig(config)
+      setRepoConfigError(null)
+      setLoadedProjectKey(projectKey)
+    }
     return config
   }, [apiBase, accessToken, projectKey])
 
@@ -118,5 +150,28 @@ export function useProjectSettings(
     await refresh()
   }, [apiBase, accessToken, projectKey, refresh])
 
-  return { members, invites, repoConfig, loading, error, isAdmin, refresh, rename, updateAllowedOrigins, saveAgentInstructions, invite, removeMember, cancelInvite }
+  const hasCurrentProject = loadedProjectKey === projectKey
+  const currentMembers = hasCurrentProject ? members : []
+  const currentInvites = hasCurrentProject ? invites : []
+  const currentRepoConfig = hasCurrentProject ? repoConfig : null
+  const currentRepoConfigError = hasCurrentProject ? repoConfigError : null
+  const currentError = hasCurrentProject ? error : null
+  const currentIsAdmin = currentMembers.some((m) => m.userId === currentUserId && m.role === 'admin')
+
+  return {
+    members: currentMembers,
+    invites: currentInvites,
+    repoConfig: currentRepoConfig,
+    repoConfigError: currentRepoConfigError,
+    loading: hasCurrentProject ? loading : true,
+    error: currentError,
+    isAdmin: currentIsAdmin,
+    refresh,
+    rename,
+    updateAllowedOrigins,
+    saveAgentInstructions,
+    invite,
+    removeMember,
+    cancelInvite,
+  }
 }

--- a/apps/dashboard/hooks/useProjectSettings.ts
+++ b/apps/dashboard/hooks/useProjectSettings.ts
@@ -1,27 +1,32 @@
 import { useCallback, useEffect, useState } from 'react'
 import {
   cancelProjectInvite as apiCancelInvite,
+  getProjectRepoConfig,
   inviteProjectMember as apiInvite,
   listProjectInvites,
   listProjectMembers,
   removeProjectMember as apiRemoveMember,
   renameProject as apiRename,
   updateProjectAllowedOrigins as apiUpdateAllowedOrigins,
+  updateProjectRepoConfig,
   type Project,
   type ProjectInvite,
   type ProjectMember,
+  type RepoConfig,
 } from '../api'
 import { mocksEnabled } from '../lib/mocks'
 
 export interface UseProjectSettingsResult {
   members: ProjectMember[]
   invites: ProjectInvite[]
+  repoConfig: RepoConfig | null
   loading: boolean
   error: string | null
   isAdmin: boolean
   refresh: () => Promise<void>
   rename: (name: string) => Promise<Project>
   updateAllowedOrigins: (domains: string[]) => Promise<Project>
+  saveAgentInstructions: (value: string) => Promise<RepoConfig | null>
   invite: (email: string, role?: 'admin' | 'member') => Promise<void>
   removeMember: (userId: string) => Promise<void>
   cancelInvite: (email: string) => Promise<void>
@@ -42,6 +47,7 @@ export function useProjectSettings(
 ): UseProjectSettingsResult {
   const [members, setMembers] = useState<ProjectMember[]>([])
   const [invites, setInvites] = useState<ProjectInvite[]>([])
+  const [repoConfig, setRepoConfig] = useState<RepoConfig | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -52,16 +58,21 @@ export function useProjectSettings(
     if (mocksEnabled) {
       setMembers([{ userId: currentUserId, email: 'you@example.com', role: 'admin', createdAt: new Date().toISOString() }])
       setInvites([])
+      setRepoConfig(null)
       setLoading(false)
       return
     }
     try {
-      const [m, i] = await Promise.all([
+      // Repo config is admin-gated (403 for members): degrade to null rather
+      // than failing the whole settings panel, same as invites.
+      const [m, i, rc] = await Promise.all([
         listProjectMembers(apiBase, accessToken, projectKey),
         listProjectInvites(apiBase, accessToken, projectKey).catch(() => [] as ProjectInvite[]),
+        getProjectRepoConfig(apiBase, accessToken, projectKey).catch(() => null),
       ])
       setMembers(m)
       setInvites(i)
+      setRepoConfig(rc)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load project settings')
     } finally {
@@ -85,6 +96,13 @@ export function useProjectSettings(
     return project
   }, [apiBase, accessToken, projectKey, onProjectUpdated])
 
+  const saveAgentInstructions = useCallback(async (value: string) => {
+    // '' clears the field server-side; the response is the fresh config.
+    const config = await updateProjectRepoConfig(apiBase, accessToken, projectKey, { agentInstructions: value })
+    setRepoConfig(config)
+    return config
+  }, [apiBase, accessToken, projectKey])
+
   const invite = useCallback(async (email: string, role: 'admin' | 'member' = 'member') => {
     await apiInvite(apiBase, accessToken, projectKey, email, role)
     await refresh()
@@ -100,5 +118,5 @@ export function useProjectSettings(
     await refresh()
   }, [apiBase, accessToken, projectKey, refresh])
 
-  return { members, invites, loading, error, isAdmin, refresh, rename, updateAllowedOrigins, invite, removeMember, cancelInvite }
+  return { members, invites, repoConfig, loading, error, isAdmin, refresh, rename, updateAllowedOrigins, saveAgentInstructions, invite, removeMember, cancelInvite }
 }


### PR DESCRIPTION
## What

Completes the `agent_instructions` write path (the column existed and was rendered into prompts, but nothing could write it):

- **API:** the repo-config PATCH accepts `agentInstructions` (cap 4000) plus `localPath`/`devCommand`/`testCommand` (cap 400) with partial-patch semantics — `undefined` leaves a column untouched, `null`/empty clears it, so writing instructions no longer clobbers `repo_url` (and vice versa). Trimmed at the edges only, inner markdown verbatim. Auth unchanged (project admin).
- **Prompts:** the terse `- Extra:` line becomes a `## Project instructions (from the team)` section appended after the repo block — content verbatim, omitted entirely when unset.
- **Dashboard:** admin-gated editor in project settings — textarea with helper text, live character counter against the shared 4000 cap, busy/error states matching existing form patterns. Repo config degrades to null for non-admins.

## Deploy note

**Wanted deployed soon** — this feeds the design-system demo flow: the generated agent prompt can then carry the team's standing instructions (e.g. "follow AGENTS.md 'For the feedback loop' before implementing").

## Verification

Rebased on trunk after #164–#168. Full suite green: 57 files, 595 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)