### PR TITLE
Prevent dashboard crashes for comments without page metadata

### DIFF
--- a/api/_lib/store.ts
+++ b/api/_lib/store.ts
@@ -19,10 +19,10 @@ const getSupabase = getServiceSupabase
 type CommentRow = {
   id: string
   project_id: string
-  url: string
-  x: number
-  y: number
-  element: string
+  url: string | null
+  x: number | null
+  y: number | null
+  element: string | null
   comment: string
   status: string | null
   implementation_status: ImplementationStatus | null

--- a/apps/dashboard/api.ts
+++ b/apps/dashboard/api.ts
@@ -27,10 +27,10 @@ export interface TextRangeAnchorRecord {
 export interface CommentRecord {
   id: string
   projectId: string
-  pageUrl: string
-  selector: string
-  x: number
-  y: number
+  pageUrl: string | null
+  selector: string | null
+  x: number | null
+  y: number | null
   body: string
   reviewStatus: 'open' | 'accepted' | 'rejected'
   implementationStatus: 'unassigned' | 'claimed' | 'in_progress' | 'blocked' | 'done'

--- a/apps/dashboard/components/CommandPalette.tsx
+++ b/apps/dashboard/components/CommandPalette.tsx
@@ -46,8 +46,8 @@ export function CommandPalette({ onClose, comments, onSelect, onAction, selected
         return (
           c.body.toLowerCase().includes(q) ||
           c.author.toLowerCase().includes(q) ||
-          c.selector.toLowerCase().includes(q) ||
-          c.pageUrl.toLowerCase().includes(q)
+          c.selector?.toLowerCase().includes(q) ||
+          c.pageUrl?.toLowerCase().includes(q)
         )
       })
       .slice(0, 8)
@@ -55,7 +55,7 @@ export function CommandPalette({ onClose, comments, onSelect, onAction, selected
         id: c.id,
         type: 'comment',
         label: c.body.length > 80 ? c.body.slice(0, 80) + '…' : c.body,
-        detail: `${c.author} · ${truncateUrl(c.pageUrl)}`,
+        detail: c.pageUrl ? `${c.author} · ${truncateUrl(c.pageUrl)}` : c.author,
         icon: 'comment',
       }))
 

--- a/apps/dashboard/components/CommentDetail.test.tsx
+++ b/apps/dashboard/components/CommentDetail.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { CommentRecord } from '../api'
+import { mapServerComment } from '../lib/comment'
+import { CommandPalette } from './CommandPalette'
+import { CommentDetail } from './CommentDetail'
+import { CommentList } from './CommentList'
+
+const recordWithoutPageContext: CommentRecord = {
+  id: 'legacy-comment',
+  projectId: 'project',
+  pageUrl: null,
+  selector: null,
+  x: null,
+  y: null,
+  body: 'The feedback is still available.',
+  reviewStatus: 'accepted',
+  implementationStatus: 'unassigned',
+  claimedByAgentId: null,
+  imageUrl: null,
+  authorName: null,
+  createdAt: '2026-07-23T08:27:59Z',
+  updatedAt: '2026-07-23T08:27:59Z',
+  targetType: 'element_point',
+  anchor: null,
+}
+
+const commentWithoutPageContext = mapServerComment(recordWithoutPageContext)
+
+describe('CommentDetail', () => {
+  it('preserves nullable page metadata from the server', () => {
+    expect(commentWithoutPageContext).toMatchObject({
+      pageUrl: null,
+      selector: null,
+      x: null,
+      y: null,
+      author: 'Anonymous',
+    })
+  })
+
+  it('renders feedback and omits unavailable page metadata', () => {
+    const { container } = render(
+      <CommentDetail
+        selectedComment={commentWithoutPageContext}
+        selectedProject="project"
+        commentsLoading={false}
+        commentsError={null}
+        projectComments={[commentWithoutPageContext]}
+        filteredComments={[commentWithoutPageContext]}
+        selectedIdx={0}
+        goPrev={vi.fn()}
+        goNext={vi.fn()}
+        toggleReview={vi.fn()}
+        handleToggleDone={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('The feedback is still available.')).toBeInTheDocument()
+    expect(screen.getByText('Anonymous')).toBeInTheDocument()
+    expect(screen.queryByText('Open page')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Pin placed at/)).not.toBeInTheDocument()
+    expect(container.querySelector('code')).not.toBeInTheDocument()
+  })
+
+  it('renders a safe fallback in the comment list', () => {
+    render(
+      <CommentList
+        filteredComments={[commentWithoutPageContext]}
+        counts={{ all: 1, open: 0, ready: 1, done: 0, rejected: 0 }}
+        statusFilter="all"
+        selectFilter={vi.fn()}
+        bulkMode={false}
+        enterBulkMode={vi.fn()}
+        exitBulkMode={vi.fn()}
+        bulkSelectedIds={new Set()}
+        toggleSelectAllVisible={vi.fn()}
+        applyBulkAction={vi.fn()}
+        toggleBulkSelect={vi.fn()}
+        commentsLoading={false}
+        commentsError={null}
+        selectedCommentId={commentWithoutPageContext.id}
+        setSelectedCommentId={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('No page context')).toBeInTheDocument()
+    expect(screen.getByText('The feedback is still available.')).toBeInTheDocument()
+  })
+
+  it('opens and searches the command palette without page metadata', () => {
+    Element.prototype.scrollIntoView = vi.fn()
+
+    render(
+      <CommandPalette
+        onClose={vi.fn()}
+        comments={[commentWithoutPageContext]}
+        onSelect={vi.fn()}
+        onAction={vi.fn()}
+        selectedCommentId=""
+      />,
+    )
+
+    expect(screen.getAllByText('Anonymous')).toHaveLength(1)
+
+    fireEvent.change(screen.getByPlaceholderText(/Search feedback/), {
+      target: { value: 'missing page' },
+    })
+
+    expect(screen.getByText('No results for "missing page"')).toBeInTheDocument()
+  })
+})

--- a/apps/dashboard/components/CommentDetail.tsx
+++ b/apps/dashboard/components/CommentDetail.tsx
@@ -50,8 +50,12 @@ export function CommentDetail({
           <div className="flex items-center justify-between px-6 h-[44px] shrink-0 border-b border-border bg-card">
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <span className="font-mono font-medium">#{selectedComment.id}</span>
-              <span>·</span>
-              <span className="font-mono">{truncateUrl(selectedComment.pageUrl)}</span>
+              {selectedComment.pageUrl ? (
+                <>
+                  <span>·</span>
+                  <span className="font-mono">{truncateUrl(selectedComment.pageUrl)}</span>
+                </>
+              ) : null}
               <span>·</span>
               {(() => {
                 const ds = getDisplayStatus(selectedComment)
@@ -82,7 +86,7 @@ export function CommentDetail({
                   >
                     <img
                       src={selectedComment.screenshotUrl}
-                      alt={`Screenshot of ${selectedComment.pageUrl}`}
+                      alt={selectedComment.pageUrl ? `Screenshot of ${selectedComment.pageUrl}` : 'Feedback screenshot'}
                       className="max-w-full max-h-[520px] w-auto h-auto object-contain"
                       draggable={false}
                     />
@@ -96,13 +100,17 @@ export function CommentDetail({
                     </div>
                     <div>
                       <p className="text-xs font-semibold text-foreground">No screenshot captured</p>
-                      <p className="text-[11px] text-muted-foreground">Pin placed at ({selectedComment.x}, {selectedComment.y})</p>
+                      {selectedComment.x != null && selectedComment.y != null ? (
+                        <p className="text-[11px] text-muted-foreground">Pin placed at ({selectedComment.x}, {selectedComment.y})</p>
+                      ) : null}
                     </div>
                   </div>
-                  <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-muted/60 border border-border">
-                    <SelectorIcon size={12} />
-                    <code className="text-[12px] font-mono text-foreground/70 break-all">{selectedComment.selector}</code>
-                  </div>
+                  {selectedComment.selector ? (
+                    <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-muted/60 border border-border">
+                      <SelectorIcon size={12} />
+                      <code className="text-[12px] font-mono text-foreground/70 break-all">{selectedComment.selector}</code>
+                    </div>
+                  ) : null}
                 </div>
               )}
 
@@ -132,11 +140,11 @@ export function CommentDetail({
                         {selectedComment.anchor.containerSelector} · chars {selectedComment.anchor.startOffset}–{selectedComment.anchor.endOffset}
                       </div>
                     </div>
-                  ) : (
+                  ) : selectedComment.selector ? (
                     <div className="mt-2 text-xs font-mono text-muted-foreground">
                       {selectedComment.selector}
                     </div>
-                  )}
+                  ) : null}
                 </div>
               </div>
             </div>
@@ -171,9 +179,11 @@ export function CommentDetail({
 
               <div className="w-px h-5 bg-border mx-1" />
 
-              <ActionBtn variant="neutral" onClick={() => window.open(selectedComment.pageUrl, '_blank')}>
-                <ExternalLinkIcon size={13} /> Open page
-              </ActionBtn>
+              {selectedComment.pageUrl ? (
+                <ActionBtn variant="neutral" onClick={() => window.open(selectedComment.pageUrl!, '_blank')}>
+                  <ExternalLinkIcon size={13} /> Open page
+                </ActionBtn>
+              ) : null}
 
               <div className="flex-1" />
 

--- a/apps/dashboard/components/CommentList.tsx
+++ b/apps/dashboard/components/CommentList.tsx
@@ -216,7 +216,7 @@ export function CommentList({
                       </span>
                     ) : (
                       <span className="text-[10px] text-muted-foreground/40 font-mono ml-auto truncate max-w-[140px]">
-                        {comment.selector.split(' > ').pop()}
+                        {comment.selector?.split(' > ').pop() || 'No page context'}
                       </span>
                     )}
                   </div>

--- a/apps/dashboard/lib/comment.ts
+++ b/apps/dashboard/lib/comment.ts
@@ -18,7 +18,7 @@ export function mapServerComment(record: CommentRecord): Comment {
     id: record.id,
     projectId: record.projectId,
     pageUrl: record.pageUrl,
-    selector: record.selector || '',
+    selector: record.selector,
     x: record.x,
     y: record.y,
     body: record.body,

--- a/apps/dashboard/lib/types.ts
+++ b/apps/dashboard/lib/types.ts
@@ -9,10 +9,10 @@ export type DisplayStatus = 'open' | 'ready' | 'done' | 'rejected'
 export interface Comment {
   id: string
   projectId: string
-  pageUrl: string
-  selector: string
-  x: number
-  y: number
+  pageUrl: string | null
+  selector: string | null
+  x: number | null
+  y: number | null
   body: string
   reviewStatus: ReviewStatus
   implementationStatus: ImplStatus


### PR DESCRIPTION
# Prevent dashboard crashes for comments without page metadata

- Align comment metadata types with the nullable values already allowed by the database.
- Keep feedback details usable when legacy comments lack a page URL, selector, coordinates, or screenshot.
- Hide page-specific actions and metadata when their underlying context is unavailable.
- Make comment browsing and command-palette search resilient to feedback-only records.

Closes #185
