### PR TITLE
Reserve comment issue creation safely

### DIFF
--- a/api/_lib/store.github-issue.integration.test.ts
+++ b/api/_lib/store.github-issue.integration.test.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from 'node:crypto'
+import postgres from 'postgres'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const databaseUrl = process.env.DATABASE_URL
+const describeDatabase = databaseUrl ? describe : describe.skip
+
+describeDatabase('comment GitHub issue database fencing', () => {
+  const sql = postgres(databaseUrl as string, { max: 6 })
+  const projectKey = `github-issue-${randomUUID()}`
+  const commentIds = Array.from({ length: 5 }, () => randomUUID())
+
+  beforeAll(async () => {
+    await sql`
+      insert into comments (id, project_id, comment, status)
+      values
+        (${commentIds[0]}, ${projectKey}, 'first', 'approved'),
+        (${commentIds[1]}, ${projectKey}, 'second', 'approved'),
+        (${commentIds[2]}, ${projectKey}, 'third', 'approved'),
+        (${commentIds[3]}, ${projectKey}, 'fourth', 'approved'),
+        (${commentIds[4]}, ${projectKey}, 'fifth', 'approved')
+    `
+  })
+
+  afterAll(async () => {
+    await sql`delete from comments where project_id = ${projectKey}`
+    await sql.end()
+  })
+
+  async function claim(
+    commentId: string,
+    token: string,
+    recovery = false,
+    scopedProject = projectKey,
+  ) {
+    return sql`
+      select id
+      from claim_comment_github_issue(
+        ${commentId}::uuid,
+        ${scopedProject},
+        ${token}::uuid,
+        300,
+        ${recovery}
+      )
+    `
+  }
+
+  it('allows exactly one concurrent claimant and rejects cross-project claims', async () => {
+    const firstToken = randomUUID()
+    const secondToken = randomUUID()
+    const [first, second] = await Promise.all([
+      claim(commentIds[0], firstToken),
+      claim(commentIds[0], secondToken),
+    ])
+
+    expect(first.length + second.length).toBe(1)
+    const winner = first.length ? firstToken : secondToken
+    await expect(claim(commentIds[0], randomUUID(), false, 'another-project'))
+      .resolves.toHaveLength(0)
+
+    const released = await sql`
+      select release_comment_github_issue(
+        ${commentIds[0]}::uuid,
+        ${projectKey},
+        ${winner}::uuid
+      ) as released
+    `
+    expect(released[0].released).toBe(true)
+  })
+
+  it('fences review changes until the database lease is released', async () => {
+    const token = randomUUID()
+    await expect(claim(commentIds[1], token)).resolves.toHaveLength(1)
+
+    await expect(sql`
+      select *
+      from update_comment_review_status(
+        ${commentIds[1]}::uuid,
+        ${projectKey},
+        'rejected'
+      )
+    `).rejects.toThrow('github_issue_creation_in_progress')
+
+    await expect(sql`
+      select *
+      from write_github_repo_connection_if_admin(
+        ${projectKey},
+        ${randomUUID()}::uuid,
+        0,
+        null,
+        null,
+        null,
+        null
+      )
+    `).rejects.toThrow('github_issue_creation_in_progress')
+
+    await expect(sql`
+      select remove_project_member(${projectKey}, ${randomUUID()}::uuid)
+    `).rejects.toThrow('github_issue_creation_in_progress')
+
+    await sql`
+      select release_comment_github_issue(
+        ${commentIds[1]}::uuid,
+        ${projectKey},
+        ${token}::uuid
+      )
+    `
+    const updated = await sql`
+      select status
+      from update_comment_review_status(
+        ${commentIds[1]}::uuid,
+        ${projectKey},
+        'rejected'
+      )
+    `
+    expect(updated[0].status).toBe('rejected')
+  })
+
+  it('requires explicit recovery for indeterminate creation attempts', async () => {
+    const firstToken = randomUUID()
+    await expect(claim(commentIds[2], firstToken)).resolves.toHaveLength(1)
+    const marked = await sql`
+      select mark_comment_github_issue_uncertain(
+        ${commentIds[2]}::uuid,
+        ${projectKey},
+        ${firstToken}::uuid
+      ) as marked
+    `
+    expect(marked[0].marked).toBe(true)
+
+    await sql`
+      select release_comment_github_issue(
+        ${commentIds[2]}::uuid,
+        ${projectKey},
+        ${firstToken}::uuid
+      )
+    `
+    await expect(claim(commentIds[2], randomUUID())).resolves.toHaveLength(0)
+    const recoveryToken = randomUUID()
+    await expect(claim(commentIds[2], recoveryToken, true)).resolves.toHaveLength(1)
+
+    const finalized = await sql`
+      select finalize_comment_github_issue(
+        ${commentIds[2]}::uuid,
+        ${projectKey},
+        ${recoveryToken}::uuid,
+        17,
+        'https://github.com/acme/site/issues/17',
+        now()
+      ) as finalized
+    `
+    expect(finalized[0].finalized).toBe(true)
+  })
+
+  it('resets deterministic failures so a regular retry can claim', async () => {
+    const token = randomUUID()
+    await expect(claim(commentIds[4], token)).resolves.toHaveLength(1)
+    await sql`
+      select mark_comment_github_issue_uncertain(
+        ${commentIds[4]}::uuid,
+        ${projectKey},
+        ${token}::uuid
+      )
+    `
+    const reset = await sql`
+      select reset_comment_github_issue_attempt(
+        ${commentIds[4]}::uuid,
+        ${projectKey},
+        ${token}::uuid
+      ) as reset
+    `
+    expect(reset[0].reset).toBe(true)
+    await expect(claim(commentIds[4], randomUUID())).resolves.toHaveLength(1)
+  })
+
+  it('enforces all-or-none issue metadata and paired lease fields', async () => {
+    await expect(sql`
+      update comments
+      set github_issue_url = 'https://github.com/acme/site/issues/1'
+      where id = ${commentIds[3]}::uuid
+    `).rejects.toThrow('comments_github_issue_fields_check')
+
+    await expect(sql`
+      update comments
+      set github_issue_lease_token = ${randomUUID()}::uuid
+      where id = ${commentIds[3]}::uuid
+    `).rejects.toThrow('comments_github_issue_lease_check')
+  })
+})

--- a/api/_lib/store.github-issue.test.ts
+++ b/api/_lib/store.github-issue.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./supabase.js', () => ({ getServiceSupabase: vi.fn() }))
+
+import { getServiceSupabase } from './supabase.js'
+import {
+  claimCommentGithubIssue,
+  deleteCommentById,
+  finalizeCommentGithubIssue,
+  getCommentForGithubIssue,
+  getGithubIssueConnection,
+  listComments,
+  listProjectComments,
+  markCommentGithubIssueUncertain,
+  resetCommentGithubIssueAttempt,
+  releaseCommentGithubIssue,
+} from './store.js'
+
+type Result = { data: unknown; error: { message: string } | null }
+
+const row = {
+  id: 'comment-1',
+  project_id: 'project-1',
+  url: 'https://example.com',
+  x: 10,
+  y: 20,
+  element: '#hero',
+  comment: 'Increase contrast',
+  status: 'approved',
+  implementation_status: 'unassigned',
+  claimed_by_agent_id: null,
+  image_url: null,
+  author_name: 'Ada',
+  target_type: 'element_point',
+  anchor: null,
+  github_issue_number: 42,
+  github_issue_url: 'https://github.com/acme/site/issues/42',
+  github_issue_created_at: '2026-07-23T12:00:00.000Z',
+  github_issue_lease_token: 'lease',
+  github_issue_lease_expires_at: '2026-07-23T12:05:00.000Z',
+  github_issue_uncertain_at: null,
+  created_at: '2026-07-23T11:00:00.000Z',
+  updated_at: null,
+}
+
+function chain(result: Result) {
+  const builder: Record<string, unknown> = {}
+  for (const method of ['select', 'update', 'delete', 'eq', 'is', 'or', 'order']) {
+    builder[method] = vi.fn(() => builder)
+  }
+  builder.maybeSingle = vi.fn(() => Promise.resolve(result))
+  builder.then = (resolve: (value: Result) => unknown, reject: (error: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject)
+  return builder
+}
+
+function mockResult(result: Result) {
+  const builder = chain(result)
+  vi.mocked(getServiceSupabase).mockReturnValue({
+    from: vi.fn(() => builder),
+  } as never)
+  return builder
+}
+
+function mockRpcResult(result: Result) {
+  const builder = chain(result)
+  const rpc = vi.fn(() => builder)
+  vi.mocked(getServiceSupabase).mockReturnValue({ rpc } as never)
+  return { builder, rpc }
+}
+
+beforeEach(() => vi.mocked(getServiceSupabase).mockReset())
+
+describe('comment GitHub issue persistence', () => {
+  it('keeps issue metadata out of public comments and includes it for project comments', async () => {
+    mockResult({ data: [row], error: null })
+    expect((await listComments('project-1'))[0]).not.toHaveProperty('githubIssue')
+
+    mockResult({ data: [row], error: null })
+    expect((await listProjectComments('project-1'))[0].githubIssue).toEqual({
+      issueNumber: 42,
+      issueUrl: row.github_issue_url,
+      createdAt: row.github_issue_created_at,
+    })
+  })
+
+  it('maps an incomplete issue as null and applies project filters', async () => {
+    const builder = mockResult({
+      data: [{ ...row, github_issue_url: null }],
+      error: null,
+    })
+    const comments = await listProjectComments('project-1', {
+      pageUrl: row.url,
+      reviewStatus: 'accepted',
+      implementationStatus: 'done',
+    })
+    expect(comments[0].githubIssue).toBeNull()
+    expect(builder.eq).toHaveBeenCalledTimes(4)
+
+    mockResult({ data: null, error: null })
+    await expect(listProjectComments('project-1')).resolves.toEqual([])
+  })
+
+  it('loads private issue state without exposing it in the mapped issue', async () => {
+    mockResult({ data: row, error: null })
+    const comment = await getCommentForGithubIssue('project-1', 'comment-1')
+    expect(comment?.githubIssueLeaseToken).toBe('lease')
+    expect(comment?.githubIssueUncertainAt).toBeNull()
+    expect(comment?.githubIssue).toBeTruthy()
+
+    const {
+      github_issue_lease_token: _token,
+      github_issue_lease_expires_at: _expiry,
+      github_issue_uncertain_at: _uncertain,
+      ...legacyRow
+    } = row
+    mockResult({ data: legacyRow, error: null })
+    await expect(getCommentForGithubIssue('project-1', 'comment-1')).resolves.toMatchObject({
+      githubIssueLeaseToken: null,
+      githubIssueLeaseExpiresAt: null,
+      githubIssueUncertainAt: null,
+    })
+
+    mockResult({ data: null, error: null })
+    await expect(getCommentForGithubIssue('project-1', 'missing')).resolves.toBeNull()
+  })
+
+  it('claims through the project-scoped database clock RPC', async () => {
+    const { rpc } = mockRpcResult({ data: { ...row, github_issue_number: null }, error: null })
+    const claimed = await claimCommentGithubIssue(
+      'project-1',
+      'comment-1',
+      'new-lease',
+      1_000,
+      true,
+    )
+    expect(claimed?.id).toBe('comment-1')
+    expect(rpc).toHaveBeenCalledWith('claim_comment_github_issue', {
+      p_comment_id: 'comment-1',
+      p_project_key: 'project-1',
+      p_lease_token: 'new-lease',
+      p_lease_seconds: 1,
+      p_recovery: true,
+    })
+
+    mockRpcResult({ data: null, error: null })
+    await expect(claimCommentGithubIssue('project-1', 'comment-1', 'lease', Number.NaN))
+      .resolves.toBeNull()
+  })
+
+  it('finalizes, releases, and marks uncertain through fenced RPCs', async () => {
+    const finalize = mockRpcResult({ data: true, error: null })
+    await expect(finalizeCommentGithubIssue('project-1', 'comment-1', 'lease', {
+      issueNumber: 42,
+      issueUrl: row.github_issue_url,
+      createdAt: row.github_issue_created_at,
+    })).resolves.toBe(true)
+    expect(finalize.rpc).toHaveBeenCalledWith('finalize_comment_github_issue', expect.objectContaining({
+      p_project_key: 'project-1',
+      p_lease_token: 'lease',
+    }))
+
+    mockRpcResult({ data: false, error: null })
+    await expect(releaseCommentGithubIssue('project-1', 'comment-1', 'wrong')).resolves.toBe(false)
+
+    mockRpcResult({ data: true, error: null })
+    await expect(markCommentGithubIssueUncertain('project-1', 'comment-1', 'lease'))
+      .resolves.toBe(true)
+
+    mockRpcResult({ data: true, error: null })
+    await expect(resetCommentGithubIssueAttempt('project-1', 'comment-1', 'lease'))
+      .resolves.toBe(true)
+  })
+
+  it('returns only complete private repository connections', async () => {
+    mockResult({ data: {
+      github_owner: 'acme',
+      github_repo: 'site',
+      github_installation_id: '99',
+      github_connection_version: 3,
+    }, error: null })
+    await expect(getGithubIssueConnection('project-1')).resolves.toEqual({
+      owner: 'acme',
+      repo: 'site',
+      installationId: '99',
+      connectionVersion: 3,
+    })
+
+    mockResult({ data: null, error: null })
+    await expect(getGithubIssueConnection('project-1')).resolves.toBeNull()
+  })
+
+  it('surfaces database errors from every operation', async () => {
+    const failure = { data: null, error: { message: 'database unavailable' } }
+    for (const operation of [
+      () => listProjectComments('project-1'),
+      () => getCommentForGithubIssue('project-1', 'comment-1'),
+      () => getGithubIssueConnection('project-1'),
+      () => deleteCommentById('comment-1', 'project-1'),
+    ]) {
+      mockResult(failure)
+      await expect(operation()).rejects.toThrow('database unavailable')
+    }
+    for (const operation of [
+      () => claimCommentGithubIssue('project-1', 'comment-1', 'lease'),
+      () => finalizeCommentGithubIssue('project-1', 'comment-1', 'lease', {
+        issueNumber: 1,
+        issueUrl: 'https://github.com/acme/site/issues/1',
+        createdAt: new Date().toISOString(),
+      }),
+      () => releaseCommentGithubIssue('project-1', 'comment-1', 'lease'),
+      () => markCommentGithubIssueUncertain('project-1', 'comment-1', 'lease'),
+      () => resetCommentGithubIssueAttempt('project-1', 'comment-1', 'lease'),
+    ]) {
+      mockRpcResult(failure)
+      await expect(operation()).rejects.toThrow('database unavailable')
+    }
+  })
+
+  it('reports whether a project-scoped comment deletion matched a row', async () => {
+    mockResult({ data: [{ id: 'comment-1' }], error: null })
+    await expect(deleteCommentById('comment-1', 'project-1')).resolves.toBe(true)
+
+    mockResult({ data: [], error: null })
+    await expect(deleteCommentById('comment-1', 'project-1')).resolves.toBe(false)
+  })
+})

--- a/api/_lib/store.test.ts
+++ b/api/_lib/store.test.ts
@@ -981,6 +981,7 @@ describe('comment functions', () => {
     }
 
     const supabase = {
+      rpc: vi.fn(() => chain),
       from: vi.fn((table: string) => {
         if (table === 'feedback_share_items') {
           return {
@@ -1081,7 +1082,7 @@ describe('comment functions', () => {
   it('updateReviewStatus keeps target metadata in its response', async () => {
     const { selects } = buildCommentsSupabase({ result: { data: TEXT_RANGE_ROW, error: null } })
 
-    const comment = await updateReviewStatus('comment-1', 'accepted')
+    const comment = await updateReviewStatus('project-1', 'comment-1', 'accepted')
 
     expect(selects[0]).toContain('target_type, anchor')
     expect(comment.anchor).toEqual({ kind: 'text_range', selectedText: 'términos y condiciones' })

--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -31,6 +31,12 @@ type CommentRow = {
   author_name: string | null
   target_type: string | null
   anchor: Record<string, unknown> | null
+  github_issue_number?: number | null
+  github_issue_url?: string | null
+  github_issue_created_at?: string | null
+  github_issue_lease_token?: string | null
+  github_issue_lease_expires_at?: string | null
+  github_issue_uncertain_at?: string | null
   created_at: string
   updated_at: string | null
 }
@@ -39,6 +45,8 @@ type CommentRow = {
 // hand-rolled select list elsewhere) silently drops fields from responses.
 const COMMENT_COLUMNS =
   'id, project_id, url, x, y, element, comment, status, implementation_status, claimed_by_agent_id, image_url, author_name, target_type, anchor, created_at, updated_at'
+const COMMENT_GITHUB_ISSUE_COLUMNS =
+  `${COMMENT_COLUMNS}, github_issue_number, github_issue_url, github_issue_created_at, github_issue_lease_token, github_issue_lease_expires_at, github_issue_uncertain_at`
 
 type ProjectRow = {
   public_key: string
@@ -160,6 +168,19 @@ function mapComment(row: CommentRow) {
     anchor: row.anchor ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at || row.created_at,
+  }
+}
+
+function mapProjectComment(row: CommentRow) {
+  return {
+    ...mapComment(row),
+    githubIssue: row.github_issue_number && row.github_issue_url && row.github_issue_created_at
+      ? {
+          issueNumber: row.github_issue_number,
+          issueUrl: row.github_issue_url,
+          createdAt: row.github_issue_created_at,
+        }
+      : null,
   }
 }
 
@@ -893,6 +914,29 @@ export async function getRepoConfig(projectKey: string) {
   return mapRepoConfig(data as RepoConfigRow | null)
 }
 
+export async function getGithubIssueConnection(projectKey: string) {
+  const { data, error } = await getSupabase()
+    .from('project_repo_configs')
+    .select('github_owner, github_repo, github_installation_id, github_connection_version')
+    .eq('project_key', projectKey)
+    .maybeSingle()
+
+  if (error) throw new Error(error.message)
+  const row = data as {
+    github_owner: string | null
+    github_repo: string | null
+    github_installation_id: string | null
+    github_connection_version: number
+  } | null
+  if (!row?.github_owner || !row.github_repo || !row.github_installation_id) return null
+  return {
+    owner: row.github_owner,
+    repo: row.github_repo,
+    installationId: row.github_installation_id,
+    connectionVersion: row.github_connection_version,
+  }
+}
+
 export async function getGithubConnectionVersion(projectKey: string) {
   const supabase = getSupabase()
   const { data, error } = await supabase
@@ -1199,6 +1243,137 @@ export async function listComments(projectKey: string, filters: {
   return (data || []).map((row) => mapComment(row as CommentRow))
 }
 
+export async function listProjectComments(projectKey: string, filters: {
+  pageUrl?: string
+  reviewStatus?: ReviewStatus
+  implementationStatus?: ImplementationStatus
+} = {}) {
+  let query = getSupabase()
+    .from('comments')
+    .select(COMMENT_GITHUB_ISSUE_COLUMNS)
+    .eq('project_id', projectKey)
+
+  if (filters.pageUrl) query = query.eq('url', filters.pageUrl)
+  if (filters.reviewStatus) query = query.eq('status', toLegacyStatus(filters.reviewStatus))
+  if (filters.implementationStatus) query = query.eq('implementation_status', filters.implementationStatus)
+
+  const { data, error } = await query.order('created_at', { ascending: false })
+  if (error) throw new Error(error.message)
+  return (data || []).map((row) => mapProjectComment(row as CommentRow))
+}
+
+export async function getCommentForGithubIssue(projectKey: string, commentId: string) {
+  const { data, error } = await getSupabase()
+    .from('comments')
+    .select(COMMENT_GITHUB_ISSUE_COLUMNS)
+    .eq('id', commentId)
+    .eq('project_id', projectKey)
+    .maybeSingle()
+
+  if (error) throw new Error(error.message)
+  if (!data) return null
+  const row = data as CommentRow
+  return {
+    ...mapProjectComment(row),
+    githubIssueLeaseToken: row.github_issue_lease_token ?? null,
+    githubIssueLeaseExpiresAt: row.github_issue_lease_expires_at ?? null,
+    githubIssueUncertainAt: row.github_issue_uncertain_at ?? null,
+  }
+}
+
+export async function claimCommentGithubIssue(
+  projectKey: string,
+  commentId: string,
+  leaseToken: string,
+  leaseMilliseconds = 5 * 60_000,
+  recovery = false,
+) {
+  const leaseSeconds = Number.isFinite(leaseMilliseconds)
+    ? Math.ceil(leaseMilliseconds / 1_000)
+    : 5 * 60
+  const { data, error } = await getSupabase()
+    .rpc('claim_comment_github_issue', {
+      p_comment_id: commentId,
+      p_project_key: projectKey,
+      p_lease_token: leaseToken,
+      p_lease_seconds: leaseSeconds,
+      p_recovery: recovery,
+    } as never)
+    .select(COMMENT_GITHUB_ISSUE_COLUMNS)
+    .maybeSingle()
+
+  if (error) throw new Error(error.message)
+  return data ? mapProjectComment(data as CommentRow) : null
+}
+
+export async function finalizeCommentGithubIssue(
+  projectKey: string,
+  commentId: string,
+  leaseToken: string,
+  issue: { issueNumber: number; issueUrl: string; createdAt: string },
+) {
+  const { data, error } = await getSupabase()
+    .rpc('finalize_comment_github_issue', {
+      p_comment_id: commentId,
+      p_project_key: projectKey,
+      p_lease_token: leaseToken,
+      p_issue_number: issue.issueNumber,
+      p_issue_url: issue.issueUrl,
+      p_issue_created_at: issue.createdAt,
+    } as never)
+
+  if (error) throw new Error(error.message)
+  return data === true
+}
+
+export async function releaseCommentGithubIssue(
+  projectKey: string,
+  commentId: string,
+  leaseToken: string,
+) {
+  const { data, error } = await getSupabase()
+    .rpc('release_comment_github_issue', {
+      p_comment_id: commentId,
+      p_project_key: projectKey,
+      p_lease_token: leaseToken,
+    } as never)
+
+  if (error) throw new Error(error.message)
+  return data === true
+}
+
+export async function markCommentGithubIssueUncertain(
+  projectKey: string,
+  commentId: string,
+  leaseToken: string,
+) {
+  const { data, error } = await getSupabase()
+    .rpc('mark_comment_github_issue_uncertain', {
+      p_comment_id: commentId,
+      p_project_key: projectKey,
+      p_lease_token: leaseToken,
+    } as never)
+
+  if (error) throw new Error(error.message)
+  return data === true
+}
+
+export async function resetCommentGithubIssueAttempt(
+  projectKey: string,
+  commentId: string,
+  leaseToken: string,
+) {
+  const { data, error } = await getSupabase()
+    .rpc('reset_comment_github_issue_attempt', {
+      p_comment_id: commentId,
+      p_project_key: projectKey,
+      p_lease_token: leaseToken,
+    } as never)
+
+  if (error) throw new Error(error.message)
+  return data === true
+}
+
 export async function listAcceptedCommentsForPage(projectKey: string, pageUrl: string) {
   const supabase = getSupabase()
   const { data, error } = await supabase
@@ -1271,15 +1446,18 @@ export async function getComment(commentId: string) {
   return data ? mapComment(data as CommentRow) : null
 }
 
-export async function updateReviewStatus(commentId: string, reviewStatus: ReviewStatus) {
+export async function updateReviewStatus(
+  projectKey: string,
+  commentId: string,
+  reviewStatus: ReviewStatus,
+) {
   const supabase = getSupabase()
   const { data, error } = await supabase
-    .from('comments')
-    .update({
-      status: toLegacyStatus(reviewStatus),
-      updated_at: new Date().toISOString(),
-    })
-    .eq('id', commentId)
+    .rpc('update_comment_review_status', {
+      p_comment_id: commentId,
+      p_project_key: projectKey,
+      p_status: toLegacyStatus(reviewStatus),
+    } as never)
     .select(COMMENT_COLUMNS)
     .single()
 

--- a/api/v1/comments/[commentId]/review-status.test.ts
+++ b/api/v1/comments/[commentId]/review-status.test.ts
@@ -100,6 +100,7 @@ describe('api/v1/comments/[commentId]/review-status', () => {
     let res = mockRes()
     await call({ method: 'PATCH', query: { commentId: 'c' }, body: { reviewStatus: 'accepted' }, headers: {} }, res)
     expect(res.statusCode).toBe(200)
+    expect(updateReviewStatus).toHaveBeenCalledWith('p', 'c', 'accepted')
     expect(createFeedbackEvent).toHaveBeenCalledWith(expect.objectContaining({ eventType: 'comment.reviewed' }))
 
     vi.mocked(updateReviewStatus).mockRejectedValueOnce(new Error('boom'))

--- a/api/v1/comments/[commentId]/review-status.ts
+++ b/api/v1/comments/[commentId]/review-status.ts
@@ -25,7 +25,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!existing || !existing.projectId) return jsonError(req, res, 404, 'Comment not found')
     if (!(await requireProjectMembership(req, res, user, existing.projectId))) return
 
-    const comment = await updateReviewStatus(commentId, reviewStatus)
+    const comment = await updateReviewStatus(existing.projectId, commentId, reviewStatus)
     const activeShares = await findActiveSharesForComment(commentId)
     await Promise.all(activeShares.map((share) => createFeedbackEvent({
       shareId: share.id,
@@ -42,4 +42,3 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
   }
 }
-

--- a/api/v1/projects/[projectId]/comments.test.ts
+++ b/api/v1/projects/[projectId]/comments.test.ts
@@ -4,11 +4,11 @@ vi.mock('../../../_lib/auth.js', () => ({
   requireUser: vi.fn(),
   requireProjectMembership: vi.fn(),
 }))
-vi.mock('../../../_lib/store.js', () => ({ listComments: vi.fn() }))
+vi.mock('../../../_lib/store.js', () => ({ listProjectComments: vi.fn() }))
 
 import handler from './comments.js'
 import { requireProjectMembership, requireUser } from '../../../_lib/auth.js'
-import { listComments } from '../../../_lib/store.js'
+import { listProjectComments } from '../../../_lib/store.js'
 
 function mockRes() {
   return {
@@ -27,7 +27,7 @@ const call = (req: unknown, res: unknown) =>
 beforeEach(() => {
   vi.mocked(requireUser).mockReset()
   vi.mocked(requireProjectMembership).mockReset()
-  vi.mocked(listComments).mockReset()
+  vi.mocked(listProjectComments).mockReset()
 })
 
 describe('api/v1/projects/[projectId]/comments', () => {
@@ -69,14 +69,14 @@ describe('api/v1/projects/[projectId]/comments', () => {
   it('lists comments for members; returns 500 on store throw', async () => {
     vi.mocked(requireUser).mockResolvedValue({ userId: 'u', email: 'a@b.c' })
     vi.mocked(requireProjectMembership).mockResolvedValue(true)
-    vi.mocked(listComments).mockResolvedValueOnce([{ id: 'c1' }] as never)
+    vi.mocked(listProjectComments).mockResolvedValueOnce([{ id: 'c1' }] as never)
 
     let res = mockRes()
     await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
     expect(res.statusCode).toBe(200)
     expect(res.body).toEqual([{ id: 'c1' }])
 
-    vi.mocked(listComments).mockRejectedValueOnce(new Error('boom'))
+    vi.mocked(listProjectComments).mockRejectedValueOnce(new Error('boom'))
     res = mockRes()
     await call({ method: 'GET', query: { projectId: 'p' }, headers: {} }, res)
     expect(res.statusCode).toBe(500)

--- a/api/v1/projects/[projectId]/comments.ts
+++ b/api/v1/projects/[projectId]/comments.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { requireProjectMembership, requireUser } from '../../../_lib/auth.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../../_lib/http.js'
-import { listComments } from '../../../_lib/store.js'
+import { listProjectComments } from '../../../_lib/store.js'
 import type { ImplementationStatus, ReviewStatus } from '../../../_lib/status.js'
 
 const REVIEW_STATUSES = new Set<ReviewStatus>(['open', 'accepted', 'rejected'])
@@ -30,7 +30,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return jsonError(req, res, 400, 'Invalid implementationStatus')
     }
 
-    const comments = await listComments(projectId, {
+    const comments = await listProjectComments(projectId, {
       pageUrl,
       reviewStatus: reviewStatus as ReviewStatus | undefined,
       implementationStatus: implementationStatus as ImplementationStatus | undefined,
@@ -42,4 +42,3 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return jsonError(req, res, 500, error instanceof Error ? error.message : 'Unexpected error')
   }
 }
-

--- a/api/v1/public/comments.test.ts
+++ b/api/v1/public/comments.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('../../_lib/store.js', () => ({
   ensurePublicProject: vi.fn(),
   createPublicComment: vi.fn(),
+  getComment: vi.fn(),
   listComments: vi.fn(),
   listProjectMembers: vi.fn(),
   notifyProjectMembersOfCommentActivity: vi.fn(),
@@ -24,7 +25,7 @@ vi.mock('@vercel/functions', () => ({ waitUntil: vi.fn() }))
 
 import { waitUntil } from '@vercel/functions'
 import { canSendCommentActivityEmail, getCommentActivityCooldownSeconds, getCommentActivityDashboardUrl, hasCommentActivityEmailConfig, sendCommentActivityEmail } from '../../_lib/comment-activity-email.js'
-import { createPublicComment, deleteCommentsForProject, ensurePublicProject, listComments, listProjectMembers, notifyProjectMembersOfCommentActivity, releaseCommentActivityEmailReservation, reserveCommentActivityEmail, updateReviewStatus } from '../../_lib/store.js'
+import { createPublicComment, deleteCommentsForProject, ensurePublicProject, getComment, listComments, listProjectMembers, notifyProjectMembersOfCommentActivity, releaseCommentActivityEmailReservation, reserveCommentActivityEmail, updateReviewStatus } from '../../_lib/store.js'
 import { getServiceSupabase } from '../../_lib/supabase.js'
 import handler from './comments.js'
 
@@ -74,6 +75,7 @@ const call = (req: unknown, res: unknown) =>
 beforeEach(() => {
   vi.mocked(ensurePublicProject).mockReset()
   vi.mocked(createPublicComment).mockReset()
+  vi.mocked(getComment).mockReset()
   vi.mocked(listComments).mockReset()
   vi.mocked(listProjectMembers).mockReset()
   vi.mocked(notifyProjectMembersOfCommentActivity).mockReset()
@@ -1265,6 +1267,7 @@ describe('api/v1/public/comments', () => {
   })
 
   it('updates a comment review status for widget compatibility', async () => {
+    vi.mocked(getComment).mockResolvedValue({ id: 'comment-1', projectId: 'demo-project' } as never)
     vi.mocked(updateReviewStatus).mockResolvedValue({
       id: 'comment-1',
       projectId: 'demo-project',
@@ -1291,13 +1294,14 @@ describe('api/v1/public/comments', () => {
       body: { id: 'comment-1', reviewStatus: 'accepted' },
     }), res)
 
-    expect(updateReviewStatus).toHaveBeenCalledWith('comment-1', 'accepted')
+    expect(updateReviewStatus).toHaveBeenCalledWith('demo-project', 'comment-1', 'accepted')
     expect(res.statusCode).toBe(200)
     expect((res.body as Record<string, unknown>).reviewStatus).toBe('accepted')
     expect(res.headers['Access-Control-Allow-Origin']).toBe('*')
   })
 
   it('normalizes widget review status aliases on PATCH', async () => {
+    vi.mocked(getComment).mockResolvedValue({ id: 'comment-1', projectId: 'demo-project' } as never)
     vi.mocked(updateReviewStatus)
       .mockResolvedValueOnce({
         id: 'comment-1',
@@ -1348,8 +1352,8 @@ describe('api/v1/public/comments', () => {
       body: { id: 'comment-1', reviewStatus: 'pending' },
     }), pendingRes)
 
-    expect(updateReviewStatus).toHaveBeenNthCalledWith(1, 'comment-1', 'rejected')
-    expect(updateReviewStatus).toHaveBeenNthCalledWith(2, 'comment-1', 'open')
+    expect(updateReviewStatus).toHaveBeenNthCalledWith(1, 'demo-project', 'comment-1', 'rejected')
+    expect(updateReviewStatus).toHaveBeenNthCalledWith(2, 'demo-project', 'comment-1', 'open')
     expect(rejectedRes.statusCode).toBe(200)
     expect(pendingRes.statusCode).toBe(200)
   })
@@ -1363,6 +1367,18 @@ describe('api/v1/public/comments', () => {
 
     expect(res.statusCode).toBe(400)
     expect(res.body).toEqual({ error: 'reviewStatus must be open, accepted, or rejected' })
+    expect(updateReviewStatus).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when a PATCH comment no longer exists', async () => {
+    vi.mocked(getComment).mockResolvedValue(null)
+    const res = mockRes()
+    await call(mockReq({
+      method: 'PATCH',
+      body: { id: 'missing', reviewStatus: 'accepted' },
+    }), res)
+
+    expect(res.statusCode).toBe(404)
     expect(updateReviewStatus).not.toHaveBeenCalled()
   })
 })

--- a/api/v1/public/comments.ts
+++ b/api/v1/public/comments.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { waitUntil } from '@vercel/functions'
-import { createPublicComment, deleteCommentById, deleteCommentsForProject, ensurePublicProject, listComments, listProjectMembers, notifyProjectMembersOfCommentActivity, releaseCommentActivityEmailReservation, reserveCommentActivityEmail, updateReviewStatus } from '../../_lib/store.js'
+import { createPublicComment, deleteCommentById, deleteCommentsForProject, ensurePublicProject, getComment, listComments, listProjectMembers, notifyProjectMembersOfCommentActivity, releaseCommentActivityEmailReservation, reserveCommentActivityEmail, updateReviewStatus } from '../../_lib/store.js'
 import { getStringQuery, handleOptions, jsonError, methodNotAllowed, setCors } from '../../_lib/http.js'
 import { getRequestHostname, isHostnameAllowed } from '../../_lib/origins.js'
 import { parseCommentTarget } from '../../_lib/anchor.js'
@@ -173,7 +173,9 @@ async function handlePatch(req: VercelRequest, res: VercelResponse) {
       return jsonError(req, res, 400, 'reviewStatus must be open, accepted, or rejected')
     }
 
-    const comment = await updateReviewStatus(id, nextStatus)
+    const existing = await getComment(id)
+    if (!existing?.projectId) return jsonError(req, res, 404, 'Comment not found')
+    const comment = await updateReviewStatus(existing.projectId, id, nextStatus)
     setCors(req, res, METHODS)
     return res.status(200).json(comment)
   } catch (error) {

--- a/db/migrations/0013_bright_guardsmen.sql
+++ b/db/migrations/0013_bright_guardsmen.sql
@@ -1,0 +1,365 @@
+ALTER TABLE "comments" ADD COLUMN "github_issue_number" integer;--> statement-breakpoint
+ALTER TABLE "comments" ADD COLUMN "github_issue_url" text;--> statement-breakpoint
+ALTER TABLE "comments" ADD COLUMN "github_issue_created_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "comments" ADD COLUMN "github_issue_lease_token" uuid;--> statement-breakpoint
+ALTER TABLE "comments" ADD COLUMN "github_issue_lease_expires_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "comments" ADD COLUMN "github_issue_uncertain_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_github_issue_fields_check" CHECK ((
+        ("comments"."github_issue_number" is null and "comments"."github_issue_url" is null and "comments"."github_issue_created_at" is null)
+        or
+        ("comments"."github_issue_number" > 0 and "comments"."github_issue_url" is not null and "comments"."github_issue_created_at" is not null)
+      ));--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_github_issue_lease_check" CHECK ((
+        ("comments"."github_issue_lease_token" is null and "comments"."github_issue_lease_expires_at" is null)
+        or
+        ("comments"."github_issue_lease_token" is not null and "comments"."github_issue_lease_expires_at" is not null)
+      ));--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_github_issue_state_check" CHECK ((
+        ("comments"."github_issue_number" is null)
+        or
+        ("comments"."github_issue_lease_token" is null and "comments"."github_issue_uncertain_at" is null)
+      ));--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION public.claim_comment_github_issue(
+	p_comment_id uuid,
+	p_project_key text,
+	p_lease_token uuid,
+	p_lease_seconds integer,
+	p_recovery boolean DEFAULT false
+)
+RETURNS SETOF public.comments
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+	PERFORM pg_advisory_xact_lock(hashtextextended('crrt-github-issue:' || p_project_key, 0));
+
+	RETURN QUERY
+	UPDATE public.comments AS comment
+	SET
+		github_issue_lease_token = p_lease_token,
+		github_issue_lease_expires_at = now() + make_interval(
+			secs => least(greatest(p_lease_seconds, 30), 900)
+		)
+	WHERE comment.id = p_comment_id
+		AND comment.project_id = p_project_key
+		AND comment.status = 'approved'
+		AND comment.github_issue_number IS NULL
+		AND (
+			(p_recovery AND comment.github_issue_uncertain_at IS NOT NULL)
+			OR
+			(NOT p_recovery AND comment.github_issue_uncertain_at IS NULL)
+		)
+		AND (
+			comment.github_issue_lease_token IS NULL
+			OR comment.github_issue_lease_expires_at <= now()
+		)
+	RETURNING comment.*;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION public.finalize_comment_github_issue(
+	p_comment_id uuid,
+	p_project_key text,
+	p_lease_token uuid,
+	p_issue_number integer,
+	p_issue_url text,
+	p_issue_created_at timestamp with time zone
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+	v_updated integer;
+BEGIN
+	PERFORM pg_advisory_xact_lock(hashtextextended('crrt-github-issue:' || p_project_key, 0));
+
+	UPDATE public.comments AS comment
+	SET
+		github_issue_number = p_issue_number,
+		github_issue_url = p_issue_url,
+		github_issue_created_at = p_issue_created_at,
+		github_issue_lease_token = NULL,
+		github_issue_lease_expires_at = NULL,
+		github_issue_uncertain_at = NULL
+	WHERE comment.id = p_comment_id
+		AND comment.project_id = p_project_key
+		AND comment.status = 'approved'
+		AND comment.github_issue_lease_token = p_lease_token
+		AND comment.github_issue_number IS NULL;
+
+	GET DIAGNOSTICS v_updated = ROW_COUNT;
+	RETURN v_updated = 1;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION public.release_comment_github_issue(
+	p_comment_id uuid,
+	p_project_key text,
+	p_lease_token uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+	v_updated integer;
+BEGIN
+	PERFORM pg_advisory_xact_lock(hashtextextended('crrt-github-issue:' || p_project_key, 0));
+
+	UPDATE public.comments AS comment
+	SET
+		github_issue_lease_token = NULL,
+		github_issue_lease_expires_at = NULL
+	WHERE comment.id = p_comment_id
+		AND comment.project_id = p_project_key
+		AND comment.github_issue_lease_token = p_lease_token
+		AND comment.github_issue_number IS NULL;
+
+	GET DIAGNOSTICS v_updated = ROW_COUNT;
+	RETURN v_updated = 1;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION public.mark_comment_github_issue_uncertain(
+	p_comment_id uuid,
+	p_project_key text,
+	p_lease_token uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+	v_updated integer;
+BEGIN
+	PERFORM pg_advisory_xact_lock(hashtextextended('crrt-github-issue:' || p_project_key, 0));
+
+	UPDATE public.comments AS comment
+	SET
+		github_issue_uncertain_at = COALESCE(comment.github_issue_uncertain_at, now())
+	WHERE comment.id = p_comment_id
+		AND comment.project_id = p_project_key
+		AND comment.status = 'approved'
+		AND comment.github_issue_lease_token = p_lease_token
+		AND comment.github_issue_number IS NULL;
+
+	GET DIAGNOSTICS v_updated = ROW_COUNT;
+	RETURN v_updated = 1;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION public.reset_comment_github_issue_attempt(
+	p_comment_id uuid,
+	p_project_key text,
+	p_lease_token uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+	v_updated integer;
+BEGIN
+	PERFORM pg_advisory_xact_lock(hashtextextended('crrt-github-issue:' || p_project_key, 0));
+
+	UPDATE public.comments AS comment
+	SET
+		github_issue_lease_token = NULL,
+		github_issue_lease_expires_at = NULL,
+		github_issue_uncertain_at = NULL
+	WHERE comment.id = p_comment_id
+		AND comment.project_id = p_project_key
+		AND comment.status = 'approved'
+		AND comment.github_issue_lease_token = p_lease_token
+		AND comment.github_issue_number IS NULL;
+
+	GET DIAGNOSTICS v_updated = ROW_COUNT;
+	RETURN v_updated = 1;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION public.update_comment_review_status(
+	p_comment_id uuid,
+	p_project_key text,
+	p_status text
+)
+RETURNS SETOF public.comments
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+	IF p_status NOT IN ('pending', 'approved', 'rejected') THEN
+		RAISE EXCEPTION 'invalid_review_status';
+	END IF;
+
+	PERFORM pg_advisory_xact_lock(hashtextextended('crrt-github-issue:' || p_project_key, 0));
+
+	IF p_status <> 'approved' AND EXISTS (
+		SELECT 1
+		FROM public.comments AS comment
+		WHERE comment.id = p_comment_id
+			AND comment.project_id = p_project_key
+			AND (
+				comment.github_issue_lease_token IS NOT NULL
+				OR comment.github_issue_uncertain_at IS NOT NULL
+			)
+	) THEN
+		RAISE EXCEPTION 'github_issue_creation_in_progress';
+	END IF;
+
+	RETURN QUERY
+	UPDATE public.comments AS comment
+	SET status = p_status, updated_at = now()
+	WHERE comment.id = p_comment_id
+		AND comment.project_id = p_project_key
+	RETURNING comment.*;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION public.write_github_repo_connection_if_admin(
+	p_project_key text,
+	p_user_id uuid,
+	p_expected_version integer,
+	p_repo_url text,
+	p_github_owner text,
+	p_github_repo text,
+	p_github_installation_id text
+)
+RETURNS SETOF public.project_repo_configs
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+	PERFORM pg_advisory_xact_lock(hashtextextended('crrt-github-issue:' || p_project_key, 0));
+
+	UPDATE public.comments AS comment
+	SET github_issue_lease_token = NULL, github_issue_lease_expires_at = NULL
+	WHERE comment.project_id = p_project_key
+		AND comment.github_issue_number IS NULL
+		AND comment.github_issue_uncertain_at IS NULL
+		AND comment.github_issue_lease_expires_at <= now();
+
+	IF EXISTS (
+		SELECT 1
+		FROM public.comments AS comment
+		WHERE comment.project_id = p_project_key
+			AND comment.github_issue_number IS NULL
+			AND (
+				comment.github_issue_lease_token IS NOT NULL
+				OR comment.github_issue_uncertain_at IS NOT NULL
+			)
+	) THEN
+		RAISE EXCEPTION 'github_issue_creation_in_progress';
+	END IF;
+
+	RETURN QUERY
+	UPDATE public.project_repo_configs AS config
+	SET
+		repo_url = p_repo_url,
+		github_owner = p_github_owner,
+		github_repo = p_github_repo,
+		github_installation_id = p_github_installation_id,
+		github_connection_version = config.github_connection_version + 1,
+		updated_at = now()
+	WHERE config.project_key = p_project_key
+		AND config.github_connection_version = p_expected_version
+		AND EXISTS (
+			SELECT 1
+			FROM public.project_members AS member
+			WHERE member.project_key = config.project_key
+				AND member.user_id = p_user_id
+				AND member.role = 'admin'
+		)
+	RETURNING config.*;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION public.remove_project_member(p_project_key text, p_user_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+	v_role text;
+	v_admin_count integer;
+BEGIN
+	PERFORM pg_advisory_xact_lock(hashtextextended('crrt-github-issue:' || p_project_key, 0));
+
+	UPDATE public.comments AS comment
+	SET github_issue_lease_token = NULL, github_issue_lease_expires_at = NULL
+	WHERE comment.project_id = p_project_key
+		AND comment.github_issue_number IS NULL
+		AND comment.github_issue_uncertain_at IS NULL
+		AND comment.github_issue_lease_expires_at <= now();
+
+	IF EXISTS (
+		SELECT 1
+		FROM public.comments AS comment
+		WHERE comment.project_id = p_project_key
+			AND comment.github_issue_number IS NULL
+			AND (
+				comment.github_issue_lease_token IS NOT NULL
+				OR comment.github_issue_uncertain_at IS NOT NULL
+			)
+	) THEN
+		RAISE EXCEPTION 'github_issue_creation_in_progress';
+	END IF;
+
+	SELECT member.role
+	INTO v_role
+	FROM public.project_members AS member
+	WHERE member.project_key = p_project_key AND member.user_id = p_user_id;
+
+	IF v_role IS NULL THEN
+		RETURN 'not_found';
+	END IF;
+
+	IF v_role = 'admin' THEN
+		PERFORM 1
+		FROM public.project_members AS member
+		WHERE member.project_key = p_project_key AND member.role = 'admin'
+		FOR UPDATE;
+
+		SELECT count(*)
+		INTO v_admin_count
+		FROM public.project_members AS member
+		WHERE member.project_key = p_project_key AND member.role = 'admin';
+
+		IF v_admin_count <= 1 THEN
+			RETURN 'last_admin';
+		END IF;
+	END IF;
+
+	DELETE FROM public.project_members AS member
+	WHERE member.project_key = p_project_key AND member.user_id = p_user_id;
+
+	RETURN 'removed';
+END;
+$$;--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION public.claim_comment_github_issue(uuid, text, uuid, integer, boolean) FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.finalize_comment_github_issue(uuid, text, uuid, integer, text, timestamp with time zone) FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.release_comment_github_issue(uuid, text, uuid) FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.mark_comment_github_issue_uncertain(uuid, text, uuid) FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.reset_comment_github_issue_attempt(uuid, text, uuid) FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.update_comment_review_status(uuid, text, text) FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.write_github_repo_connection_if_admin(text, uuid, integer, text, text, text, text) FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.remove_project_member(text, uuid) FROM PUBLIC;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION public.claim_comment_github_issue(uuid, text, uuid, integer, boolean) TO service_role;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION public.finalize_comment_github_issue(uuid, text, uuid, integer, text, timestamp with time zone) TO service_role;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION public.release_comment_github_issue(uuid, text, uuid) TO service_role;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION public.mark_comment_github_issue_uncertain(uuid, text, uuid) TO service_role;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION public.reset_comment_github_issue_attempt(uuid, text, uuid) TO service_role;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION public.update_comment_review_status(uuid, text, text) TO service_role;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION public.write_github_repo_connection_if_admin(text, uuid, integer, text, text, text, text) TO service_role;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION public.remove_project_member(text, uuid) TO service_role;

--- a/db/migrations/meta/0013_snapshot.json
+++ b/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1561 @@
+{
+  "id": "129e6683-93a3-460c-be9f-cbde602df0bc",
+  "prevId": "b9f78d67-7ab4-4b0b-b70e-d302c15200a8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_presence_share_seen_idx": {
+          "name": "agent_presence_share_seen_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_presence_share_id_feedback_shares_id_fk": {
+          "name": "agent_presence_share_id_feedback_shares_id_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_presence_share_id_agent_id_pk": {
+          "name": "agent_presence_share_id_agent_id_pk",
+          "columns": [
+            "share_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "implementation_status": {
+          "name": "implementation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unassigned'"
+        },
+        "claimed_by_agent_id": {
+          "name": "claimed_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'element_point'"
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_number": {
+          "name": "github_issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_created_at": {
+          "name": "github_issue_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_lease_token": {
+          "name": "github_issue_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_lease_expires_at": {
+          "name": "github_issue_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_uncertain_at": {
+          "name": "github_issue_uncertain_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_project_created_idx": {
+          "name": "comments_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_project_url_idx": {
+          "name": "comments_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_project_status_idx": {
+          "name": "comments_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "implementation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "comments_github_issue_fields_check": {
+          "name": "comments_github_issue_fields_check",
+          "value": "(\n        (\"comments\".\"github_issue_number\" is null and \"comments\".\"github_issue_url\" is null and \"comments\".\"github_issue_created_at\" is null)\n        or\n        (\"comments\".\"github_issue_number\" > 0 and \"comments\".\"github_issue_url\" is not null and \"comments\".\"github_issue_created_at\" is not null)\n      )"
+        },
+        "comments_github_issue_lease_check": {
+          "name": "comments_github_issue_lease_check",
+          "value": "(\n        (\"comments\".\"github_issue_lease_token\" is null and \"comments\".\"github_issue_lease_expires_at\" is null)\n        or\n        (\"comments\".\"github_issue_lease_token\" is not null and \"comments\".\"github_issue_lease_expires_at\" is not null)\n      )"
+        },
+        "comments_github_issue_state_check": {
+          "name": "comments_github_issue_state_check",
+          "value": "(\n        (\"comments\".\"github_issue_number\" is null)\n        or\n        (\"comments\".\"github_issue_lease_token\" is null and \"comments\".\"github_issue_uncertain_at\" is null)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feedback_events": {
+      "name": "feedback_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feedback_events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_events_share_id_idx": {
+          "name": "feedback_events_share_id_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_events_share_id_feedback_shares_id_fk": {
+          "name": "feedback_events_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_events",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_events_comment_id_comments_id_fk": {
+          "name": "feedback_events_comment_id_comments_id_fk",
+          "tableFrom": "feedback_events",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_operation_keys": {
+      "name": "feedback_operation_keys",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_event_id": {
+          "name": "feedback_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_operation_keys_share_id_feedback_shares_id_fk": {
+          "name": "feedback_operation_keys_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_operation_keys_feedback_event_id_feedback_events_id_fk": {
+          "name": "feedback_operation_keys_feedback_event_id_feedback_events_id_fk",
+          "tableFrom": "feedback_operation_keys",
+          "tableTo": "feedback_events",
+          "columnsFrom": [
+            "feedback_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_operation_keys_share_id_agent_id_idempotency_key_pk": {
+          "name": "feedback_operation_keys_share_id_agent_id_idempotency_key_pk",
+          "columns": [
+            "share_id",
+            "agent_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_share_items": {
+      "name": "feedback_share_items",
+      "schema": "",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_share_items_share_id_feedback_shares_id_fk": {
+          "name": "feedback_share_items_share_id_feedback_shares_id_fk",
+          "tableFrom": "feedback_share_items",
+          "tableTo": "feedback_shares",
+          "columnsFrom": [
+            "share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feedback_share_items_comment_id_comments_id_fk": {
+          "name": "feedback_share_items_comment_id_comments_id_fk",
+          "tableFrom": "feedback_share_items",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feedback_share_items_share_id_comment_id_pk": {
+          "name": "feedback_share_items_share_id_comment_id_pk",
+          "columns": [
+            "share_id",
+            "comment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_shares": {
+      "name": "feedback_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_page_url": {
+          "name": "scope_page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ciphertext": {
+          "name": "access_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_shares_one_project_scope_per_project": {
+          "name": "feedback_shares_one_project_scope_per_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "scope_type = 'project' and revoked_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_shares_project_id_projects_public_key_fk": {
+          "name": "feedback_shares_project_id_projects_public_key_fk",
+          "tableFrom": "feedback_shares",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_shares_slug_unique": {
+          "name": "feedback_shares_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "feedback_shares_scope_type_check": {
+          "name": "feedback_shares_scope_type_check",
+          "value": "\"feedback_shares\".\"scope_type\" in ('page', 'selection', 'project')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_user_installations": {
+      "name": "github_user_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_account_id": {
+          "name": "github_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_account_login": {
+          "name": "github_account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_account_type": {
+          "name": "github_account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_user_installations_user_id_idx": {
+          "name": "github_user_installations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_user_installations_user_installation_unique": {
+          "name": "github_user_installations_user_installation_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_user_installations_account_type_check": {
+          "name": "github_user_installations_account_type_check",
+          "value": "\"github_user_installations\".\"github_account_type\" in ('User', 'Organization')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_unread_comment_activity_project_idx": {
+          "name": "notifications_unread_comment_activity_project_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "((payload->>'projectKey'))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notifications\".\"kind\" = 'comment.activity' and \"notifications\".\"read_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_kind_check": {
+          "name": "notifications_kind_check",
+          "value": "\"notifications\".\"kind\" in ('invite.received', 'invite.accepted', 'invite.declined', 'comment.activity') and (\"notifications\".\"kind\" <> 'comment.activity' or nullif(btrim(\"notifications\".\"payload\"->>'projectKey'), '') is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_comment_email_cooldowns": {
+      "name": "project_comment_email_cooldowns",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pending_count": {
+          "name": "pending_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cooldown_until": {
+          "name": "cooldown_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_comment_email_cooldowns_project_key_projects_public_key_fk": {
+          "name": "project_comment_email_cooldowns_project_key_projects_public_key_fk",
+          "tableFrom": "project_comment_email_cooldowns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_invites": {
+      "name": "project_invites",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_invites_email_idx": {
+          "name": "project_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_invites_project_key_projects_public_key_fk": {
+          "name": "project_invites_project_key_projects_public_key_fk",
+          "tableFrom": "project_invites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_invites_project_key_email_pk": {
+          "name": "project_invites_project_key_email_pk",
+          "columns": [
+            "project_key",
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_invites_role_check": {
+          "name": "project_invites_role_check",
+          "value": "\"project_invites\".\"role\" in ('admin', 'member')"
+        },
+        "project_invites_email_lower_check": {
+          "name": "project_invites_email_lower_check",
+          "value": "\"project_invites\".\"email\" = lower(\"project_invites\".\"email\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_key_projects_public_key_fk": {
+          "name": "project_members_project_key_projects_public_key_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_key_user_id_pk": {
+          "name": "project_members_project_key_user_id_pk",
+          "columns": [
+            "project_key",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_members_role_check": {
+          "name": "project_members_role_check",
+          "value": "\"project_members\".\"role\" in ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_repo_configs": {
+      "name": "project_repo_configs",
+      "schema": "",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_owner": {
+          "name": "github_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_connection_version": {
+          "name": "github_connection_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_command": {
+          "name": "dev_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_command": {
+          "name": "test_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_command": {
+          "name": "build_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_instructions": {
+          "name": "agent_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_repo_configs_project_key_projects_public_key_fk": {
+          "name": "project_repo_configs_project_key_projects_public_key_fk",
+          "tableFrom": "project_repo_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_key"
+          ],
+          "columnsTo": [
+            "public_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "claimable": {
+          "name": "claimable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.super_admins": {
+      "name": "super_admins",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.admin_project_metrics": {
+      "columns": {
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimable": {
+          "name": "claimable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_comment_count": {
+          "name": "pending_comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_comment_count": {
+          "name": "accepted_comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_comment_count": {
+          "name": "rejected_comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unassigned_comment_count": {
+          "name": "unassigned_comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_comment_count": {
+          "name": "claimed_comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_progress_comment_count": {
+          "name": "in_progress_comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_comment_count": {
+          "name": "blocked_comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_comment_count": {
+          "name": "done_comment_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_share_count": {
+          "name": "feedback_share_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commented_url_count": {
+          "name": "commented_url_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_comment_at": {
+          "name": "first_comment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_comment_at": {
+          "name": "last_comment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    with comment_metrics as (\n      select project_id,\n        count(*)::bigint as comment_count,\n        count(*) filter (where status is null or status not in ('approved', 'accepted', 'rejected'))::bigint as pending_comment_count,\n        count(*) filter (where status in ('approved', 'accepted'))::bigint as accepted_comment_count,\n        count(*) filter (where status = 'rejected')::bigint as rejected_comment_count,\n        count(*) filter (where implementation_status is null or implementation_status = 'unassigned')::bigint as unassigned_comment_count,\n        count(*) filter (where implementation_status = 'claimed')::bigint as claimed_comment_count,\n        count(*) filter (where implementation_status = 'in_progress')::bigint as in_progress_comment_count,\n        count(*) filter (where implementation_status = 'blocked')::bigint as blocked_comment_count,\n        count(*) filter (where implementation_status = 'done')::bigint as done_comment_count,\n        count(distinct url)::bigint as commented_url_count,\n        min(created_at) as first_comment_at,\n        max(created_at) as last_comment_at\n      from \"comments\"\n      group by project_id\n    ), share_metrics as (\n      select project_id, count(*)::bigint as feedback_share_count\n      from \"feedback_shares\"\n      group by project_id\n    )\n    select p.public_key, p.name, p.claimable, p.created_at,\n      cm.comment_count, cm.pending_comment_count, cm.accepted_comment_count,\n      cm.rejected_comment_count, cm.unassigned_comment_count,\n      cm.claimed_comment_count, cm.in_progress_comment_count,\n      cm.blocked_comment_count, cm.done_comment_count,\n      coalesce(sm.feedback_share_count, 0)::bigint as feedback_share_count,\n      cm.commented_url_count, cm.first_comment_at, cm.last_comment_at\n    from \"projects\" p\n    join comment_metrics cm on cm.project_id = p.public_key\n    left join share_metrics sm on sm.project_id = p.public_key\n  ",
+      "name": "admin_project_metrics",
+      "schema": "public",
+      "isExisting": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "materialized": false
+    },
+    "public.admin_user_metrics": {
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_project_count": {
+          "name": "admin_project_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_project_count": {
+          "name": "member_project_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "super_admin": {
+          "name": "super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "\n    with user_ids as (\n      select user_id from \"project_members\"\n      union\n      select user_id from \"super_admins\"\n    )\n    select u.user_id,\n      count(pm.project_key) filter (where pm.role = 'admin')::bigint as admin_project_count,\n      count(pm.project_key) filter (where pm.role = 'member')::bigint as member_project_count,\n      (sa.user_id is not null) as super_admin\n    from user_ids u\n    left join \"project_members\" pm on pm.user_id = u.user_id\n    left join \"super_admins\" sa on sa.user_id = u.user_id\n    group by u.user_id, sa.user_id\n  ",
+      "name": "admin_user_metrics",
+      "schema": "public",
+      "isExisting": false,
+      "with": {
+        "securityInvoker": true
+      },
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1783941824345,
       "tag": "0012_salty_plazm",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1784797003171,
+      "tag": "0013_bright_guardsmen",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -163,6 +163,12 @@ export const comments = pgTable(
     targetType: text('target_type').default('element_point'),
     // TextRangeAnchor JSON for text_range comments; null means no anchor
     anchor: jsonb('anchor'),
+    githubIssueNumber: integer('github_issue_number'),
+    githubIssueUrl: text('github_issue_url'),
+    githubIssueCreatedAt: timestamp('github_issue_created_at', { withTimezone: true }),
+    githubIssueLeaseToken: uuid('github_issue_lease_token'),
+    githubIssueLeaseExpiresAt: timestamp('github_issue_lease_expires_at', { withTimezone: true }),
+    githubIssueUncertainAt: timestamp('github_issue_uncertain_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
   },
@@ -173,6 +179,30 @@ export const comments = pgTable(
       t.projectId,
       t.status,
       t.implementationStatus,
+    ),
+    githubIssueFieldsCheck: check(
+      'comments_github_issue_fields_check',
+      sql`(
+        (${t.githubIssueNumber} is null and ${t.githubIssueUrl} is null and ${t.githubIssueCreatedAt} is null)
+        or
+        (${t.githubIssueNumber} > 0 and ${t.githubIssueUrl} is not null and ${t.githubIssueCreatedAt} is not null)
+      )`,
+    ),
+    githubIssueLeaseCheck: check(
+      'comments_github_issue_lease_check',
+      sql`(
+        (${t.githubIssueLeaseToken} is null and ${t.githubIssueLeaseExpiresAt} is null)
+        or
+        (${t.githubIssueLeaseToken} is not null and ${t.githubIssueLeaseExpiresAt} is not null)
+      )`,
+    ),
+    githubIssueStateCheck: check(
+      'comments_github_issue_state_check',
+      sql`(
+        (${t.githubIssueNumber} is null)
+        or
+        (${t.githubIssueLeaseToken} is null and ${t.githubIssueUncertainAt} is null)
+      )`,
     ),
   }),
 )


### PR DESCRIPTION
- Stack on #186 and merge only after the comment issue schema is available.
- Claim accepted comments with expiring leases so concurrent requests cannot create duplicate issues.
- Finalize, release, reset, and recover creation attempts only when the caller still owns the matching lease.
- Preserve uncertain outcomes for marker-based recovery when GitHub succeeds but local persistence is interrupted.
- Map stored issue metadata into authenticated dashboard comment responses while keeping lease state private.